### PR TITLE
리프레시 토큰 최대 수 제한 및 초과분 삭제 로직 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/RecipeServiceApplication.java
+++ b/src/main/java/com/jdc/recipe_service/RecipeServiceApplication.java
@@ -2,8 +2,12 @@ package com.jdc.recipe_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableJpaAuditing
+@EnableScheduling
 public class RecipeServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -85,6 +85,7 @@ public class SecurityConfig {
                                     "/api/recipes/*/favorite",
                                     "/api/ratings/recipe/*",
                                     "/api/token/logout",
+                                    "/api/token/logout/all",
                                     "/api/me/fridge/items/bulk",
                                     "/api/recipes/*/private",
                                     "/api/recipes/*/finalize"
@@ -189,6 +190,7 @@ public class SecurityConfig {
                                 "/api/me/fridge/items/bulk",
                                 "/api/ratings/recipe/*",
                                 "/api/token/logout",
+                                "/api/token/logout/all",
                                 "/api/recipes/*/private",
                                 "/api/recipes/*/finalize"
                         ).authenticated()

--- a/src/main/java/com/jdc/recipe_service/domain/entity/RefreshToken.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/RefreshToken.java
@@ -7,7 +7,12 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "refresh_tokens")
+@Table(
+        name = "refresh_tokens",
+        indexes = {
+                @Index(name = "idx_rt_user_created", columnList = "user_id, created_at")
+        }
+)
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/jdc/recipe_service/domain/entity/common/BaseTimeEntity.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/common/BaseTimeEntity.java
@@ -1,27 +1,25 @@
 package com.jdc.recipe_service.domain.entity.common;
 
-import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     protected LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     protected LocalDateTime updatedAt;
-
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/com/jdc/recipe_service/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/RefreshTokenRepository.java
@@ -1,13 +1,29 @@
 package com.jdc.recipe_service.domain.repository;
 
 import com.jdc.recipe_service.domain.entity.RefreshToken;
+import com.jdc.recipe_service.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByToken(String token);
 
-    void deleteByUserId(Long userId);
+    List<RefreshToken> findByUserOrderByCreatedAtAsc(User user);
+
+    // 전체 로그아웃
+    @Modifying
+    @Query("delete from RefreshToken t where t.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
+
+    //만료 토큰 청소
+    @Modifying
+    @Query("delete from RefreshToken t where t.expiredAt < :now")
+    void deleteAllByExpiredAtBefore(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/jdc/recipe_service/scheduler/RefreshTokenCleanupScheduler.java
+++ b/src/main/java/com/jdc/recipe_service/scheduler/RefreshTokenCleanupScheduler.java
@@ -1,0 +1,23 @@
+package com.jdc.recipe_service.scheduler;
+
+import com.jdc.recipe_service.domain.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCleanupScheduler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    // 매일 자정에 만료된 토큰 일괄 삭제
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void cleanExpiredTokens() {
+        refreshTokenRepository.deleteAllByExpiredAtBefore(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -6,39 +6,54 @@ import com.jdc.recipe_service.jwt.JwtTokenProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
+    private static final int MAX_REFRESH_TOKENS = 4;
+
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+    @Transactional
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
-        // AccessToken, RefreshToken 생성
-        String accessToken = jwtTokenProvider.createAccessToken(oAuth2User.getUser());
+        // 토큰 생성 & 저장
+        String accessToken  = jwtTokenProvider.createAccessToken(oAuth2User.getUser());
         String refreshToken = jwtTokenProvider.createRefreshToken();
+        refreshTokenRepository.save(RefreshToken.builder()
+                .user(oAuth2User.getUser())
+                .token(refreshToken)
+                .expiredAt(LocalDateTime.now().plusDays(7))
+                .build());
 
-        // RefreshToken DB 저장
-        refreshTokenRepository.save(
-                RefreshToken.builder()
-                        .user(oAuth2User.getUser())
-                        .token(refreshToken)
-                        .expiredAt(LocalDateTime.now().plusDays(7))
-                        .build()
-        );
+        // 사용자별 토큰 개수 체크 & 초과분 삭제
+        List<RefreshToken> tokens = refreshTokenRepository
+                .findByUserOrderByCreatedAtAsc(oAuth2User.getUser());
+
+        if (tokens.size() > MAX_REFRESH_TOKENS) {
+            int overflow = tokens.size() - MAX_REFRESH_TOKENS;
+            for (int i = 0; i < overflow; i++) {
+                refreshTokenRepository.delete(tokens.get(i));
+            }
+        }
 
         // 리프레시 토큰을 HttpOnly 쿠키에 저장
         Cookie cookie = new Cookie("refreshToken", refreshToken);


### PR DESCRIPTION
### 1. 리프레시 토큰 개수 제한
- 사용자당 최대 4개의 리프레시 토큰 발급
- 초과 시 오래된 토큰부터 즉시 삭제

### 2. 만료 토큰 자동 청소
- 매일 자정에 만료된 토큰 레코드를 일괄 삭제하는 스케줄러 도입

### 3. 전체 로그아웃 기능
- /api/token/logout/all 엔드포인트 추가

### 4. 모든 기기(토큰)에서 동시 로그아웃 지원
- Repository 메서드 확장
- deleteByUserId(userId) : 전체 로그아웃
- deleteAllByExpiredAtBefore(now) : 만료 토큰 청소

### 5. 엔티티 시간 관리 개선
- BaseTimeEntity 에 @PrePersist/@PreUpdate 로 생성·수정일 자동 처리
- 기존 @EnableJpaAuditing 대신에 코드 레벨에서 관리

### 6. 앱 설정 변경
- @EnableJpaAuditing 및 @EnableScheduling 활성화
