### PR TITLE
DB에 CASCADE 적용으로 서비스 코드 수정

### DIFF
--- a/src/main/java/com/jdc/recipe_service/controller/RecipeController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/RecipeController.java
@@ -77,7 +77,6 @@ public class RecipeController {
         }
         Long userId = userDetails.getUser().getId();
         recipeService.deleteRecipe(recipeId, userId);
-        cookingRecordService.deleteByRecipeId(recipeId);
         return ResponseEntity.ok("레시피가 성공적으로 삭제되었습니다.");
     }
 

--- a/src/main/java/com/jdc/recipe_service/service/CookingRecordService.java
+++ b/src/main/java/com/jdc/recipe_service/service/CookingRecordService.java
@@ -63,11 +63,6 @@ public class CookingRecordService {
         repo.deleteByRatingId(ratingId);
     }
 
-    /** 레시피 삭제 시점에 호출하여 연관 기록 모두 삭제 */
-    @Transactional
-    public void deleteByRecipeId(Long recipeId) {
-        repo.deleteByRecipeId(recipeId);
-    }
 
     /** 월별 달력 요약(일별 절약액 + 월합계) */
     @Transactional(readOnly = true)

--- a/src/main/java/com/jdc/recipe_service/service/RecipeRatingService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeRatingService.java
@@ -91,7 +91,6 @@ public class RecipeRatingService {
 
         updateRecipeAverageRating(recipe);
 
-        cookingRecordService.deleteByRatingId(rating.getId());
 
         return deletedId;
     }

--- a/src/main/java/com/jdc/recipe_service/service/RecipeService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeService.java
@@ -511,10 +511,6 @@ public class RecipeService {
         Recipe recipe = getRecipeOrThrow(recipeId);
         validateOwnership(recipe, userId);
 
-        cookingRecordService.deleteByRecipeId(recipeId);
-
-        recipeRatingRepository.deleteByRecipeId(recipeId);
-
         // ✅ b. S3 이미지 삭제 추가
         List<RecipeImage> images = recipeImageRepository.findByRecipeId(recipeId);
         List<String> fileKeys = images.stream()
@@ -598,7 +594,7 @@ public class RecipeService {
 
 
     private Recipe getRecipeOrThrow(Long recipeId) {
-        return recipeRepository.findById(recipeId)
+        return recipeRepository.findWithUserById(recipeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
     }
 


### PR DESCRIPTION
### 주요 변경 사항
- DDL 마이그레이션으로 recipe_ratings.recipe_id 및 cooking_records.recipe_id, cooking_records.rating_id 외래키에 ON DELETE CASCADE 적용
- JPA 엔티티에서 cascade = REMOVE / orphanRemoval = true 어노테이션 제거
- CookingRecordService.deleteByRatingId, RecipeService.deleteRecipe 내 명시적 삭제 로직 제거
- 레시피/평점/요리기록 삭제 흐름을 DB에 위임하여 코드 단순화
### 상세
- DB 마이그레이션
- recipe_ratings.recipe_id → ON DELETE CASCADE
- cooking_records.recipe_id → ON DELETE CASCADE
- cooking_records.rating_id → ON DELETE CASCADE
### Entity
- Recipe , RecipeRating , CookingRecord 클래스의 @OneToMany(cascade=REMOVE, orphanRemoval=true) 제거
### Service
- 평점 삭제 시 요리기록 수동 삭제(deleteByRatingId) 호출 제거
- 레시피 삭제 시 평점·요리기록·이미지 등 연관 엔티티 삭제 로직 내 요리기록 삭제 부분 제거