### PR TITLE
Feature/notifications and mobile auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	implementation 'mysql:mysql-connector-java:8.0.33'
@@ -48,6 +49,10 @@ dependencies {
 
 	//ouath2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	//OAuth2 Resource Server
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-jose'
 
 	//jjwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/jdc/recipe_service/config/CustomJwtAuthenticationConverter.java
+++ b/src/main/java/com/jdc/recipe_service/config/CustomJwtAuthenticationConverter.java
@@ -1,0 +1,37 @@
+package com.jdc.recipe_service.config;
+
+import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.repository.UserRepository;
+import com.jdc.recipe_service.security.CustomUserDetails;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+
+import java.util.Collection;
+
+public class CustomJwtAuthenticationConverter
+        implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    private final UserRepository userRepository;
+    private final JwtGrantedAuthoritiesConverter authoritiesConverter;
+
+    public CustomJwtAuthenticationConverter(UserRepository userRepository) {
+        this.userRepository = userRepository;
+        this.authoritiesConverter = new JwtGrantedAuthoritiesConverter();
+        this.authoritiesConverter.setAuthorityPrefix("ROLE_");
+    }
+
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+        Collection<GrantedAuthority> authorities = authoritiesConverter.convert(jwt);
+        Long userId = Long.valueOf(jwt.getSubject());
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found: " + userId));
+        CustomUserDetails principal = new CustomUserDetails(user);
+
+        return new UsernamePasswordAuthenticationToken(principal, jwt, authorities);
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/config/JwtConverterConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/JwtConverterConfig.java
@@ -1,0 +1,23 @@
+package com.jdc.recipe_service.config;
+
+import com.jdc.recipe_service.domain.repository.UserRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+@Configuration
+public class JwtConverterConfig {
+
+    private final UserRepository userRepository;
+
+    public JwtConverterConfig(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Bean
+    public Converter<Jwt, AbstractAuthenticationToken> jwtAuthenticationConverter() {
+        return new CustomJwtAuthenticationConverter(userRepository);
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.jdc.recipe_service.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/queue", "/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+        registry.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/notifications")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/controller/NotificationController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/NotificationController.java
@@ -1,0 +1,38 @@
+package com.jdc.recipe_service.controller;
+
+import com.jdc.recipe_service.domain.dto.notification.NotificationDto;
+import com.jdc.recipe_service.security.CustomUserDetails;
+import com.jdc.recipe_service.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService service;
+
+    @GetMapping
+    public List<NotificationDto> getAll(@AuthenticationPrincipal CustomUserDetails user) {
+        return service.getNotifications(user.getId());
+    }
+
+    @PostMapping("/read-all")
+    public ResponseEntity<Void> markAllRead(@AuthenticationPrincipal CustomUserDetails user) {
+        service.markAllAsRead(user.getId());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        service.deleteNotification(id, user.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/controller/NotificationPreferenceController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/NotificationPreferenceController.java
@@ -1,0 +1,44 @@
+package com.jdc.recipe_service.controller;
+
+import com.jdc.recipe_service.domain.dto.notification.UserNotificationPreferenceDto;
+import com.jdc.recipe_service.domain.type.NotificationType;
+import com.jdc.recipe_service.security.CustomUserDetails;
+import com.jdc.recipe_service.service.NotificationPreferenceService;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notification-preferences")
+@RequiredArgsConstructor
+public class NotificationPreferenceController {
+    private final NotificationPreferenceService prefService;
+
+    @GetMapping
+    public List<UserNotificationPreferenceDto> getPreferences(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        return prefService.findByUserId(user.getId());
+    }
+
+    @PatchMapping("/{type}")
+    public ResponseEntity<UserNotificationPreferenceDto> update(
+            @PathVariable NotificationType type,
+            @RequestBody PreferenceDto dto,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        var pref = prefService.updatePreference(
+                user.getId(), type, dto.isEnabled());
+        return ResponseEntity.ok(UserNotificationPreferenceDto.of(pref));
+    }
+
+    @Getter
+    @Setter
+    public static class PreferenceDto {
+        private boolean enabled;
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/notification/NotificationCreateDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/notification/NotificationCreateDto.java
@@ -1,0 +1,19 @@
+package com.jdc.recipe_service.domain.dto.notification;
+
+import com.jdc.recipe_service.domain.type.NotificationType;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationCreateDto {
+    private Long userId;
+    private Long actorId;
+    private NotificationType type;
+    private String content;
+    private String relatedType;
+    private Long relatedId;
+    private String relatedUrl;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/notification/NotificationDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/notification/NotificationDto.java
@@ -1,0 +1,41 @@
+package com.jdc.recipe_service.domain.dto.notification;
+
+import com.jdc.recipe_service.domain.entity.Notification;
+import com.jdc.recipe_service.domain.type.NotificationType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationDto {
+    private Long id;
+    private Long userId;
+    private Long actorId;
+    private NotificationType type;
+    private String content;
+    private String relatedType;
+    private Long relatedId;
+    private String relatedUrl;
+    private boolean isRead;
+    private LocalDateTime createdAt;
+
+    public static NotificationDto fromEntity(Notification n) {
+        return NotificationDto.builder()
+                .id(n.getId())
+                .userId(n.getUser().getId())
+                .actorId(n.getActor() != null ? n.getActor().getId() : null)
+                .type(n.getType())
+                .content(n.getContent())
+                .relatedType(n.getRelatedType())
+                .relatedId(n.getRelatedId())
+                .relatedUrl(n.getRelatedUrl())
+                .isRead(n.getIsRead())
+                .createdAt(n.getCreatedAt())
+                .build();
+    }
+}
+

--- a/src/main/java/com/jdc/recipe_service/domain/dto/notification/UserNotificationPreferenceDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/notification/UserNotificationPreferenceDto.java
@@ -1,0 +1,22 @@
+package com.jdc.recipe_service.domain.dto.notification;
+
+import com.jdc.recipe_service.domain.entity.UserNotificationPreference;
+import com.jdc.recipe_service.domain.type.NotificationType;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserNotificationPreferenceDto {
+    private NotificationType notificationType;
+    private boolean enabled;
+
+    public static UserNotificationPreferenceDto of(UserNotificationPreference pref) {
+        return UserNotificationPreferenceDto.builder()
+                .notificationType(pref.getNotificationType())
+                .enabled(pref.getEnabled())
+                .build();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/entity/Notification.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/Notification.java
@@ -1,0 +1,60 @@
+package com.jdc.recipe_service.domain.entity;
+
+import com.jdc.recipe_service.domain.entity.common.BaseTimeEntity;
+import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.type.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "notifications",
+        indexes = @Index(name = "idx_notifications_query", columnList = "user_id,is_read,created_at")
+)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_notification_user"))
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_id", foreignKey = @ForeignKey(name = "fk_notification_actor"))
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private User actor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 32, nullable = false)
+    private NotificationType type;
+
+    @Column(length = 255, nullable = false)
+    private String content;
+
+    @Column(name = "related_type", length = 32)
+    private String relatedType;
+
+    @Column(name = "related_id")
+    private Long relatedId;
+
+    @Column(name = "related_url", length = 255)
+    private String relatedUrl;
+
+    @Column(name = "is_read", nullable = false)
+    @Builder.Default
+    private Boolean isRead = false;
+
+    private LocalDateTime readAt;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/entity/UserNotificationPreference.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/UserNotificationPreference.java
@@ -1,0 +1,44 @@
+package com.jdc.recipe_service.domain.entity;
+
+import com.jdc.recipe_service.domain.entity.common.BaseTimeEntity;
+import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.type.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Table(
+        name = "user_notification_preferences",
+        uniqueConstraints = @UniqueConstraint(name = "ux_user_type", columnNames = {"user_id", "notification_type"})
+)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserNotificationPreference extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_pref_user"))
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+            name = "notification_type",
+            length = 32,
+            nullable = false
+    )
+    private NotificationType notificationType;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean enabled = true;
+}
+

--- a/src/main/java/com/jdc/recipe_service/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.jdc.recipe_service.domain.repository;
+
+import com.jdc.recipe_service.domain.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
+    List<Notification> findByUserIdAndIsReadFalse(Long userId);
+}

--- a/src/main/java/com/jdc/recipe_service/domain/repository/UserNotificationPreferenceRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/UserNotificationPreferenceRepository.java
@@ -1,0 +1,19 @@
+package com.jdc.recipe_service.domain.repository;
+
+import com.jdc.recipe_service.domain.entity.UserNotificationPreference;
+import com.jdc.recipe_service.domain.type.NotificationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserNotificationPreferenceRepository
+        extends JpaRepository<UserNotificationPreference, Long> {
+
+    Optional<UserNotificationPreference>
+    findByUserIdAndNotificationType(Long userId, NotificationType type);
+
+    List<UserNotificationPreference>
+    findByUserId(Long userId);
+}
+

--- a/src/main/java/com/jdc/recipe_service/domain/type/NotificationType.java
+++ b/src/main/java/com/jdc/recipe_service/domain/type/NotificationType.java
@@ -1,0 +1,8 @@
+package com.jdc.recipe_service.domain.type;
+
+public enum NotificationType {
+    NEW_COMMENT,
+    NEW_REPLY,
+    AI_RECIPE_DONE,
+    NEW_FAVORITE,
+}

--- a/src/main/java/com/jdc/recipe_service/security/CustomUserDetails.java
+++ b/src/main/java/com/jdc/recipe_service/security/CustomUserDetails.java
@@ -20,6 +20,10 @@ public class CustomUserDetails implements UserDetails {
         return user;
     }
 
+    public Long getId() {
+        return user.getId();
+    }
+
     @Override
     public String getUsername() {
         return String.valueOf(user.getId()); // 또는 user.getEmail()

--- a/src/main/java/com/jdc/recipe_service/service/NotificationPreferenceService.java
+++ b/src/main/java/com/jdc/recipe_service/service/NotificationPreferenceService.java
@@ -1,0 +1,40 @@
+package com.jdc.recipe_service.service;
+
+import com.jdc.recipe_service.domain.dto.notification.UserNotificationPreferenceDto;
+import com.jdc.recipe_service.domain.entity.UserNotificationPreference;
+import com.jdc.recipe_service.domain.repository.UserNotificationPreferenceRepository;
+import com.jdc.recipe_service.domain.repository.UserRepository;
+import com.jdc.recipe_service.domain.type.NotificationType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationPreferenceService {
+    private final UserNotificationPreferenceRepository prefRepo;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserNotificationPreference updatePreference(Long userId, NotificationType type, boolean enabled) {
+        return prefRepo.findByUserIdAndNotificationType(userId, type)
+                .map(pref -> { pref.setEnabled(enabled); return pref; })
+                .orElseGet(() -> prefRepo.save(
+                        UserNotificationPreference.builder()
+                                .user(userRepository.getReferenceById(userId))
+                                .notificationType(type)
+                                .enabled(enabled)
+                                .build()
+                ));
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserNotificationPreferenceDto> findByUserId(Long userId) {
+        return prefRepo.findByUserId(userId).stream()
+                .map(UserNotificationPreferenceDto::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/service/NotificationService.java
+++ b/src/main/java/com/jdc/recipe_service/service/NotificationService.java
@@ -1,0 +1,89 @@
+package com.jdc.recipe_service.service;
+
+import com.jdc.recipe_service.domain.dto.notification.NotificationCreateDto;
+import com.jdc.recipe_service.domain.dto.notification.NotificationDto;
+import com.jdc.recipe_service.domain.entity.Notification;
+import com.jdc.recipe_service.domain.entity.UserNotificationPreference;
+import com.jdc.recipe_service.domain.repository.NotificationRepository;
+import com.jdc.recipe_service.domain.repository.UserNotificationPreferenceRepository;
+import com.jdc.recipe_service.domain.repository.UserRepository;
+import com.jdc.recipe_service.domain.type.NotificationType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepo;
+    private final UserNotificationPreferenceRepository prefRepo;
+    private final UserRepository userRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Transactional
+    public void createNotification(NotificationCreateDto dto) {
+        NotificationType type = dto.getType();
+
+        UserNotificationPreference pref = prefRepo
+                .findByUserIdAndNotificationType(dto.getUserId(), type)
+                .orElseGet(() -> prefRepo.save(
+                        UserNotificationPreference.builder()
+                                .user(userRepository.getReferenceById(dto.getUserId()))
+                                .notificationType(type)
+                                .enabled(true)
+                                .build()
+                ));
+        if (!pref.getEnabled()) return;
+
+        var userProxy = userRepository.getReferenceById(dto.getUserId());
+        var actorProxy = dto.getActorId() != null
+                ? userRepository.getReferenceById(dto.getActorId())
+                : null;
+
+        Notification n = Notification.builder()
+                .user(userProxy)
+                .actor(actorProxy)
+                .type(type)
+                .content(dto.getContent())
+                .relatedType(dto.getRelatedType())
+                .relatedId(dto.getRelatedId())
+                .relatedUrl(dto.getRelatedUrl())
+                .build();
+        notificationRepo.save(n);
+
+        messagingTemplate.convertAndSendToUser(
+                String.valueOf(userProxy.getId()),
+                "/queue/notifications",
+                NotificationDto.fromEntity(n)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationDto> getNotifications(Long userId) {
+        return notificationRepo.findByUserIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(NotificationDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void markAllAsRead(Long userId) {
+        var unread = notificationRepo.findByUserIdAndIsReadFalse(userId);
+        unread.forEach(n -> n.setIsRead(true));
+        notificationRepo.saveAll(unread);
+    }
+
+    @Transactional
+    public void deleteNotification(Long id, Long userId) {
+        Notification n = notificationRepo.findById(id)
+                .orElseThrow(() -> new RuntimeException("알림이 존재하지 않습니다."));
+        if (!n.getUser().getId().equals(userId)) {
+            throw new RuntimeException("권한이 없습니다.");
+        }
+        notificationRepo.delete(n);
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -51,7 +51,9 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
-
+      resourceserver:
+        jwt:
+          issuer-uri: https://accounts.google.com
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
# Feature/notifications and mobile auth

# 요약
- 알림(Notifications) 모듈 전반 구현  
- OAuth2 리소스 서버 설정 및 커스텀 JWT 컨버터 추가  

# 1. 알림 기능(Notification)
- 데이터 모델  
  - `NotificationType` enum: NEW_COMMENT, NEW_REPLY, AI_RECIPE_DONE, NEW_FAVORITE  
  - `Notification` 엔티티: enum 매핑(@Enumerated), `@OnDelete` 설정  
  - `UserNotificationPreference` 엔티티: enum 매핑, 유니크 제약, `@OnDelete`  
- 영속성 계층  
  - `NotificationRepository`  
    - findByUserIdOrderByCreatedAtDesc(Long userId)  
    - findByUserIdAndIsReadFalse(Long userId)  
  - `UserNotificationPreferenceRepository`  
    - findByUserIdAndNotificationType(Long, NotificationType)  
    - findByUserId(Long userId)  
- DTO  
  - `NotificationCreateDto`, `NotificationDto` (fromEntity 메서드)  
  - `UserNotificationPreferenceDto` (of 팩토리 메서드)  
- 서비스  
  - `NotificationService`: create, getAll, markAllAsRead, delete (JPA 프록시, 빌더, WebSocket 푸시)  
  - `NotificationPreferenceService`: updatePreference, findByUserId  
- REST API  
  - `/api/notifications`  
    - GET  /api/notifications  
    - POST /api/notifications/read-all  
    - DELETE /api/notifications/{id}  
  - `/api/notification-preferences`  
    - GET   /api/notification-preferences  
    - PATCH /api/notification-preferences/{type}  
- 실시간 푸시  
  - `WebSocketConfig`: STOMP `/ws/notifications`, 브로커 `/queue`, `/topic`, 사용자 Dest `/user`  
  - 서버→클라이언트: messagingTemplate.convertAndSendToUser(userId, "/queue/notifications", dto)  
- 보안  
  - `SecurityConfig`:  
    - WebSocket 핸드쉐이크(`/ws/notifications/**`), STOMP(`/app/**`, `/user/**`, `/queue/**`, `/topic/**`) 모두 인증  
    - 알림 REST(`/api/notifications/**`, `/api/notification-preferences/**`) 모든 메서드 인증  
    - CORS preflight(OPTIONS) 예외  

# 2. OAuth2 리소스 서버 & 커스텀 JWT 컨버터
- 의존성 추가  
  - spring-boot-starter-oauth2-resource-server  
  - spring-boot-starter-oauth2-jose  
- CustomJwtAuthenticationConverter  
  - JWT sub 클레임 → User.id 매핑, CustomUserDetails 생성  
- JwtConverterConfig  
  - Converter<Jwt, AbstractAuthenticationToken> 빈 등록  
- SecurityConfig 변경  
  - oauth2ResourceServer().jwt(jwt -> jwt.jwtAuthenticationConverter(...))  
- application-*.yml 설정  
  ```yaml
  spring:
    security:
      oauth2:
        resourceserver:
          jwt:
            issuer-uri: https://accounts.google.com
