### PR TITLE
JWT 토큰 만료 시 401 응답 처리 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/controller/UserController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/UserController.java
@@ -52,14 +52,6 @@ public class UserController {
         return ResponseEntity.ok(users);
     }
 
-    @GetMapping("/me")
-    public ResponseEntity<UserResponseDTO> getCurrentUser(Authentication authentication) {
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        Long userId = Long.parseLong(userDetails.getUsername()); // 또는 userDetails.getUser().getId();
-
-        UserResponseDTO response = userService.getUser(userId);
-        return ResponseEntity.ok(response);
-    }
 
     // 유저 업데이트 API
     @PutMapping("/{id}")

--- a/src/main/java/com/jdc/recipe_service/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/jdc/recipe_service/jwt/JwtAuthenticationFilter.java
@@ -35,27 +35,48 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = authHeader.substring(7);
             log.info("📦 JWT 토큰 추출됨: {}", token);
 
-            if (jwtTokenProvider.validateToken(token)) {
-                Long userId = jwtTokenProvider.getUserIdFromToken(token);
-                log.info("✅ 토큰 유효. userId: {}", userId);
+            try {
+                // 만약 validateToken 내부에서 만료/유효성 오류 발생 시 JwtException 던질 수 있음
+                if (jwtTokenProvider.validateToken(token)) {
+                    // ----- 토큰이 유효할 경우 -----
+                    Long userId = jwtTokenProvider.getUserIdFromToken(token);
+                    log.info("✅ 토큰 유효. userId: {}", userId);
 
-                UserDetails userDetails = userDetailsService.loadUserByUsername(userId.toString());
-                log.info("🙋‍♂️ UserDetails 로드됨: {}", userDetails.getUsername());
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(userId.toString());
+                    log.info("🙋‍♂️ UserDetails 로드됨: {}", userDetails.getUsername());
 
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                        userDetails, null, userDetails.getAuthorities()
-                );
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities()
+                    );
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-                log.info("🔓 인증 완료. SecurityContext 에 저장됨.");
-            } else {
-                log.warn("❌ 유효하지 않은 토큰.");
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    log.info("🔓 인증 완료. SecurityContext 에 저장됨.");
+
+                } else {
+                    // ----- validateToken이 false 일 때 (추가로 boolean 반환하게 만들 수도 있음) -----
+                    log.warn("❌ 유효하지 않은 토큰.");
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write("{\"message\":\"유효하지 않은 토큰입니다.\"}");
+                    return; // 필터 체인 진행 중단
+                }
+
+            } catch (io.jsonwebtoken.JwtException e) {
+                // ----- 만료되거나 서명이 틀린 토큰 등 예외 발생 -----
+                log.warn("❌ JWTException 발생: {}", e.getMessage());
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json;charset=UTF-8");
+                // e.getMessage()가 "토큰이 만료되었습니다." 등일 수 있음
+                response.getWriter().write("{\"message\":\"" + e.getMessage() + "\"}");
+                return; // 더 이상 진행하지 않고 401 응답
             }
+
         } else {
             log.warn("🚫 Authorization 헤더 없음 또는 'Bearer '로 시작하지 않음.");
         }
 
+        // 토큰이 없거나 정상 인증된 경우 → 체인 계속 진행
         filterChain.doFilter(request, response);
     }
     @Override

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -8,7 +8,7 @@
 <h1>🔐 소셜 로그인 테스트</h1>
 
 <div>
-    <a href="/oauth2/authorization/google">
+        <a href="/oauth2/authorization/google">
         <button>구글 로그인</button>
     </a>
 </div>


### PR DESCRIPTION
- Access Token 만료 시 401 Unauthorized 응답 반환 로직 추가
- 프론트에서 해당 응답 감지 후 Refresh 로직 실행을 위해 구현
- api/users/me 삭제 (api/me로 관리)