### PR TITLE
캘린더 API date 파라미터 변경·레코드 요약 필드 추가·보안 설정 업데이트Feature/calendar

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
                             .requestMatchers(HttpMethod.GET,
                                     "/api/me",
                                     "/api/me/favorites",
-                                    "/api/me/fridge/items"
+                                    "/api/me/fridge/items",
+                                    "/api/me/calendar/**"
                             ).authenticated()
 
                             // 4) 보호된 POST
@@ -150,7 +151,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET,
                                 "/api/me",
                                 "/api/me/favorites",
-                                "/api/me/fridge/items"
+                                "/api/me/fridge/items",
+                                "/api/me/calendar/**"
                         ).authenticated()
 
                         // 3) 읽기 전용 GET (모두 허용)

--- a/src/main/java/com/jdc/recipe_service/controller/CalendarController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/CalendarController.java
@@ -2,11 +2,13 @@ package com.jdc.recipe_service.controller;
 
 import com.jdc.recipe_service.domain.dto.calendar.CalendarMonthSummaryDto;
 import com.jdc.recipe_service.domain.dto.calendar.CookingRecordDto;
+import com.jdc.recipe_service.domain.dto.calendar.CookingRecordSummaryDto;
 import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.security.CustomUserDetails;
 import com.jdc.recipe_service.service.CookingRecordService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,8 +24,21 @@ public class CalendarController {
 
     private final CookingRecordService service;
 
+    @Value("${app.s3.bucket-name}")
+    private String bucketName;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    private String generateImageUrl(String key) {
+        return key == null
+                ? null
+                : String.format("https://%s.s3.%s.amazonaws.com/%s",
+                bucketName, region, key);
+    }
+
     // 월별 (일별 savings 리스트 + 월합계 saving)
-    @GetMapping
+    @GetMapping(params = { "year", "month" })
     public ResponseEntity<CalendarMonthSummaryDto> monthSummary(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam int year,
@@ -33,22 +48,34 @@ public class CalendarController {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
         Long userId = userDetails.getUser().getId();
-        CalendarMonthSummaryDto result = service.getMonthlySummary(userId, year, month);
+        var result = service.getMonthlySummary(userId, year, month);
         return ResponseEntity.ok(result);
     }
 
-    // 특정 날짜의 상세 기록 리스트
-    @GetMapping("/{date}")
-    public ResponseEntity<List<CookingRecordDto>> dayRecords(
+    // 2) 특정 날짜 기록 리스트
+    @GetMapping(params = "date")
+    public ResponseEntity<List<CookingRecordSummaryDto>> dayRecords(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
         if (userDetails == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
+        if (date == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
         Long userId = userDetails.getUser().getId();
-        List<CookingRecordDto> records = service.getDailyRecords(userId, date);
-        return ResponseEntity.ok(records);
+
+        var entities = service.getDailyRecordEntities(userId, date);
+        var summaries = entities.stream()
+                .map(e -> CookingRecordSummaryDto.from(
+                        e,
+                        generateImageUrl(e.getRecipe().getImageKey())
+                ))
+                .toList();
+
+        return ResponseEntity.ok(summaries);
     }
 
     // 개별 기록 상세

--- a/src/main/java/com/jdc/recipe_service/domain/dto/calendar/CookingRecordSummaryDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/calendar/CookingRecordSummaryDto.java
@@ -6,17 +6,18 @@ import lombok.Getter;
 public class CookingRecordSummaryDto {
     private Long recipeId;
     private String recipeTitle;
-    private Integer ingredientCost;
-    private Integer marketPrice;
     private Integer savings;
+    private String imageUrl;
 
-    public static CookingRecordSummaryDto from(com.jdc.recipe_service.domain.entity.CookingRecord e) {
+    public static CookingRecordSummaryDto from(
+            com.jdc.recipe_service.domain.entity.CookingRecord e,
+                                               String imageUrl
+    ) {
         var dto = new CookingRecordSummaryDto();
         dto.recipeId       = e.getRecipe().getId();
         dto.recipeTitle    = e.getRecipe().getTitle();
-        dto.ingredientCost = e.getIngredientCost();
-        dto.marketPrice    = e.getMarketPrice();
         dto.savings        = e.getSavings();
+        dto.imageUrl       = imageUrl;
         return dto;
     }
 }

--- a/src/main/java/com/jdc/recipe_service/service/CookingRecordService.java
+++ b/src/main/java/com/jdc/recipe_service/service/CookingRecordService.java
@@ -92,14 +92,17 @@ public class CookingRecordService {
         return new CalendarMonthSummaryDto(daily, monthlyTotal);
     }
 
-    /** 특정 일자의 기록 리스트 */
+    /** 특정 일자의 생 엔티티 리스트 */
     @Transactional(readOnly = true)
-    public List<CookingRecordDto> getDailyRecords(Long userId, LocalDate date) {
+    public List<com.jdc.recipe_service.domain.entity.CookingRecord> getDailyRecordEntities(
+            Long userId, LocalDate date) {
+
         var start = date.atStartOfDay();
         var end   = start.plusDays(1);
-        return repo.findByUserIdAndCreatedAtBetweenOrderByCreatedAtDesc(userId, start, end).stream()
-                .map(CookingRecordDto::from)
-                .toList();
+
+        return repo.findByUserIdAndCreatedAtBetweenOrderByCreatedAtDesc(
+                userId, start, end
+        );
     }
 
     /** 개별 기록 상세 */


### PR DESCRIPTION
### 캘린더 조회 API
- 기존 GET /api/me/calendar/{date} → GET /api/me/calendar?date=YYYY-MM-DD (RequestParam 방식)

### 일별 레코드 응답 구조
- CookingRecordSummaryDto에 아래 필드만 반환하도록 변경
  - recipeId
  - recipeTitle
  - recipeImageUrl (S3 키 → URL로 변환)
  - savings

### SecurityConfig
- /api/me/calendar/** 추가