### PR TITLE
Feature/user

### DIFF
--- a/src/main/java/com/jdc/recipe_service/controller/AdminUserController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/AdminUserController.java
@@ -1,0 +1,53 @@
+package com.jdc.recipe_service.controller;
+
+import com.jdc.recipe_service.domain.dto.user.UserRequestDTO;
+import com.jdc.recipe_service.domain.dto.user.UserResponseDTO;
+import com.jdc.recipe_service.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final UserService userService;
+
+    // 관리자가 사용자 생성 ->삭제할 예정 , 일단 구현만 해둠 (소셜 인증 안 됨)
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<UserResponseDTO> createUser(@Valid @RequestBody UserRequestDTO dto) {
+        UserResponseDTO response = userService.createUser(dto);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    // 관리자가 전체 사용자 목록 조회
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<UserResponseDTO>> getAllUsers() {
+        List<UserResponseDTO> users = userService.getAllUsers();
+        return ResponseEntity.ok(users);
+    }
+
+    // 관리자가 특정 사용자 조회
+    @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<UserResponseDTO> getUser(@PathVariable Long id) {
+        UserResponseDTO response = userService.getUser(id);
+        return ResponseEntity.ok(response);
+    }
+
+    // 관리자가 사용자 하드 삭제
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<String> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.ok("사용자가 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/controller/CommentController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/CommentController.java
@@ -2,17 +2,15 @@ package com.jdc.recipe_service.controller;
 
 import com.jdc.recipe_service.domain.dto.comment.CommentDto;
 import com.jdc.recipe_service.domain.dto.comment.CommentRequestDto;
-import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.exception.CommentAccessDeniedException;
 import com.jdc.recipe_service.security.CustomUserDetails;
 import com.jdc.recipe_service.service.CommentService;
-import com.jdc.recipe_service.service.UserService;
-import org.springframework.lang.Nullable;
+import org.springframework.http.HttpStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.nio.file.AccessDeniedException;
 import java.util.List;
 
 @RestController
@@ -21,64 +19,82 @@ import java.util.List;
 public class CommentController {
 
     private final CommentService commentService;
-    private final UserService userService;
 
-    // 댓글 생성 (상위 댓글)
+    // 1) 댓글 생성 (상위 댓글)
     @PostMapping
-    public ResponseEntity<CommentDto> createComment(@PathVariable Long recipeId,
-                                                    @RequestBody CommentRequestDto requestDto,
-                                                    Authentication authentication) {
-//        User user = ((CustomUserDetails) authentication.getPrincipal()).getUser();
-        User user = (authentication != null && authentication.isAuthenticated())
-                ? ((CustomUserDetails) authentication.getPrincipal()).getUser()
-                : userService.getGuestUser(); // ✅ fallback 처리
-        CommentDto created = commentService.createComment(recipeId, requestDto, user);
-        return ResponseEntity.ok(created);
+    public ResponseEntity<CommentDto> createComment(
+            @PathVariable Long recipeId,
+            @RequestBody CommentRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        CommentDto created = commentService.createComment(
+                recipeId, requestDto, userDetails.getUser());
+        // REST 관례에 따라 201 Created
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
-    // 대댓글 생성
+    // 2) 대댓글 생성
     @PostMapping("/{parentId}/replies")
-    public ResponseEntity<CommentDto> createReply(@PathVariable Long recipeId,
-                                                  @PathVariable Long parentId,
-                                                  @RequestBody CommentRequestDto requestDto,
-                                                  Authentication authentication) {
-//        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUser().getId();
-        Long userId = (authentication != null && authentication.isAuthenticated())
-                ? ((CustomUserDetails) authentication.getPrincipal()).getUser().getId()
-                : userService.getGuestUser().getId(); // ✅ fallback 처리
-        CommentDto created = commentService.createReply(recipeId, parentId, requestDto, userId);
-        return ResponseEntity.ok(created);
+    public ResponseEntity<CommentDto> createReply(
+            @PathVariable Long recipeId,
+            @PathVariable Long parentId,
+            @RequestBody CommentRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        CommentDto created = commentService.createReply(
+                recipeId, parentId, requestDto, userDetails.getUser().getId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
-    // 댓글 조회
+    // 3) 댓글 조회 (좋아요 포함)
     @GetMapping
-    public ResponseEntity<List<CommentDto>> getAllCommentsWithLikes(@PathVariable Long recipeId,
-                                                                    @Nullable Authentication authentication) {
-        Long userId = (authentication != null && authentication.isAuthenticated())
-                ? ((CustomUserDetails) authentication.getPrincipal()).getUser().getId()
-                : null; // 조회는 fallback 없이 null 허용
-        return ResponseEntity.ok(commentService.getAllCommentsWithLikes(recipeId, userId));
-    }
-
-    @GetMapping("/{parentId}/replies")
-    public List<CommentDto> getReplies(@PathVariable Long parentId,
-                                       @Nullable Authentication authentication) {
-        Long userId = (authentication != null && authentication.isAuthenticated())
-                ? ((CustomUserDetails) authentication.getPrincipal()).getUser().getId()
+    public ResponseEntity<List<CommentDto>> getAllCommentsWithLikes(
+            @PathVariable Long recipeId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails != null
+                ? userDetails.getUser().getId()
                 : null;
-        return commentService.getRepliesWithLikes(parentId, userId);
+        List<CommentDto> comments = commentService.getAllCommentsWithLikes(recipeId, userId);
+        return ResponseEntity.ok(comments);
     }
 
-    // 댓글 삭제
+    // 4) 대댓글 조회
+    @GetMapping("/{parentId}/replies")
+    public ResponseEntity<List<CommentDto>> getReplies(
+            @PathVariable Long recipeId,
+            @PathVariable Long parentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails != null
+                ? userDetails.getUser().getId()
+                : null;
+        List<CommentDto> replies = commentService.getRepliesWithLikes(parentId, userId);
+        return ResponseEntity.ok(replies);
+    }
+
+    // 5) 댓글 삭제
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<String> deleteComment(@PathVariable Long recipeId,
-                                                @PathVariable Long commentId,
-                                                Authentication authentication) throws AccessDeniedException {
-//        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUser().getId();
-        Long userId = (authentication != null && authentication.isAuthenticated())
-                ? ((CustomUserDetails) authentication.getPrincipal()).getUser().getId()
-                : userService.getGuestUser().getId(); // ✅ fallback 처리
-        commentService.deleteComment(commentId, userId);
-        return ResponseEntity.ok("댓글이 삭제되었습니다.");
+    public ResponseEntity<String> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        Long userId = userDetails.getUser().getId();
+        try {
+            commentService.deleteComment(commentId, userId);
+            return ResponseEntity.ok("댓글이 삭제되었습니다.");
+        } catch (CommentAccessDeniedException ex) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ex.getMessage());
+        }
     }
 }

--- a/src/main/java/com/jdc/recipe_service/controller/CommentLikeController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/CommentLikeController.java
@@ -3,8 +3,9 @@ package com.jdc.recipe_service.controller;
 import com.jdc.recipe_service.security.CustomUserDetails;
 import com.jdc.recipe_service.service.CommentLikeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -18,15 +19,17 @@ public class CommentLikeController {
 
     // 댓글 좋아요 토글
     @PostMapping("/{commentId}/like")
-    public ResponseEntity<?> toggleLike(@PathVariable Long commentId,
-                                        Authentication authentication) {
-        if (authentication == null || !authentication.isAuthenticated()) {
-            return ResponseEntity.status(401).body(Map.of("message", "로그인이 필요합니다."));
+    public ResponseEntity<?> toggleLike(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("message", "로그인이 필요합니다."));
         }
-        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUser().getId();
+        Long userId = userDetails.getUser().getId();
         boolean liked = commentLikeService.toggleLike(commentId, userId);
         String message = liked ? "댓글 좋아요 등록 완료" : "댓글 좋아요 취소 완료";
-
         return ResponseEntity.ok(Map.of(
                 "liked", liked,
                 "message", message

--- a/src/main/java/com/jdc/recipe_service/controller/LoginTestController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/LoginTestController.java
@@ -30,14 +30,4 @@ public class LoginTestController {
                 user.getUser().getProvider()
         );
     }
-    @GetMapping("/api/me")
-    public ResponseEntity<UserResponseDTO> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        if (userDetails == null) {
-            return ResponseEntity.status(401).build(); // 인증 안 됐을 경우
-        }
-
-        User user = userDetails.getUser();
-        UserResponseDTO response = new UserResponseDTO(user);
-        return ResponseEntity.ok(response);
-    }
 }

--- a/src/main/java/com/jdc/recipe_service/controller/LoginTestController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/LoginTestController.java
@@ -1,13 +1,8 @@
 package com.jdc.recipe_service.controller;
 
-import com.jdc.recipe_service.domain.dto.user.UserResponseDTO;
-import com.jdc.recipe_service.domain.entity.User;
-import com.jdc.recipe_service.security.CustomUserDetails;
 import com.jdc.recipe_service.security.oauth.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/jdc/recipe_service/controller/MyAccountController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/MyAccountController.java
@@ -1,0 +1,57 @@
+package com.jdc.recipe_service.controller;
+
+import com.jdc.recipe_service.domain.dto.recipe.RecipeSimpleDto;
+import com.jdc.recipe_service.domain.dto.user.UserRequestDTO;
+import com.jdc.recipe_service.domain.dto.user.UserResponseDTO;
+import com.jdc.recipe_service.security.CustomUserDetails;
+import com.jdc.recipe_service.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/me")
+@RequiredArgsConstructor
+public class MyAccountController {
+
+    private final UserService userService;
+
+    //  내 정보 조회
+    @GetMapping
+    public ResponseEntity<UserResponseDTO> getMyInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = Long.valueOf(userDetails.getUsername());
+        return ResponseEntity.ok(userService.getUser(userId));
+    }
+
+    //  내 프로필 수정
+    @PutMapping
+    public ResponseEntity<UserResponseDTO> updateMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserRequestDTO dto) {
+        Long userId = Long.valueOf(userDetails.getUsername());
+        return ResponseEntity.ok(userService.updateUser(userId, dto));
+    }
+
+    //  내 계정 삭제 (하드 삭제)
+    @DeleteMapping
+    public ResponseEntity<String> deleteMyAccount(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = Long.valueOf(userDetails.getUsername());
+        userService.deleteUser(userId);
+        return ResponseEntity.ok("계정이 삭제되었습니다.");
+    }
+
+    // 내 즐겨찾기 조회
+    @GetMapping("/favorites")
+    public ResponseEntity<List<RecipeSimpleDto>> getMyFavorites(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = Long.valueOf(userDetails.getUsername());
+        List<RecipeSimpleDto> favorites = userService.getFavoriteRecipesByUser(userId);
+        return ResponseEntity.ok(favorites);
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/controller/RecipeLikeController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/RecipeLikeController.java
@@ -4,8 +4,9 @@ import com.jdc.recipe_service.security.CustomUserDetails;
 import com.jdc.recipe_service.service.RecipeFavoriteService;
 import com.jdc.recipe_service.service.RecipeLikeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -19,26 +20,38 @@ public class RecipeLikeController {
     private final RecipeFavoriteService favoriteService;
 
     @PostMapping("/{id}/like")
-    public ResponseEntity<?> toggleLike(@PathVariable Long id, Authentication authentication) {
-        if (authentication == null || !authentication.isAuthenticated()) {
-            return ResponseEntity.status(401).body(Map.of("message", "로그인이 필요합니다."));
+    public ResponseEntity<?> toggleLike(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("message", "로그인이 필요합니다."));
         }
-
-        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUser().getId();
+        Long userId = userDetails.getUser().getId();
         boolean liked = likeService.toggleLike(userId, id);
         String message = liked ? "레시피 좋아요 등록 완료" : "레시피 좋아요 취소 완료";
-        return ResponseEntity.ok(Map.of("liked", liked, "message", message));
+        return ResponseEntity.ok(Map.of(
+                "liked", liked,
+                "message", message
+        ));
     }
 
     @PostMapping("/{id}/favorite")
-    public ResponseEntity<?> toggleFavorite(@PathVariable Long id, Authentication authentication) {
-        if (authentication == null || !authentication.isAuthenticated()) {
-            return ResponseEntity.status(401).body(Map.of("message", "로그인이 필요합니다."));
+    public ResponseEntity<?> toggleFavorite(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("message", "로그인이 필요합니다."));
         }
-
-        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUser().getId();
+        Long userId = userDetails.getUser().getId();
         boolean favorited = favoriteService.toggleFavorite(userId, id);
         String message = favorited ? "레시피 즐겨찾기 등록 완료" : "레시피 즐겨찾기 취소 완료";
-        return ResponseEntity.ok(Map.of("favorited", favorited, "message", message));
+        return ResponseEntity.ok(Map.of(
+                "favorited", favorited,
+                "message", message
+        ));
     }
 }

--- a/src/main/java/com/jdc/recipe_service/controller/UserController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/UserController.java
@@ -20,7 +20,6 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 public class UserController {
 
     private final UserService userService;
-    private final RecipeService recipeService;
 
     // 공개 프로필 조회
     @GetMapping("/{userId}")
@@ -34,7 +33,7 @@ public class UserController {
             @PathVariable Long userId,
             @PageableDefault(size = 10, sort = "createdAt", direction = DESC) Pageable pageable) {
 
-        Page<MyRecipeSummaryDto> page = recipeService.getMyRecipes(userId, pageable);
+        Page<MyRecipeSummaryDto> page = userService.getMyRecipes(userId, pageable);
         return ResponseEntity.ok(page);
     }
 }

--- a/src/main/java/com/jdc/recipe_service/controller/UserController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/UserController.java
@@ -1,101 +1,40 @@
 package com.jdc.recipe_service.controller;
 
 import com.jdc.recipe_service.domain.dto.recipe.MyRecipeSummaryDto;
-import com.jdc.recipe_service.domain.dto.recipe.RecipeSimpleDto;
-import com.jdc.recipe_service.domain.dto.user.UserRequestDTO;
-import com.jdc.recipe_service.domain.dto.user.UserResponseDTO;
-import com.jdc.recipe_service.security.CustomUserDetails;
+import com.jdc.recipe_service.domain.dto.user.UserDto;
 import com.jdc.recipe_service.service.RecipeService;
 import com.jdc.recipe_service.service.UserService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
-@Validated
 public class UserController {
 
     private final UserService userService;
     private final RecipeService recipeService;
 
-    // 유저 생성 API
-    @PostMapping
-    public ResponseEntity<UserResponseDTO> createUser(@Valid @RequestBody UserRequestDTO dto) {
-        UserResponseDTO response = userService.createUser(dto);
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    // 공개 프로필 조회
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserDto> getUserProfile(@PathVariable Long userId) {
+        UserDto dto = userService.getPublicProfile(userId);
+        return ResponseEntity.ok(dto);
     }
-
-    // 유저 조회 API (단일)
-    @GetMapping("/{id}")
-    public ResponseEntity<UserResponseDTO> getUser(@PathVariable Long id) {
-        UserResponseDTO response = userService.getUser(id);
-        return ResponseEntity.ok(response);
-    }
-
-    // 모든 유저 조회 API
-    @GetMapping
-    public ResponseEntity<List<UserResponseDTO>> getAllUsers() {
-        List<UserResponseDTO> users = userService.getAllUsers();
-        return ResponseEntity.ok(users);
-    }
-
-
-    // 유저 업데이트 API
-    @PutMapping("/{id}")
-    public ResponseEntity<UserResponseDTO> updateUser(@PathVariable Long id, @Valid @RequestBody UserRequestDTO dto) {
-        UserResponseDTO updatedUser = userService.updateUser(id, dto);
-        return ResponseEntity.ok(updatedUser);
-    }
-
-    // 유저 삭제 API
-    @DeleteMapping("/{id}")
-    public ResponseEntity<String> deleteUser(@PathVariable Long id) {
-        userService.deleteUser(id);
-        return ResponseEntity.ok("사용자가 삭제되었습니다.");
-    }
-
-    // 즐겨찾기 조회
-    @GetMapping("/{userId}/favorites")
-    public ResponseEntity<List<RecipeSimpleDto>> getFavoriteRecipes(@PathVariable Long userId,
-                                                                    Authentication authentication) {
-//        Long currentUserId = (authentication != null && authentication.isAuthenticated())
-//                ? ((CustomUserDetails) authentication.getPrincipal()).getUser().getId()
-//                : null;
-        Long currentUserId = (authentication != null && authentication.isAuthenticated())
-                ? ((CustomUserDetails) authentication.getPrincipal()).getUser().getId()
-                : userService.getGuestUser().getId(); // ✅ fallback 적용
-
-        List<RecipeSimpleDto> recipes = userService.getFavoriteRecipesByUser(userId, currentUserId);
-        return ResponseEntity.ok(recipes);
-    }
-
-
-    //작성 레시피 조회
+    // 작성 레시피 조회 (누구나 가능)
     @GetMapping("/{userId}/recipes")
     public ResponseEntity<Page<MyRecipeSummaryDto>> getUserRecipes(
-            @PathVariable(required = false) Long userId,
-            Authentication authentication,
+            @PathVariable Long userId,
             @PageableDefault(size = 10, sort = "createdAt", direction = DESC) Pageable pageable) {
 
-        Long resolvedUserId = (authentication != null && authentication.isAuthenticated())
-                ? ((CustomUserDetails) authentication.getPrincipal()).getUser().getId()
-                : userService.getGuestUser().getId(); // ✅ fallback 적용
-
-        return ResponseEntity.ok(recipeService.getMyRecipes(resolvedUserId, pageable));
+        Page<MyRecipeSummaryDto> page = recipeService.getMyRecipes(userId, pageable);
+        return ResponseEntity.ok(page);
     }
-
-
 }

--- a/src/main/java/com/jdc/recipe_service/domain/dto/user/UserRequestDTO.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/user/UserRequestDTO.java
@@ -20,14 +20,4 @@ public class UserRequestDTO {
     @Size(max = 255)
     private String introduction;
 
-
-    //추후 삭제
-    @NotBlank
-    @Size(max = 50)
-    private String provider;
-
-    //추후 삭제
-    @NotBlank
-    @Size(max = 100)
-    private String oauthId;
 }

--- a/src/main/java/com/jdc/recipe_service/domain/entity/User.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/User.java
@@ -7,7 +7,8 @@ import lombok.*;
 
 @Entity
 @Table(name = "users", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"provider", "oauth_id"})
+        @UniqueConstraint(columnNames = {"provider", "oauth_id"}),
+        @UniqueConstraint(columnNames = {"nickname"})
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/jdc/recipe_service/domain/repository/UserRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/UserRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByProviderAndOauthId(String provider, String oauthId);
+
     Optional<User> findByNickname(String nickname);
 
     boolean existsByNickname(String nickname);

--- a/src/main/java/com/jdc/recipe_service/domain/repository/UserRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/UserRepository.java
@@ -8,4 +8,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByProviderAndOauthId(String provider, String oauthId);
+    Optional<User> findByNickname(String nickname);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/jdc/recipe_service/domain/type/TagType.java
+++ b/src/main/java/com/jdc/recipe_service/domain/type/TagType.java
@@ -2,6 +2,8 @@ package com.jdc.recipe_service.domain.type;
 
 import lombok.Getter;
 import org.apache.coyote.BadRequestException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 @Getter
 public enum TagType {
@@ -36,11 +38,19 @@ public enum TagType {
         throw new IllegalArgumentException("존재하지 않는 태그입니다: " + name);
     }
 
-    public static TagType fromNameOrThrow(String tagName) throws BadRequestException {
+    public static TagType fromNameOrThrow(String tagName) {
         try {
             return TagType.valueOf(tagName);
         } catch (IllegalArgumentException e) {
-            throw new BadRequestException("잘못된 태그 이름입니다: " + tagName);
+            // 1) IllegalArgumentException 을 바로 던지고
+            // throw new IllegalArgumentException("잘못된 태그 이름입니다: " + tagName, e);
+
+            // 또는 2) 스프링 예외로 바로 매핑하고 싶다면 아래와 같이:
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "잘못된 태그 이름입니다: " + tagName,
+                    e
+            );
         }
     }
 }

--- a/src/main/java/com/jdc/recipe_service/mapper/UserMapper.java
+++ b/src/main/java/com/jdc/recipe_service/mapper/UserMapper.java
@@ -1,9 +1,6 @@
 package com.jdc.recipe_service.mapper;
 
-import com.jdc.recipe_service.domain.dto.user.CommentUserDto;
-import com.jdc.recipe_service.domain.dto.user.UserDto;
-import com.jdc.recipe_service.domain.dto.user.UserRequestDTO;
-import com.jdc.recipe_service.domain.dto.user.UserResponseDTO;
+import com.jdc.recipe_service.domain.dto.user.*;
 import com.jdc.recipe_service.domain.entity.User;
 
 public class UserMapper {
@@ -29,17 +26,16 @@ public class UserMapper {
                 .build();
     }
 
-    // 요청 DTO → 엔티티 변환
+    // 프로필 수정용: nickname/profileImage/introduction만
     public static User toEntity(UserRequestDTO dto) {
         if (dto == null) return null;
         return User.builder()
                 .nickname(dto.getNickname())
                 .profileImage(dto.getProfileImage())
                 .introduction(dto.getIntroduction())
-                .provider(dto.getProvider())
-                .oauthId(dto.getOauthId())
                 .build();
     }
+
 
     // 엔티티 → 응답용 전체 DTO
     public static UserResponseDTO toDto(User user) {

--- a/src/main/java/com/jdc/recipe_service/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/jdc/recipe_service/security/oauth/CustomOAuth2UserService.java
@@ -5,6 +5,7 @@ import com.jdc.recipe_service.domain.repository.UserRepository;
 import com.jdc.recipe_service.domain.type.Role;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -21,23 +22,35 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        String provider = userRequest.getClientRegistration().getRegistrationId(); // google, kakao, naver
-        String oauthId = oAuth2User.getName(); // 각 플랫폼 고유 식별자
-
-        // 사용자 이메일 or 프로필 등 정보 꺼내기 (단순화된 예시)
-        String nickname = (String) oAuth2User.getAttributes().get("name");
+        String provider     = userRequest.getClientRegistration().getRegistrationId();
+        String oauthId      = oAuth2User.getName();
+        String baseNickname = (String) oAuth2User.getAttributes().get("name");
         String profileImage = (String) oAuth2User.getAttributes().get("picture");
 
-        // 기존 사용자 조회 or 새로 생성
         User user = userRepository.findByProviderAndOauthId(provider, oauthId)
-                .orElseGet(() -> userRepository.save(User.builder()
-                        .provider(provider)
-                        .oauthId(oauthId)
-                        .nickname(nickname)
-                        .role(Role.USER)
-                        .profileImage(profileImage)
-                        .build()));
+                .orElseGet(() -> {
+                    // 닉네임 중복 검사 & 랜덤값 추가
+                    String nickname = makeUniqueNickname(baseNickname);
+                    return userRepository.save(User.builder()
+                            .provider(provider)
+                            .oauthId(oauthId)
+                            .nickname(nickname)
+                            .role(Role.USER)
+                            .profileImage(profileImage)
+                            .build());
+                });
 
         return new CustomOAuth2User(user, oAuth2User.getAttributes());
+    }
+
+
+    private String makeUniqueNickname(String baseNickname) {
+        String candidate = baseNickname;
+        // DB에 존재하면 랜덤 suffix
+        while (userRepository.existsByNickname(candidate)) {
+            String suffix = RandomStringUtils.randomAlphanumeric(5);
+            candidate = baseNickname + "_" + suffix;
+        }
+        return candidate;
     }
 }

--- a/src/main/java/com/jdc/recipe_service/service/CommentService.java
+++ b/src/main/java/com/jdc/recipe_service/service/CommentService.java
@@ -154,7 +154,8 @@ public class CommentService {
         }).filter(Objects::nonNull).toList();
     }
 
-    public void deleteComment(Long commentId, Long userId) throws AccessDeniedException {
+    @Transactional
+    public void deleteComment(Long commentId, Long userId) {
         RecipeComment comment = recipeCommentRepository.findById(commentId)
                 .orElseThrow(() -> new RuntimeException("댓글이 존재하지 않습니다."));
 

--- a/src/main/java/com/jdc/recipe_service/service/UserService.java
+++ b/src/main/java/com/jdc/recipe_service/service/UserService.java
@@ -1,5 +1,6 @@
 package com.jdc.recipe_service.service;
 
+import com.jdc.recipe_service.domain.dto.recipe.MyRecipeSummaryDto;
 import com.jdc.recipe_service.domain.dto.recipe.RecipeSimpleDto;
 import com.jdc.recipe_service.domain.dto.user.UserDto;
 import com.jdc.recipe_service.domain.dto.user.UserRequestDTO;
@@ -9,6 +10,7 @@ import com.jdc.recipe_service.domain.entity.RecipeFavorite;
 import com.jdc.recipe_service.domain.entity.User;
 import com.jdc.recipe_service.domain.repository.RecipeFavoriteRepository;
 import com.jdc.recipe_service.domain.repository.RecipeLikeRepository;
+import com.jdc.recipe_service.domain.repository.RecipeRepository;
 import com.jdc.recipe_service.domain.repository.UserRepository;
 import com.jdc.recipe_service.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +32,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final RecipeFavoriteRepository recipeFavoriteRepository;
     private final RecipeLikeRepository recipeLikeRepository;
+    private final RecipeRepository recipeRepository;
+
 
     // 관리자 전용: 사용자 생성
     public UserResponseDTO createUser(UserRequestDTO dto) {
@@ -114,9 +118,18 @@ public class UserService {
     }
 
 
-    public User getGuestUser() {
-        return userRepository.findById(3L)
-                .orElseThrow(() -> new RuntimeException("테스트 유저가 없습니다."));
+    @Transactional(readOnly = true)
+    public Page<MyRecipeSummaryDto> getMyRecipes(Long userId, Pageable pageable) {
+        return recipeRepository.findByUserId(userId, pageable)
+                .map(recipe -> MyRecipeSummaryDto.builder()
+                        .id(recipe.getId())
+                        .title(recipe.getTitle())
+                        .imageUrl(recipe.getImageUrl())
+                        .dishType(recipe.getDishType().getDisplayName())
+                        .createdAt(recipe.getCreatedAt())
+                        .isAiGenerated(recipe.isAiGenerated())
+                        .build());
     }
+
 
 }


### PR DESCRIPTION
- 컨트롤러 전반에 Authentication → @AuthenticationPrincipal CustomUserDetails 패턴 적용
  • 인증 필수 엔드포인트: userDetails == null 체크 후 401 반환
  • 선택 인증(읽기 전용) 엔드포인트: userDetails != null ? userId : null

- RecipeService.getByTagWithLikeInfo() 예외 처리 개선
  • BadRequestException throws 제거
  • TagType.fromNameOrThrow() 호출부 try/catch 로 ResponseStatusException(HttpStatus.BAD_REQUEST) 반환

- SecurityConfig DSL 업그레이드
  • http.formLogin(form → disable) → http.formLogin(AbstractHttpConfigurer::disable)
  • headers.frameOptions() 람다 기반 호출 유지

- UserRequestDTO / UserMapper 불일치 해결
  • provider·oauthId 필드 삭제된 DTO 반영
  • 관리자 생성 API(AdminUserController) 제거

- CommentController, CommentLikeController, RecipeLikeController, RecipeController 등 인증 로직 리팩토링

- GlobalExceptionHandler 추가 검토 안내 주석 추가