### PR TITLE
OAuth2 로그인 리디렉션 로직 수정 및 HTTPS 설정 적용

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -38,6 +38,9 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .requiresChannel(channel -> channel
+                        .anyRequest().requiresSecure()    //HTTPS
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/oauth2/**", "/login/**", "/h2-console/**", "/api/token/refresh", "/login", "/error", "/api/recipes/**",
                                 "/swagger-ui.html",

--- a/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -39,11 +39,14 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
                         .build()
         );
 
-        String origin = request.getHeader("Origin");
+        String referer = request.getHeader("Referer");
 
-        // fallback 기본 redirect URI
-        String redirectBase = (origin != null) ? origin : "https://www.haemeok.com";
-
+        String redirectBase;
+        if (referer != null && referer.contains("localhost")) {
+            redirectBase = "http://localhost:5173";
+        } else {
+            redirectBase = "https://www.haemeok.com";
+        }
         String redirectUri = redirectBase + "/oauth2/redirect" +
                 "?accessToken=" + accessToken +
                 "&refreshToken=" + refreshToken;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -52,7 +52,12 @@ spring:
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
 
+server:
+  forward-headers-strategy: framework
+
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-validity-in-ms: ${ACCESS_TOKEN_VALIDITY}
   refresh-token-validity-in-ms: ${REFRESH_TOKEN_VALIDITY}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   profiles:
     active: prod
 
+server:
+  forward-headers-strategy: framework
+
 springdoc:
   api-docs:
     enabled: true

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -18,7 +18,7 @@
     </a>
 </div>
 <div>
-    <a href="/oauth2/authorization/kakao">
+
         <button>카카오 로그인</button>
     </a>
 </div>


### PR DESCRIPTION
## 주요 변경 사항

- OAuth2AuthenticationSuccessHandler 수정:
  - Referer 기반으로 로컬(localhost)과 운영(www.haemeok.com) 환경 분기 처리
- server.forward-headers-strategy: framework 설정 application.yml, application-prod.yml에 추가
- Swagger 경로 프록시 설정을 위한 Nginx 설정 추가
- Spring Security에서 HTTPS 강제 설정 (.requiresSecure)