### PR TITLE
Feature/response-format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM --platform=linux/amd64 openjdk:17-jdk-slim
 VOLUME /tmp
 COPY build/libs/recipe-service-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-Xms1280m", "-Xmx1280m", "-jar", "/app.jar", "--spring.profiles.active=prod"]
+ENTRYPOINT ["java", "-Duser.timezone=UTC", "-Xms1280m", "-Xmx1280m", "-jar", "/app.jar", "--spring.profiles.active=prod"]
 #ENTRYPOINT ["java", "-Xms1024m", "-Xmx1024m", "-jar", "/app.jar", "--spring.profiles.active=prod"]

--- a/ecs-task-definition-template.json
+++ b/ecs-task-definition-template.json
@@ -35,8 +35,8 @@
         { "name": "APP_S3_BUCKET_NAME", "value": "${APP_S3_BUCKET_NAME}" },
         { "name": "APP_S3_UPLOAD_BASE_PATH", "value": "${APP_S3_UPLOAD_BASE_PATH}" },
         { "name": "APP_S3_PRESIGNED_URL_EXPIRATION_MINUTES", "value": "${APP_S3_PRESIGNED_URL_EXPIRATION_MINUTES}" },
-        { "name": "OPENSEARCH_HOST", "value": "${OPENSEARCH_HOST}"},
-        { "name": "REPLICATE_TOKEN", "value": "${REPLICATE_TOKEN}"}
+        { "name": "OPENSEARCH_HOST", "value": "${OPENSEARCH_HOST}" },
+        { "name": "REPLICATE_TOKEN", "value": "${REPLICATE_TOKEN}" }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/src/main/java/com/jdc/recipe_service/domain/dto/calendar/CookingRecordDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/calendar/CookingRecordDto.java
@@ -1,6 +1,9 @@
 package com.jdc.recipe_service.domain.dto.calendar;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 public class CookingRecordDto {
@@ -10,7 +13,12 @@ public class CookingRecordDto {
     private Integer ingredientCost;
     private Integer marketPrice;
     private Integer savings;
-    private String createdAt;
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'",
+            timezone = "UTC"
+    )
+    private LocalDateTime createdAt;
 
     public static CookingRecordDto from(com.jdc.recipe_service.domain.entity.CookingRecord e) {
         var dto = new CookingRecordDto();
@@ -20,7 +28,7 @@ public class CookingRecordDto {
         dto.ingredientCost = e.getIngredientCost();
         dto.marketPrice    = e.getMarketPrice();
         dto.savings        = e.getSavings();
-        dto.createdAt      = e.getCreatedAt().toString();
+        dto.createdAt      = e.getCreatedAt();
         return dto;
     }
 }

--- a/src/main/java/com/jdc/recipe_service/domain/dto/fridge/RefrigeratorItemResponseDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/fridge/RefrigeratorItemResponseDto.java
@@ -1,13 +1,20 @@
 package com.jdc.recipe_service.domain.dto.fridge;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.jdc.recipe_service.domain.dto.ingredient.IngredientResponseDto;
 import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor @Builder
 public class RefrigeratorItemResponseDto {
     private Long id;
     private IngredientResponseDto ingredient;
-    private String createdAt;
-    private String updatedAt;
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'",
+            timezone = "UTC"
+    )
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/jdc/recipe_service/domain/dto/user/UserResponseDTO.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/user/UserResponseDTO.java
@@ -1,5 +1,6 @@
 package com.jdc.recipe_service.domain.dto.user;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.jdc.recipe_service.domain.entity.User;
 import lombok.*;
 
@@ -14,19 +15,20 @@ public class UserResponseDTO {
     private String nickname;
     private String profileImage;
     private String introduction;
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'",
+            timezone = "UTC"
+    )
     private LocalDateTime createdAt;
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'",
+            timezone = "UTC"
+    )
     private LocalDateTime updatedAt;
 
