### PR TITLE
프로필 이미지 수정 presign URL 구현

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -72,7 +72,8 @@ public class SecurityConfig {
                                     "/api/me/fridge/items",
                                     "/api/me/calendar/**",
                                     "/api/me/streak",
-                                    "/api/ratings/recipe/*/me"
+                                    "/api/ratings/recipe/*/me",
+                                    "/api/users/*/profile-image/presign"
                             ).authenticated()
 
                             // 4) 보호된 POST
@@ -98,7 +99,8 @@ public class SecurityConfig {
                                     "/api/me",
                                     "/api/recipes/*",
                                     "/api/ingredients",
-                                    "/api/recipes/*/images"
+                                    "/api/recipes/*/images",
+                                    "/api/users/*"
                             ).authenticated()
 
                             // 6) 보호된 DELETE
@@ -110,6 +112,11 @@ public class SecurityConfig {
                                     "/api/recipes/*",
                                     "/api/ratings/recipe/*",
                                     "/api/ingredients"
+                            ).authenticated()
+
+                            .requestMatchers(HttpMethod.PATCH,
+                                    "/api/users/*",
+                                    "/api/me"
                             ).authenticated()
 
                             // 7) 관리자용 API
@@ -159,7 +166,8 @@ public class SecurityConfig {
                                 "/api/me/fridge/items",
                                 "/api/me/calendar/**",
                                 "/api/me/streak",
-                                "/api/ratings/recipe/*/me"
+                                "/api/ratings/recipe/*/me",
+                                "/api/users/*/profile-image/presign"
                         ).authenticated()
 
                         // 3) 읽기 전용 GET (모두 허용)
@@ -203,7 +211,8 @@ public class SecurityConfig {
                                 "/api/ingredients",
                                 "/api/recipes/*",
                                 "/api/me",
-                                "/api/recipes/*/images"
+                                "/api/recipes/*/images",
+                                "/api/users/*"
                         ).authenticated()
 
                         // 6) 인증 필요 DELETE
@@ -216,11 +225,16 @@ public class SecurityConfig {
                                 "/api/me/fridge/items/*",
                                 "/api/me/fridge/items/bulk"
                         ).authenticated()
+                        // 7) 인증 필요 PATCH
+                        .requestMatchers(HttpMethod.PATCH,
+                                "/api/users/*",
+                                "/api/me"
+                        ).authenticated()
 
-                        // 7) 관리자용 API
+                        // 8) 관리자용 API
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
 
-                        // 8) 나머지 전부 차단
+                        // 9) 나머지 전부 차단
                         .anyRequest().denyAll()
                 )
                 .exceptionHandling(e -> e.authenticationEntryPoint(entryPoint))

--- a/src/main/java/com/jdc/recipe_service/domain/dto/user/UserPatchDTO.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/user/UserPatchDTO.java
@@ -1,0 +1,20 @@
+package com.jdc.recipe_service.domain.dto.user;
+
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserPatchDTO {
+    @Size(max = 50)
+    private String nickname;
+
+    @Size(max = 255)
+    private String introduction;
+
+    @Size(max = 255)
+    private String profileImageKey;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/entity/User.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/User.java
@@ -37,13 +37,21 @@ public class User extends BaseTimeEntity {
     @Column(name = "profile_image", length = 255)
     private String profileImage;
 
+    @Column(name = "profile_image_key", length = 255)
+    private String profileImageKey;
+
     @Column(length = 255)
     private String introduction;
 
 
     public void updateProfile(String nickname, String profileImage, String introduction) {
-        this.nickname = nickname;
-        this.profileImage = profileImage;
-        this.introduction = introduction;
+        if (nickname     != null) this.nickname     = nickname;
+        if (profileImage != null) this.profileImage = profileImage;
+        if (introduction != null) this.introduction = introduction;
+    }
+    public void updateProfileImageKey(String profileImageKey) {
+        if (profileImageKey != null && !profileImageKey.isBlank()) {
+            this.profileImageKey = profileImageKey;
+        }
     }
 }

--- a/src/main/java/com/jdc/recipe_service/mapper/UserMapper.java
+++ b/src/main/java/com/jdc/recipe_service/mapper/UserMapper.java
@@ -51,13 +51,4 @@ public class UserMapper {
                 .build();
     }
 
-    // 요청 DTO로 유저 일부 필드만 업데이트
-    public static void updateEntityFromDto(UserRequestDTO dto, User user) {
-        user.updateProfile(
-                dto.getNickname() != null ? dto.getNickname() : user.getNickname(),
-                dto.getProfileImage() != null ? dto.getProfileImage() : user.getProfileImage(),
-                dto.getIntroduction() != null ? dto.getIntroduction() : user.getIntroduction()
-        );
-    }
-
 }


### PR DESCRIPTION
- GET /api/users/{userId}/profile-image/presign 엔드포인트 추가
- UserPatchDTO 생성 (nickname/introduction/profileImageKey nullable)
- UserService.updateUser(UserPatchDTO)로 시그니처 변경
  • updateProfile null-guard 적용
  • updateProfileImageKey blank vs key 분기 처리
- MyAccountController, UserController: 프로필 수정 PUT → PATCH 전환
- 인증 실패 시 CustomException(ErrorCode.AUTH_UNAUTHORIZED) 일관 적용