### PR TITLE
hotfix(recipe-search-service): 칼로리 null 처리 및 총 칼로리 소수점 둘째 자리 버림 적용

### DIFF
--- a/src/main/java/com/jdc/recipe_service/service/RecipeSearchService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeSearchService.java
@@ -36,6 +36,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -261,10 +263,13 @@ public class RecipeSearchService {
                 recipeIngredientRepository.findByRecipeId(recipeId)
         );
 
-        // 총 칼로리 계산 (각 재료 DTO의 calories 필드를 합산)
-        double totalCalories = ingredients.stream()
-                .mapToDouble(RecipeIngredientDto::getCalories)
+        double rawTotal = ingredients.stream()
+                .mapToDouble(i -> i.getCalories() != null ? i.getCalories() : 0.0)
                 .sum();
+        double totalCalories = BigDecimal
+                .valueOf(rawTotal)
+                .setScale(2, RoundingMode.DOWN)
+                .doubleValue();
 
         List<RecipeStepDto> steps = recipeStepRepository
                 .findWithIngredientsByRecipeIdOrderByStepNumber(recipeId)
@@ -307,7 +312,7 @@ public class RecipeSearchService {
                 .favoriteByCurrentUser(favoritedByUser)
                 .tags(tagNames)
                 .ingredients(ingredients)
-                .totalCalories(totalCalories)    // ← 총 칼로리 필드 세팅
+                .totalCalories(totalCalories)
                 .steps(steps)
                 .comments(comments)
                 .commentCount(commentCount)


### PR DESCRIPTION
### 변경 배경
- 특정 레시피 조회 시 `ingredients.mapToDouble(RecipeIngredientDto::getCalories).sum()` 구문에서
  `getCalories()`가 null인 경우 NPE가 발생했습니다.
- 또한, 총 칼로리(totalCalories)는 소수점 둘째 자리까지 버림(truncate) 처리해야 합니다.

### 주요 변경 사항
1. `.mapToDouble(i -> i.getCalories() != null ? i.getCalories() : 0.0)` 로 null 안전 처리  
2. `BigDecimal.setScale(2, RoundingMode.DOWN)` 으로 총 칼로리 소수점 둘째 자리 버림 적용  

### 테스트
- null인 custom_calorie, master ingredient calorie 값 모두 정상 조회 확인  
- 소수점 셋째 자리 이상이 있는 레시피에서 총 칼로리가 둘째 자리까지 잘려서 반환되는 것 확인  

### 영향 범위
- `RecipeSearchService.getRecipeDetail()`  
- 반환 DTO인 `RecipeDetailDto.totalCalories`  

