### PR TITLE
불꽃 기능 구현

### DIFF
--- a/src/main/java/com/jdc/recipe_service/controller/MyAccountController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/MyAccountController.java
@@ -1,11 +1,13 @@
 package com.jdc.recipe_service.controller;
 
+import com.jdc.recipe_service.domain.dto.calendar.CookingStreakDto;
 import com.jdc.recipe_service.domain.dto.recipe.MyRecipeSummaryDto;
 import com.jdc.recipe_service.domain.dto.recipe.RecipeSimpleDto;
 import com.jdc.recipe_service.domain.dto.recipe.user.FavoriteRecipeDto;
 import com.jdc.recipe_service.domain.dto.user.UserRequestDTO;
 import com.jdc.recipe_service.domain.dto.user.UserResponseDTO;
 import com.jdc.recipe_service.security.CustomUserDetails;
+import com.jdc.recipe_service.service.CookingRecordService;
 import com.jdc.recipe_service.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,8 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 public class MyAccountController {
 
     private final UserService userService;
+    private final CookingRecordService cookingService;
+
 
     //  내 정보 조회
     @GetMapping
@@ -84,5 +88,18 @@ public class MyAccountController {
                 userService.getUserRecipes(myId, myId, pageable);
 
         return ResponseEntity.ok(page);
+    }
+
+    @GetMapping("/streak")
+    public ResponseEntity<CookingStreakDto> getMyCookingStreak(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        Long userId = userDetails.getUser().getId();
+        CookingStreakDto stats = cookingService.getCookingStreakInfo(userId);
+        return ResponseEntity.ok(stats);
     }
 }

--- a/src/main/java/com/jdc/recipe_service/domain/dto/calendar/CookingStreakDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/calendar/CookingStreakDto.java
@@ -1,0 +1,11 @@
+package com.jdc.recipe_service.domain.dto.calendar;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CookingStreakDto {
+    private final int streak;
+    private final boolean cookedToday;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/repository/CookingRecordRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/CookingRecordRepository.java
@@ -24,6 +24,50 @@ public interface CookingRecordRepository extends JpaRepository<CookingRecord, Lo
             @Param("month")  int month
     );
 
+    /** 연속 요리 일수와 요리 여부 SQL로 계산 */
+    // language=MySQL
+    @Query(value = """
+WITH DistinctCookDates AS (
+    SELECT DISTINCT DATE(created_at) AS cook_date
+    FROM cooking_records
+    WHERE user_id = :userId
+      AND DATE(created_at) <= CURRENT_DATE
+),
+CookedTodayInfo AS (
+    SELECT EXISTS(SELECT 1 FROM DistinctCookDates WHERE cook_date = CURRENT_DATE) AS did_cook_today
+),
+TargetStreakEndDate AS (
+    SELECT
+        CASE
+            WHEN cti.did_cook_today THEN CURRENT_DATE
+            ELSE DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
+        END AS streak_end_date,
+        cti.did_cook_today
+    FROM CookedTodayInfo cti
+),
+DateWithGroupKey AS (
+    SELECT
+        cook_date,
+        DATE_SUB(cook_date, INTERVAL ROW_NUMBER() OVER (ORDER BY cook_date ASC) DAY) AS group_key
+    FROM DistinctCookDates
+),
+RelevantStreakGroup AS (
+    SELECT
+        dgk.group_key
+    FROM DateWithGroupKey dgk
+    JOIN TargetStreakEndDate tsed ON dgk.cook_date = tsed.streak_end_date
+)
+SELECT
+    COALESCE(
+        (SELECT COUNT(dgk.cook_date)
+         FROM DateWithGroupKey dgk
+         JOIN RelevantStreakGroup rsg ON dgk.group_key = rsg.group_key
+         WHERE dgk.cook_date <= (SELECT streak_end_date FROM TargetStreakEndDate)
+        ), 0) AS streak,
+    (SELECT did_cook_today FROM CookedTodayInfo) AS cooked_today
+""", nativeQuery = true)
+    Object[] findStreakAndTodayFlag(@Param("userId") Long userId);
+
     List<CookingRecord> findByUserIdAndCreatedAtBetweenOrderByCreatedAtDesc(
             Long userId, LocalDateTime start, LocalDateTime end
     );

--- a/src/main/java/com/jdc/recipe_service/service/CookingRecordService.java
+++ b/src/main/java/com/jdc/recipe_service/service/CookingRecordService.java
@@ -129,4 +129,20 @@ public class CookingRecordService {
                 .orElseThrow(() -> new IllegalArgumentException("Record not found"));
         return CookingRecordDto.from(rec);
     }
+
+    /** 불꽃(연속 요리 일수와 오늘 요리 여부) */
+    @Transactional(readOnly = true)
+    public CookingStreakDto getCookingStreakInfo(Long userId) {
+        Object[] result = repo.findStreakAndTodayFlag(userId);
+
+        int streak = 0;
+        boolean cookedToday = false;
+
+        if (result != null && result.length == 2) {
+            streak = ((Number) result[0]).intValue();
+            cookedToday = ((Number) result[1]).intValue() == 1;
+        }
+
+        return new CookingStreakDto(streak, cookedToday);
+    }
 }


### PR DESCRIPTION
### 개요
사용자의 현재 연속 요리 일수(Streak)와 오늘 요리했는지 여부를 계산하여 제공하는 기능을 추가함

### 주요 변경 사항
- **`CookingRecordRepository`**:
    - `findStreakAndTodayFlag(Long userId)` 메소드 및 Native SQL 쿼리 추가
    - SQL 쿼리는 다음 로직에 따라 연속 요리 일수와 오늘 요리 여부를 계산:
        1. 오늘 (`CURRENT_DATE`) 요리한 경우: 오늘까지의 연속된 요리 일수를 계산
        2. 오늘 요리하지 않은 경우: 어제 (`CURRENT_DATE - 1 DAY`)까지의 연속된 요리 일수를 계산합니다. (어제도 요리하지 않았다면 연속 일수는 0)
        3. 오늘 요리 여부를 boolean 값 (DB에서는 1 또는 0)으로 반환
    - 쿼리의 가독성 및 단계별 로직 구분을 위해 CTE (Common Table Expressions)와 윈도우 함수 (`ROW_NUMBER()`), 날짜 함수 (`DATE_SUB`, `CURRENT_DATE`), `EXISTS` 등을 활용

- **`CookingStreakDto`**:
    - 연속 요리 일수 (`streak`: `int`)와 오늘 요리 여부 (`cookedToday`: `boolean`)를 담는 DTO를 정의

- **`CookingService` (또는 관련 서비스 클래스)**:
    - `getCookingStreakInfo(Long userId)` 메소드를 구현하여, Repository로부터 받은 `Object[]` 결과를 `CookingStreakDto`로 변환

- **`CookingController` (또는 관련 컨트롤러 클래스)**:
    - 연속 요리 정보를 조회할 수 있는 API 엔드포인트(예: `GET /api/.../streak`)를 추가