### PR TITLE
api/refresh response 헤더 설정

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 import java.util.Arrays;
 
@@ -246,4 +247,21 @@ public class SecurityConfig {
         src.registerCorsConfiguration("/**", cfg);
         return src;
     }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration cfg = new CorsConfiguration();
+        cfg.setAllowedOrigins(Arrays.asList(
+                "http://localhost:5173",
+                "https://www.haemeok.com"
+        ));
+        cfg.setAllowedMethods(Arrays.asList("GET","POST","PUT","DELETE","OPTIONS"));
+        cfg.setAllowedHeaders(Arrays.asList("*"));
+        cfg.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource src = new UrlBasedCorsConfigurationSource();
+        src.registerCorsConfiguration("/**", cfg);
+        return new CorsFilter(src);
+    }
 }
+


### PR DESCRIPTION
### 주요 변경 사항
1. **OAuth2AuthenticationSuccessHandler**  
   - 기존 `java.servlet.http.Cookie` → `ResponseCookie`로 교체  
   - Secure, HttpOnly, Path, Max-Age뿐 아니라 `SameSite=None` 을 명시해 크로스-사이트 리디렉션 시에도 쿠키가 차단되지 않도록 설정  

2. **SecurityConfig**  
   - 모든 요청에 CORS 헤더를 보장하기 위해 전역 `CorsFilter` 빈 추가  
   - 기존 `corsConfig()` 는 유지하여 preflight 요청과 시큐리티 체인 내 CORS 처리는 그대로 수행