### PR TITLE
Ingredient 조회 JSON 출력 양식 Front 요구사항에 맞게 수정

### DIFF
--- a/src/main/java/com/jdc/recipe_service/domain/dto/fridge/RefrigeratorItemSummaryDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/fridge/RefrigeratorItemSummaryDto.java
@@ -1,8 +1,9 @@
 package com.jdc.recipe_service.domain.dto.fridge;
 
-import com.jdc.recipe_service.domain.dto.ingredient.IngredientSummaryDto;
 
 public record RefrigeratorItemSummaryDto(
-        Long               id,
-        IngredientSummaryDto ingredient
-) {}
+        Long id,
+        String name,
+        String category,
+        String imageUrl
+) { }

--- a/src/main/java/com/jdc/recipe_service/domain/dto/ingredient/IngredientSummaryDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/ingredient/IngredientSummaryDto.java
@@ -5,5 +5,6 @@ public record IngredientSummaryDto(
         String  name,
         String  category,
         String  imageUrl,
+        String unit,
         boolean inFridge
 ) { }

--- a/src/main/java/com/jdc/recipe_service/mapper/IngredientMapper.java
+++ b/src/main/java/com/jdc/recipe_service/mapper/IngredientMapper.java
@@ -27,13 +27,4 @@ public class IngredientMapper {
                 .build();
     }
 
-    public static IngredientSummaryDto toSummaryDto(Ingredient entity, boolean inFridge) {
-        return new IngredientSummaryDto(
-                entity.getId(),
-                entity.getName(),
-                entity.getCategory(),
-                entity.getImageUrl(),
-                inFridge
-        );
-    }
 }

--- a/src/main/java/com/jdc/recipe_service/service/IngredientService.java
+++ b/src/main/java/com/jdc/recipe_service/service/IngredientService.java
@@ -82,6 +82,7 @@ public class IngredientService {
                         ing.name,
                         ing.category,
                         ing.imageUrl,
+                        ing.unit,
                         ing.id.in(fridgeIds)         // inFridge 플래그
                 ))
                 .from(ing)

--- a/src/main/java/com/jdc/recipe_service/service/RefrigeratorItemService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RefrigeratorItemService.java
@@ -55,8 +55,10 @@ public class RefrigeratorItemService {
 
         return page.map(item ->
                 new RefrigeratorItemSummaryDto(
-                        item.getId(),
-                        IngredientMapper.toSummaryDto(item.getIngredient(),true)
+                        item.getIngredient().getId(),
+                        item.getIngredient().getName(),
+                        item.getIngredient().getCategory(),
+                        item.getIngredient().getImageUrl()
                 )
         );
     }


### PR DESCRIPTION
## 주요 변경사항

1. **IngredientSummaryDto 수정**  
   - 기존 필드에서 `inFridge` 제거  
   - `unit` 필드 유지 (프론트 요청 반영)  
   - 패키지: `domain/dto/ingredient/IngredientSummaryDto.java`

2. **RefrigeratorItemSummaryDto 수정**  
   - DTO 구조를 중첩(`ingredients: {...}`) 없이 flat하게 변경  
   - `ingredientId`, `name`, `category`, `imageUrl`, `unit` 필드만 포함  
   - 패키지: `domain/dto/fridge/RefrigeratorItemSummaryDto.java`

3. **IngredientMapper 정리**  
   - `toSummaryDto(…)` 삭제 후, `IngredientSummaryDto` 생성 로직 반영  
   - 사용되지 않는 import·메서드 제거

4. **RefrigeratorItemService 수정**  
   - `getMyItems()`에서 새 DTO 구조에 맞춰 매핑  
   - 중복된 DTO 참조 제거

5. **RefrigeratorItemController 검증**  
   - `/api/me/fridge/items` 응답이 flat한 JSON 배열로 반환되는지 확인

6. **테스트 및 문서 업데이트**  
   - 변경된 DTO 스펙에 맞춰 테스트 수정  
   - API 문서 예시 갱신

## 변경 파일
- **수정**  
  - `domain/dto/ingredient/IngredientSummaryDto.java`  
  - `domain/dto/fridge/RefrigeratorItemSummaryDto.java`  
  - `mapper/IngredientMapper.java`  
  - `service/RefrigeratorItemService.java`  
  - `controller/RefrigeratorItemController.java`  