### PR TITLE
api/refresh cookie 관련 수정

### DIFF
--- a/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -58,10 +58,10 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
 
         ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(true)        // HTTPS에서만 전송
-                .path("/")           // 모든 경로에서 접근 가능
+                .secure(true)
+                .path("/")
                 .maxAge(7 * 24 * 60 * 60)
-                .sameSite("None")    // 크로스-사이트에서도 허용
+                .sameSite("None")
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());


### PR DESCRIPTION
### 주요 변경 사항
- OAuth2AuthenticationSuccessHandler
   - javax.servlet.http.Cookie 대신 Spring의 ResponseCookie 사용
   - Secure, HttpOnly 외에 SameSite=None 옵션을 명시하여 쿠키가 크로스-사이트에서도 허용되도록 수정
