### PR TITLE
재료 조회 opensearch api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,10 @@ dependencies {
 	implementation 'software.amazon.awssdk:regions'
 	implementation 'software.amazon.awssdk:http-auth-aws'
 
+	//서버 인메모리 캐시(Caffeine)
+	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+
 	testImplementation 'org.springframework.security:spring-security-test'
 }
 

--- a/src/main/java/com/jdc/recipe_service/config/CacheConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/CacheConfig.java
@@ -1,0 +1,25 @@
+package com.jdc.recipe_service.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cm = new CaffeineCacheManager("ingSuggest","inSuggestFull");
+        cm.setCaffeine(Caffeine.newBuilder()
+                .maximumSize(500)
+                .expireAfterWrite(Duration.ofMinutes(10))
+        );
+        return cm;
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -156,7 +156,8 @@ public class SecurityConfig {
                                 "/api/me/favorites",
                                 "/api/me/fridge/items",
                                 "/api/me/calendar/**",
-                                "/api/ratings/recipe/*/me"
+                                "/api/ratings/recipe/*/me",
+                                "/api/search/**"
                         ).authenticated()
 
                         // 3) 읽기 전용 GET (모두 허용)

--- a/src/main/java/com/jdc/recipe_service/opensearch/controller/OpenSearchAdminController.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/controller/OpenSearchAdminController.java
@@ -14,17 +14,37 @@ public class OpenSearchAdminController {
 
     private final OpenSearchIndexService indexService;
 
-    /** recipes 인덱스를 생성하는 관리자용 API */
-    @PostMapping("/create-index")
-    public ResponseEntity<?> createIndex() {
+    /**
+     * 'ingredients' 인덱스를 삭제하고 재생성 모든 재료를 다시 인덱싱
+     */
+    @PostMapping("/ingredients/index")
+    public ResponseEntity<Map<String, Boolean>> recreateIngredientsIndex() {
+        boolean reindexed = indexService.recreateIngredientIndex();
+        return ResponseEntity.ok(Map.of("reindexed", reindexed));
+    }
+
+    /**
+     * 'ingredients' 인덱스를 삭제
+     */
+    @DeleteMapping("/ingredients/index")
+    public ResponseEntity<Map<String, Boolean>> deleteIngredientsIndex() {
+        boolean deleted = indexService.deleteIngredientIndex();
+        return ResponseEntity.ok(Map.of("deleted", deleted));
+    }
+
+    /**
+     * 지정한 이름의 인덱스를 삭제
+     */
+    @DeleteMapping("/index/{name}")
+    public ResponseEntity<Map<String, Boolean>> deleteIndexByName(
+            @PathVariable("name") String indexName) {
+        boolean deleted;
         try {
-            boolean ok = indexService.createRecipeIndex();
-            return ResponseEntity.ok(Map.of("created", ok));
-        } catch (IOException e) {
-            return ResponseEntity.status(500).body(Map.of(
-                    "error", "인덱스 생성 실패",
-                    "message", e.getMessage()
-            ));
+            deleted = indexService.deleteIndex(indexName);
+        } catch (Exception e) {
+            return ResponseEntity.status(500)
+                    .body(Map.of("error", false));
         }
+        return ResponseEntity.ok(Map.of("deleted", deleted));
     }
 }

--- a/src/main/java/com/jdc/recipe_service/opensearch/controller/SearchController.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/controller/SearchController.java
@@ -3,6 +3,7 @@ package com.jdc.recipe_service.opensearch.controller;
 import com.jdc.recipe_service.domain.dto.RecipeSearchCondition;
 import com.jdc.recipe_service.domain.dto.ingredient.IngredientSummaryDto;
 import com.jdc.recipe_service.domain.dto.recipe.RecipeSimpleDto;
+import com.jdc.recipe_service.opensearch.service.OpenSearchSuggestionService;
 import com.jdc.recipe_service.security.CustomUserDetails;
 import com.jdc.recipe_service.opensearch.service.OpenSearchService;
 import org.springframework.data.domain.Page;
@@ -20,9 +21,12 @@ import java.util.List;
 public class SearchController {
 
     private final OpenSearchService searchService;
+    private final OpenSearchSuggestionService suggestionService;
 
-    public SearchController(OpenSearchService searchService) {
+
+    public SearchController(OpenSearchService searchService, OpenSearchSuggestionService suggestionService) {
         this.searchService = searchService;
+        this.suggestionService = suggestionService;
     }
 
     /** 레시피 검색 */
@@ -54,5 +58,42 @@ public class SearchController {
         Long userId = userDetails != null ? userDetails.getUser().getId() : null;
         Page<IngredientSummaryDto> page = searchService.searchIngredients(q, category, inFridge, userId, pageable);
         return ResponseEntity.ok(page);
+    }
+
+    /**
+     * 자동완성 제안 API
+     * 최소 2글자 이상에서 호출 권장
+     */
+    @GetMapping("/ingredients/suggest")
+    public ResponseEntity<List<String>> suggest(
+            @RequestParam String prefix,
+            @RequestParam(required = false) String category,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        if (prefix.length() < 2) {
+            return ResponseEntity.ok(List.of());
+        }
+        List<String> suggestions = suggestionService.suggestIngredientNames(prefix, category,  size);
+        return ResponseEntity.ok(suggestions);
+    }
+
+    /**
+     * 풀 DTO 자동완성 제안 API
+     * 최소 2글자 이상에서 호출 권장
+     */
+    @GetMapping("/ingredients/suggest-full")
+    public ResponseEntity<List<IngredientSummaryDto>> suggestFull(
+            @RequestParam String prefix,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) Boolean inFridge,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (prefix.length() < 2) {
+            return ResponseEntity.ok(List.of());
+        }
+        Long userId = userDetails != null ? userDetails.getUser().getId() : null;
+        List<IngredientSummaryDto> suggestions =
+                suggestionService.suggestFull(prefix, category, inFridge, size, userId);
+        return ResponseEntity.ok(suggestions);
     }
 }

--- a/src/main/java/com/jdc/recipe_service/opensearch/service/OpenSearchIndexService.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/service/OpenSearchIndexService.java
@@ -1,65 +1,134 @@
 package com.jdc.recipe_service.opensearch.service;
 
+import com.jdc.recipe_service.domain.entity.Ingredient;
+import com.jdc.recipe_service.domain.repository.IngredientRepository;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.client.indices.CreateIndexRequest;
-import org.opensearch.client.indices.CreateIndexResponse;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
+@RequiredArgsConstructor
 public class OpenSearchIndexService {
 
     private final RestHighLevelClient client;
+    private final IngredientRepository ingredientRepo;
 
-    public OpenSearchIndexService(RestHighLevelClient client) {
-        this.client = client;
+    /**
+     * 'ingredients' 인덱스가 존재하면 HTTP DELETE로 삭제
+     */
+    public boolean deleteIngredientIndex() {
+        try {
+            // Low-level REST Client 사용
+            Request req = new Request("DELETE", "/ingredients");
+            Response resp = client.getLowLevelClient().performRequest(req);
+            return resp.getStatusLine().getStatusCode() == 200;
+        } catch (ResponseException e) {
+            // 404 Not Found: 인덱스가 없는 경우
+            if (e.getResponse().getStatusLine().getStatusCode() == 404) {
+                return false;
+            }
+            throw new CustomException(ErrorCode.SEARCH_FAILURE, e.getMessage());
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.SEARCH_FAILURE, e.getMessage());
+        }
     }
 
-    public boolean createRecipeIndex() throws IOException {
-        CreateIndexRequest request = new CreateIndexRequest("recipes");
-        request.settings("""
-        {
-          "analysis": {
-            "filter": {
-              "my_synonym": {
-                "type": "synonym",
-                "synonyms": ["감자,포테이토", "김치,kimchi"]
-              }
-            },
-            "tokenizer": {
-              "autocomplete_tokenizer": {
-                "type": "edge_ngram",
-                "min_gram": 2,
-                "max_gram": 20,
-                "token_chars": ["letter"]
-              }
-            },
-            "analyzer": {
-              "autocomplete_analyzer": {
-                "tokenizer": "autocomplete_tokenizer",
-                "filter": ["lowercase", "my_synonym"]
-              }
+    /**
+     * 'ingredients' 인덱스를 생성하고 모든 재료를 Bulk 인덱싱
+     * 매핑: name(text + keyword), category(keyword)
+     */
+    public boolean createIngredientIndex() throws IOException {
+        // 1) 인덱스 설정
+        CreateIndexRequest request = new CreateIndexRequest("ingredients");
+        request.settings(Settings.builder()
+                .put("index.number_of_shards", 1)
+                .put("index.number_of_replicas", 1)
+        );
+
+        String mapping = "{\n" +
+                "  \"properties\": {\n" +
+                "    \"name\":     {\"type\": \"text\",    \"fields\": {\"keyword\": {\"type\":\"keyword\"}}},\n" +
+                "    \"category\": {\"type\": \"keyword\"},\n" +
+                "    \"imageUrl\": {\"type\": \"keyword\"},\n" +
+                "    \"unit\":     {\"type\": \"keyword\"},\n" +
+                "    \"name_suggest\": {\"type\": \"completion\"}  \n" +
+                "  }\n" +
+                "}";
+        request.mapping(mapping, XContentType.JSON);
+        client.indices().create(request, RequestOptions.DEFAULT);
+
+        // 3) DB에서 재료 전량 조회 후 Bulk 요청 생성
+        List<Ingredient> all = ingredientRepo.findAll();
+        BulkRequest bulkRequest = new BulkRequest();
+        for (Ingredient ing : all) {
+            Map<String, Object> doc = new HashMap<>();
+            doc.put("name", ing.getName());
+            doc.put("category", ing.getCategory());
+            doc.put("imageUrl", ing.getImageUrl());
+            doc.put("unit",     ing.getUnit());
+            doc.put("name_suggest",  ing.getName());
+
+            bulkRequest.add(new IndexRequest("ingredients")
+                    .id(ing.getId().toString())
+                    .source(doc)
+            );
+        }
+
+        // 4) Bulk 색인 실행 및 결과 확인
+        BulkResponse bulkResponse = client.bulk(bulkRequest, RequestOptions.DEFAULT);
+        if (bulkResponse.hasFailures()) {
+            throw new CustomException(
+                    ErrorCode.SEARCH_FAILURE,
+                    "Bulk 색인 실패: " + bulkResponse.buildFailureMessage()
+            );
+        }
+        return true;
+    }
+
+    /**
+     * 'ingredients' 인덱스를 삭제 후 재생성 및 재인덱싱
+     */
+    public boolean recreateIngredientIndex() {
+        deleteIngredientIndex();
+        try {
+            return createIngredientIndex();
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.SEARCH_FAILURE, e.getMessage());
+        }
+    }
+
+    /**
+     * 지정한 인덱스를 삭제
+     */
+    public boolean deleteIndex(String indexName) {
+        try {
+            Request req = new Request("DELETE", "/" + indexName);
+            Response resp = client.getLowLevelClient().performRequest(req);
+            return resp.getStatusLine().getStatusCode() == 200;
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() == 404) {
+                return false;
             }
-          }
+            throw new CustomException(ErrorCode.SEARCH_FAILURE, e.getMessage());
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.SEARCH_FAILURE, e.getMessage());
         }
-        """, XContentType.JSON);
-        request.mapping("""
-        {
-          "properties": {
-            "title":       { "type":"text", "analyzer":"autocomplete_analyzer" },
-            "description": { "type":"text" },
-            "dishType":    { "type":"keyword" },
-            "ingredients": { "type":"text", "analyzer":"autocomplete_analyzer" },
-            "tags":        { "type":"keyword" },
-            "createdAt":   { "type":"date" },
-            "likeCount":   { "type":"integer" }
-          }
-        }
-        """, XContentType.JSON);
-        CreateIndexResponse res = client.indices().create(request, RequestOptions.DEFAULT);
-        return res.isAcknowledged();
     }
 }

--- a/src/main/java/com/jdc/recipe_service/opensearch/service/OpenSearchSuggestionService.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/service/OpenSearchSuggestionService.java
@@ -1,0 +1,114 @@
+package com.jdc.recipe_service.opensearch.service;
+
+import com.jdc.recipe_service.domain.dto.ingredient.IngredientSummaryDto;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.suggest.Suggest;
+import org.opensearch.search.suggest.SuggestBuilder;
+import org.opensearch.search.suggest.completion.CompletionSuggestionBuilder;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class OpenSearchSuggestionService {
+
+    private final RestHighLevelClient client;
+    private final OpenSearchService  searchService;
+    private static final String      INDEX = "ingredients";
+
+    public OpenSearchSuggestionService(RestHighLevelClient client,
+                                       OpenSearchService searchService) {
+        this.client = client;
+        this.searchService = searchService;
+    }
+
+    /**
+     * 1) 문자열만 자동완성 제안
+     * @param prefix    사용자 입력 접두어
+     * @param category  카테고리 필터 (optional)
+     * @param size      최대 제안 개수
+     */
+    @Cacheable(
+            value = "ingSuggest",
+            key   = "#prefix + ':' + (#category != null ? #category : '')",
+            unless= "#result.isEmpty()"
+    )
+    public List<String> suggestIngredientNames(
+            String prefix,
+            String category,
+            int size
+    ) {
+        try {
+            CompletionSuggestionBuilder sugg = new CompletionSuggestionBuilder("name_suggest")
+                    .prefix(prefix)
+                    .size(size)
+                    .skipDuplicates(true);
+            SuggestBuilder sb = new SuggestBuilder().addSuggestion("ingredient-suggest", sugg);
+
+            SearchSourceBuilder src = new SearchSourceBuilder().suggest(sb);
+
+            var response = client.search(
+                    new org.opensearch.action.search.SearchRequest(INDEX).source(src),
+                    RequestOptions.DEFAULT
+            );
+            Suggest suggest = response.getSuggest();
+
+            List<String> names = suggest.getSuggestion("ingredient-suggest")
+                    .getEntries().stream()
+                    .flatMap(entry -> entry.getOptions().stream())
+                    .map(opt -> opt.getText().string())
+                    .collect(Collectors.toList());
+
+            if (category != null && !category.isBlank()) {
+                var filtered = searchService
+                        .searchIngredients(prefix, category, null, null,
+                                PageRequest.of(0, Integer.MAX_VALUE))
+                        .getContent().stream()
+                        .map(IngredientSummaryDto::name)
+                        .collect(Collectors.toSet());
+                names = names.stream()
+                        .filter(filtered::contains)
+                        .limit(size)
+                        .collect(Collectors.toList());
+            }
+
+            return names;
+        } catch (IOException e) {
+            throw new RuntimeException("자동완성 제안 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 2) 풀 DTO 자동완성 제안 (이미지·단위·inFridge 포함)
+     * @param prefix    사용자 입력 접두어
+     * @param category  카테고리 필터 (optional)
+     * @param inFridge  냉장고 필터 (optional)
+     * @param size      최대 제안 개수
+     * @param userId    로그인 사용자 ID
+     */
+    @Cacheable(
+            value = "ingSuggestFull",
+            key   = "#prefix + ':' + (#category != null ? #category : '') + ':' + (#inFridge != null ? #inFridge : '')",
+            unless= "#result.isEmpty()"
+    )
+    public List<IngredientSummaryDto> suggestFull(
+            String prefix,
+            String category,
+            Boolean inFridge,
+            int size,
+            Long userId
+    ) {
+        Pageable pg = PageRequest.of(0, size, Sort.by("name").ascending());
+        return searchService
+                .searchIngredients(prefix, category, inFridge, userId, pg)
+                .getContent();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: prod
+    active: local
 
 server:
   forward-headers-strategy: framework


### PR DESCRIPTION
### 1. OpenSearch 인덱스 관리 API (OpenSearchIndexService / OpenSearchAdminController)
- 인덱스 생성 (POST /api/opensearch/ingredients/index)
  - ingredients 인덱스 삭제 → 재생성 → DB 전체 재색인
  - 매핑: name(text+keyword), category(keyword), imageUrl, unit, name_suggest(completion)
- 인덱스 삭제 (DELETE /api/opensearch/ingredients/index)
- 임의 인덱스 삭제 (DELETE /api/opensearch/index/{name})

### 2. OpenSearch 검색 서비스 (OpenSearchService)
- 레시피 검색 (/api/search/recipes)
  - multiMatchQuery 기반 텍스트 검색 + dishType, tags 필터 + 페이징/정렬
- 재료 검색 (/api/search/ingredients)
  - matchPhrasePrefixQuery("name", q) 기반 접두어 검색
  - category, inFridge 필터 지원
  - 애플리케이션 레벨 정렬/페이징으로도 일관된 결과 보장

### 3. 자동완성 제안 서비스 (OpenSearchSuggestionService)
- 문자열 제안 (suggestIngredientNames)
  - completion 타입 name_suggest 필드로 빠른 접두어 제안
  - prefix + category 조합으로 캐싱(Caffeine, 10min TTL, max 500)
- 풀 DTO 제안 (suggestFull)
  - 이미지URL, 단위, inFridge 상태 포함한 IngredientSummaryDto 리스트 반환
  - prefix + category + inFridge 조합별 캐싱

### 4. 컨트롤러 엔드포인트 (SearchController)
- 레시피 검색: GET /api/search/recipes
- 재료 검색: GET /api/search/ingredients
- 문자열 자동완성: GET /api/search/ingredients/suggest?prefix=&category=&size=
- 풀 DTO 자동완성: GET /api/search/ingredients/suggest-full?prefix=&category=&inFridge=&size=

### 5. 캐시 설정 (CacheConfig)
- Caffeine 기반 캐시 매니저 등록: ingSuggest, ingSuggestFull
- maximumSize=500, expireAfterWrite=10분

### 6. 보안 설정(SecurityConfig)
- /api/search/** 엔드포인트 전체를 permitAll() 처리하여 인증 없이도 검색·자동완성 사용 가능
- 로컬/운영 프로필 별로 H2 콘솔, Swagger 등 기존 설정 유지