### PR TITLE
feat: 냉장고 재료 기반 레시피 조회 기능 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
                                     "/api/me/calendar/**",
                                     "/api/me/streak",
                                     "/api/me/survey",
+                                    "/api/me/fridge/recipes",
                                     "/api/ratings/recipe/*/me",
                                     "/api/users/*/profile-image/presign"
                             ).authenticated()
@@ -169,6 +170,7 @@ public class SecurityConfig {
                                 "/api/me/calendar/**",
                                 "/api/me/streak",
                                 "/api/me/survey",
+                                "/api/me/fridge/recipes",
                                 "/api/ratings/recipe/*/me",
                                 "/api/users/*/profile-image/presign"
                         ).authenticated()

--- a/src/main/java/com/jdc/recipe_service/domain/repository/RefrigeratorItemRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/RefrigeratorItemRepository.java
@@ -24,4 +24,7 @@ public interface RefrigeratorItemRepository extends JpaRepository<RefrigeratorIt
 
     /** 삭제용 */
     void deleteByUserIdAndIngredientId(Long userId, Long ingredientId);
+
+    /** 전체 리스트 조회*/
+    List<RefrigeratorItem> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/jdc/recipe_service/exception/ErrorCode.java
+++ b/src/main/java/com/jdc/recipe_service/exception/ErrorCode.java
@@ -65,7 +65,7 @@ public enum ErrorCode {
     SEARCH_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "950", "검색 처리 중 오류가 발생했습니다."),
     INGREDIENT_SEARCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "951", "재료 검색 처리 중 오류가 발생했습니다."),
     INGREDIENT_FALLBACK_SEARCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "952", "재료 대체 검색 처리 중 오류가 발생했습니다."),
