### PR TITLE
달력 요약 API에 일별 레시피 건수 및 첫 번째 이미지 URL 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/controller/AuthController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/AuthController.java
@@ -106,7 +106,6 @@ public class AuthController {
             @RequestHeader(value = "Authorization", required = false) String authorization,
             HttpServletResponse response) {
 
-        // (A) Authorization 헤더 유효성 검사
         if (authorization == null || !authorization.startsWith("Bearer ")) {
             throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
         }
@@ -115,13 +114,10 @@ public class AuthController {
             throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
         }
 
-        // (B) 유저 ID 추출
         Long userId = jwtTokenProvider.getUserIdFromToken(accessToken);
 
-        // (C) 유저의 모든 리프레시 토큰 삭제
         refreshTokenRepository.deleteByUserId(userId);
 
-        // (D) 클라이언트 쿠키 삭제
         Cookie deleteCookie = new Cookie("refreshToken", null);
         deleteCookie.setHttpOnly(true);
         deleteCookie.setSecure(true);

--- a/src/main/java/com/jdc/recipe_service/domain/dto/calendar/CalendarDaySummaryDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/calendar/CalendarDaySummaryDto.java
@@ -9,9 +9,13 @@ public class CalendarDaySummaryDto {
 
     private LocalDate date;
     private Long totalSavings;
+    private Long totalCount;
+    private String firstImageUrl;
 
-    public CalendarDaySummaryDto(LocalDate date, Long totalSavings) {
+    public CalendarDaySummaryDto(LocalDate date, Long totalSavings, Long totalCount, String firstImageUrl) {
         this.date = date;
         this.totalSavings = totalSavings;
+        this.totalCount = totalCount;
+        this.firstImageUrl = firstImageUrl;
     }
 }


### PR DESCRIPTION
- CalendarDaySummaryDto에 totalCount, firstImageUrl 필드 추가
- CookingRecordService에 S3 이미지 URL 생성 메서드(generateImageUrl) 추가 및 @Value 프로퍼티 주입
- getMonthlySummary 로직 수정: 일별 레코드 건수 조회 및 가장 오래된 레코드의 이미지 URL 조회 후 DTO에 반영