-    //추후 삭제
     private String provider;
 
-    public UserResponseDTO(User user) {
-        this.id = user.getId();
-        this.nickname = user.getNickname();
-        this.profileImage = user.getProfileImage();
-        this.introduction = user.getIntroduction();
-        this.createdAt = user.getCreatedAt();
-        this.updatedAt = user.getUpdatedAt();
 
-    }
 }

--- a/src/main/java/com/jdc/recipe_service/service/CookingRecordService.java
+++ b/src/main/java/com/jdc/recipe_service/service/CookingRecordService.java
@@ -97,10 +97,14 @@ public class CookingRecordService {
                     List<CookingRecord> records = repo
                             .findByUserIdAndCreatedAtBetweenOrderByCreatedAtDesc(userId, start, end);
                     long totalCount = records.size();
-                    String oldestKey = records.isEmpty()
-                            ? null
-                            : records.get(records.size() - 1).getRecipe().getImageKey();
-                    String firstImageUrl = generateImageUrl(oldestKey);
+
+                    String imageKey = records.stream()
+                            .map(r -> r.getRecipe().getImageKey())
+                            .filter(key -> key != null && !key.isBlank())
+                            .findFirst()
+                            .orElse(null);
+
+                    String firstImageUrl = generateImageUrl(imageKey);
                     return new CalendarDaySummaryDto(date, totalSavings, totalCount, firstImageUrl);
                 })
                 .toList();

--- a/src/main/java/com/jdc/recipe_service/service/RefrigeratorItemService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RefrigeratorItemService.java
@@ -1,7 +1,6 @@
 package com.jdc.recipe_service.service;
 
 import com.jdc.recipe_service.domain.dto.fridge.RefrigeratorItemRequestDto;
-import com.jdc.recipe_service.domain.dto.fridge.RefrigeratorItemBulkRequestDto;
 import com.jdc.recipe_service.domain.dto.fridge.RefrigeratorItemResponseDto;
 import com.jdc.recipe_service.domain.dto.fridge.RefrigeratorItemSummaryDto;
 import com.jdc.recipe_service.domain.entity.Ingredient;
@@ -16,12 +15,9 @@ import com.jdc.recipe_service.mapper.IngredientMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -34,8 +30,6 @@ public class RefrigeratorItemService {
     private final RefrigeratorItemRepository repo;
     private final UserRepository       userRepo;
     private final IngredientRepository ingRepo;
-
-    private final DateTimeFormatter fmt = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
     /**
      * 내 냉장고 아이템 조회(페이지 + 카테고리 필터)
@@ -84,8 +78,7 @@ public class RefrigeratorItemService {
         return RefrigeratorItemResponseDto.builder()
                 .id(saved.getId())
                 .ingredient(IngredientMapper.toDto(ing))
-                .createdAt(saved.getCreatedAt().format(fmt))
-                .updatedAt(saved.getUpdatedAt().format(fmt))
+                .createdAt(saved.getCreatedAt())
                 .build();
     }
 


### PR DESCRIPTION
### 응답 DTO의 createdAt 필드 타입 String→LocalDateTime 변경 및 @JsonFormat 적용
- CookingRecordDto.createdAt @JsonFormat 처리, toString() 제거
- RefrigeratorItemResponseDto.createdAt @JsonFormat 처리, updatedAt 필드 삭제
- UserResponseDTO 및 기타 DTO에 동일 포맷 적용
- RefrigeratorItemService 포맷터(DateTimeFormatter) 제거
### 캘린더 imageKey fallback 로직 강화
- CookingRecordService.getMonthlySummary()에서 imageKey가 null 혹은 빈 문자열일 때 다음 기록의 이미지 키를 찾아 사용하도록 변경
### Dockerfile에 UTC 타임존 설정 적용
- ENTRYPOINT에 -Duser.timezone=UTC 옵션 추가하여 JVM 타임존을 UTC로 고정