-
+    FRIDGE_RECIPE_SEARCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "953", "냉장고 기반 레시피 조회 중 오류가 발생했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/jdc/recipe_service/opensearch/controller/FridgeRecipeController.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/controller/FridgeRecipeController.java
@@ -1,0 +1,49 @@
+package com.jdc.recipe_service.opensearch.controller;
+
+import com.jdc.recipe_service.opensearch.dto.FridgeRecipeDto;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.opensearch.service.FridgeRecipeSearchService;
+import com.jdc.recipe_service.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/me/fridge/recipes")
+@RequiredArgsConstructor
+public class FridgeRecipeController {
+
+    private final FridgeRecipeSearchService service;
+
+    @GetMapping
+    public ResponseEntity<Page<FridgeRecipeDto>> findByFridge(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0")  int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt,desc") String sort) {
+
+        Long userId = userDetails.getUser().getId();
+
+        String[] parts = sort.split(",");
+        Sort.Direction dir = parts.length > 1 && parts[1].equalsIgnoreCase("asc")
+                ? Sort.Direction.ASC
+                : Sort.Direction.DESC;
+        Sort sortObj = Sort.by(dir, parts[0]);
+        Pageable pageable = PageRequest.of(page, size, sortObj);
+
+        try {
+            Page<FridgeRecipeDto> result = service.searchByFridge(userId, pageable);
+            return ResponseEntity.ok(result);
+        } catch (CustomException ce) {
+            throw ce;
+        } catch (Exception e) {
+            throw new CustomException(
+                    ErrorCode.FRIDGE_RECIPE_SEARCH_ERROR,
+                    "냉장고 기반 레시피 조회 실패: " + e.getMessage()
+            );
+        }
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/opensearch/dto/FridgeRecipeDto.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/dto/FridgeRecipeDto.java
@@ -1,0 +1,38 @@
+package com.jdc.recipe_service.opensearch.dto;
+
+import com.jdc.recipe_service.domain.dto.recipe.RecipeSimpleDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "냉장고 기반 레시피 DTO (RecipeSimpleDto + 겹치는 재료)")
+public class FridgeRecipeDto extends RecipeSimpleDto {
+
+    @Schema(description = "내 냉장고 재료와 겹치는 재료 이름 리스트")
+    private List<String> matchedIngredients;
+
+    public FridgeRecipeDto(
+            RecipeSimpleDto simple,
+            List<String> matchedIngredients) {
+        super(
+                simple.getId(),
+                simple.getTitle(),
+                simple.getImageUrl(),
+                simple.getAuthorId(),
+                simple.getAuthorName(),
+                simple.getProfileImage(),
+                simple.getCreatedAt(),
+                simple.getLikeCount(),
+                simple.isLikedByCurrentUser(),
+                simple.getCookingTime(),
+                simple.getAvgRating(),
+                simple.getRatingCount()
+        );
+        this.matchedIngredients = matchedIngredients;
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/opensearch/dto/RecipeDocument.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/dto/RecipeDocument.java
@@ -14,12 +14,13 @@ import java.util.List;
 public class RecipeDocument {
     private Long id;
     private String title;
-    private String description;
-    private List<String> ingredients;
     private List<String> tags;
     private String dishType;
     private String createdAt;
     private int likeCount;
     private int cookingTime;
     private String imageUrl;
+    private Boolean  isAiGenerated;
+    private List<Long> ingredientIds;
+    private Integer ingredientCount;
 }

--- a/src/main/java/com/jdc/recipe_service/opensearch/service/FridgeRecipeSearchService.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/service/FridgeRecipeSearchService.java
@@ -1,0 +1,148 @@
+package com.jdc.recipe_service.opensearch.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jdc.recipe_service.domain.dto.recipe.RecipeSimpleDto;
+import com.jdc.recipe_service.domain.entity.Ingredient;
+import com.jdc.recipe_service.domain.entity.Recipe;
+import com.jdc.recipe_service.domain.repository.IngredientRepository;
+import com.jdc.recipe_service.domain.repository.RecipeLikeRepository;
+import com.jdc.recipe_service.domain.repository.RecipeRepository;
+import com.jdc.recipe_service.domain.repository.RefrigeratorItemRepository;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.opensearch.dto.FridgeRecipeDto;
+import com.jdc.recipe_service.opensearch.dto.RecipeDocument;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortOrder;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FridgeRecipeSearchService {
+
+    private static final String INDEX = "recipes";
+
+    private final RestHighLevelClient client;
+    private final ObjectMapper objectMapper;
+    private final RefrigeratorItemRepository fridgeRepo;
+    private final IngredientRepository ingredientRepo;
+    private final RecipeRepository recipeRepository;
+    private final RecipeLikeRepository recipeLikeRepository;
+
+    public Page<FridgeRecipeDto> searchByFridge(Long userId, Pageable pageable) {
+        List<Long> fridgeIds = fridgeRepo.findAllByUserId(userId).stream()
+                .map(fi -> fi.getIngredient().getId())
+                .collect(Collectors.toList());
+
+        SearchSourceBuilder ssb = new SearchSourceBuilder()
+                .from((int) pageable.getOffset())
+                .size(pageable.getPageSize());
+
+        if (fridgeIds.isEmpty()) {
+            ssb.query(QueryBuilders.matchAllQuery());
+        } else {
+            String json = "{\"terms_set\":{\"ingredientIds\":{"
+                    + "\"terms\":" + fridgeIds + ","
+                    + "\"minimum_should_match_field\":\"ingredientCount\""
+                    + "}}}";
+            ssb.query(QueryBuilders.wrapperQuery(json));
+        }
+
+        pageable.getSort().forEach(order ->
+                ssb.sort(order.getProperty(),
+                        order.isAscending() ? SortOrder.ASC : SortOrder.DESC)
+        );
+
+        SearchResponse resp;
+        try {
+            resp = client.search(new SearchRequest(INDEX).source(ssb), RequestOptions.DEFAULT);
+        } catch (IOException e) {
+            throw new CustomException(
+                    ErrorCode.FRIDGE_RECIPE_SEARCH_ERROR,
+                    "냉장고 기반 레시피 조회 실패: " + e.getMessage()
+            );
+        }
+
+        List<RecipeDocument> docs = Arrays.stream(resp.getHits().getHits())
+                .map(hit -> {
+                    try {
+                        return objectMapper.readValue(hit.getSourceAsString(), RecipeDocument.class);
+                    } catch (IOException ex) {
+                        throw new CustomException(
+                                ErrorCode.FRIDGE_RECIPE_SEARCH_ERROR,
+                                "검색 결과 문서 파싱 실패: " + ex.getMessage()
+                        );
+                    }
+                })
+                .collect(Collectors.toList());
+
+        List<Long> recipeIds = docs.stream()
+                .map(RecipeDocument::getId)
+                .collect(Collectors.toList());
+
+        if (recipeIds.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+
+        Map<Long, Recipe> recipeMap = recipeRepository.findAllById(recipeIds).stream()
+                .collect(Collectors.toMap(Recipe::getId, r -> r));
+
+        Set<Long> likedSet = recipeLikeRepository
+                .findByUserIdAndRecipeIdIn(userId, recipeIds).stream()
+                .map(like -> like.getRecipe().getId())
+                .collect(Collectors.toSet());
+
+        Set<Long> allMatchedIngredientIds = docs.stream()
+                .flatMap(doc -> doc.getIngredientIds().stream())
+                .filter(fridgeIds::contains)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> ingredientNameMap = ingredientRepo.findAllById(allMatchedIngredientIds).stream()
+                .collect(Collectors.toMap(Ingredient::getId, Ingredient::getName));
+
+
+        List<FridgeRecipeDto> content = new ArrayList<>();
+        for (RecipeDocument doc : docs) {
+            long likeCount = doc.getLikeCount();
+
+            Recipe r = recipeMap.get(doc.getId());
+            RecipeSimpleDto simple = new RecipeSimpleDto(
+                    doc.getId(),
+                    doc.getTitle(),
+                    doc.getImageUrl(),
+                    r != null ? r.getUser().getId() : null,
+                    r != null ? r.getUser().getNickname() : null,
+                    r != null ? r.getUser().getProfileImage() : null,
+                    LocalDateTime.parse(doc.getCreatedAt()),
+                    likeCount,
+                    likedSet.contains(doc.getId()),
+                    doc.getCookingTime(),
+                    r != null && r.getAvgRating() != null ? r.getAvgRating() : BigDecimal.ZERO,
+                    r != null ? Optional.ofNullable(r.getRatingCount()).orElse(0L) : 0L
+            );
+
+            List<String> matched = doc.getIngredientIds().stream()
+                    .filter(fridgeIds::contains)
+                    .map(ingredientNameMap::get)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+
+            content.add(new FridgeRecipeDto(simple, matched));
+        }
+        long total = resp.getHits().getTotalHits().value;
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/opensearch/service/RecipeIndexingService.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/service/RecipeIndexingService.java
@@ -126,6 +126,7 @@ public class RecipeIndexingService {
                     "ingredientCount":{ "type": "integer" }
                   }
                 }
+                """, XContentType.JSON);
 
         try {
             CreateIndexResponse res = client.indices().create(request, RequestOptions.DEFAULT);


### PR DESCRIPTION
### 기능
사용자의 냉장고에 담긴 재료로 만들 수 있는 레시피를 OpenSearch에서 빠르게 조회할 수 있는 기능 추가

### 변경 사항
1. **인덱스 매핑 & 색인 서비스**  
   - RecipeDocument/RecipeIndexingService에서 불필요한 description 필드 완전 제거  
   - 냉장고 리포지토리에 `findAllByUserId` 메서드 추가  

2. **냉장고 기반 레시피 조회 기능**  
   - FridgeRecipeDto: RecipeSimpleDto 상속 + 겹치는 재료 리스트 필드  
   - FridgeRecipeSearchService:  
     - 사용자 재료 `terms_set` 쿼리로 완전 매치  
     - 교집합 재료 이름을 1회 DB 조회로 매핑  
   - FridgeRecipeController:  
     - `GET /api/me/fridge/recipes` 엔드포인트  
     - 페이징·정렬, JWT 인증 적용  

3. **보안 & 예외 처리**  
   - SecurityConfig에 신규 엔드포인트 허용  
   - ErrorCode에 `FRIDGE_RECIPE_SEARCH_ERROR` 추가, 컨트롤러에서 예외 처리  