### PR TITLE
feat(prompt): PromptBuilder에 DB 미등록 재료 가격·칼로리 enrichment 지시문 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/domain/repository/IngredientRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/IngredientRepository.java
@@ -5,10 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 
 @Repository
 public interface IngredientRepository
         extends JpaRepository<Ingredient, Long>,
         JpaSpecificationExecutor<Ingredient> {
 
+    List<Ingredient> findAllByNameIn(List<String> names);
 }

--- a/src/main/java/com/jdc/recipe_service/util/PromptBuilder.java
+++ b/src/main/java/com/jdc/recipe_service/util/PromptBuilder.java
@@ -2,20 +2,39 @@ package com.jdc.recipe_service.util;
 
 import com.jdc.recipe_service.domain.dto.recipe.AiRecipeRequestDto;
 import com.jdc.recipe_service.domain.type.RobotType;
+import com.jdc.recipe_service.domain.repository.IngredientRepository;
+import com.jdc.recipe_service.domain.entity.Ingredient;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
 public class PromptBuilder {
 
     private final UnitService unitService;
+    private final IngredientRepository ingredientRepo;
 
-    public PromptBuilder(UnitService unitService) {
+    public PromptBuilder(UnitService unitService,
+                         IngredientRepository ingredientRepo) {
         this.unitService = unitService;
+        this.ingredientRepo = ingredientRepo;
     }
 
     public String buildPrompt(AiRecipeRequestDto request, RobotType type) {
+        List<String> names = request.getIngredients();
+
+        List<String> known = ingredientRepo.findAllByNameIn(names)
+                .stream()
+                .map(Ingredient::getName)
+                .collect(Collectors.toList());
+
+        List<String> unknown = names.stream()
+                .filter(n -> !known.contains(n))
+                .collect(Collectors.toList());
+
+        String knownList = known.isEmpty() ? "없음" : String.join(", ", known);
+        String unknownList = unknown.isEmpty() ? "없음" : String.join(", ", unknown);
 
         String unitMapping = unitService.mappingAsString();
         String allowedUnits = unitService.unitsAsString();
@@ -23,7 +42,7 @@ public class PromptBuilder {
         String unitTable = String.format("""
                 다음 재료들은 반드시 기본 단위로 작성해야 합니다:
                 {%s}
-                
+
                 ※ 'unit' 필드는 위 매핑에서 지정된 단위 외에는 절대 사용 불가합니다.
                 """, unitMapping);
 
@@ -37,7 +56,7 @@ public class PromptBuilder {
                   "servings": 2.0,
                   "ingredients": [
                      { "name": "돼지고기", "quantity": "150", "unit": "g" },
-                     { "name": "신김치",   "quantity": "200", "unit": "g" },
+                     { "name": "신김치",   "quantity": "200", "unit": "g", "customPrice": 300, "caloriesPerUnit": 15 },
                      { "name": "김치국물", "quantity": "0.5", "unit": "컵" },
                      { "name": "두부",     "quantity": "0.5", "unit": "모" },
                      { "name": "대파",     "quantity": "0.5", "unit": "대" },
@@ -123,17 +142,20 @@ public class PromptBuilder {
 
         return String.format("""
                         %s
+                        **DB에 이미 있는 재료**: [%s]
+                        **DB에 없는 재료**: [%s]
+
                         **오직 단 하나의 JSON 객체 형태로만 출력하세요. 다른 텍스트나 설명은 일절 허용되지 않습니다.**
-                        
+
                         **아래 규칙을 반드시 준수하여, 맛의 깊이와 요리 원리를 고려한 최상의 레시피를 생성하세요.**
-                        
+
                         **[요리 원리 규칙]**
                         1. **(핵심)** 찌개·볶음·조림 요리에서는 기름에 주재료나 향신채(마늘·파 등)를 먼저 볶아 풍미의 기초를 다지는 과정을 최우선으로 고려하세요.
                         2. 효율적이고 논리적인 순서로 단계를 구성하세요. (예: 모든 재료 손질 후 조리 시작)
                         3. 요청에 없더라도 필수 보조 재료(기름·맛술·설탕 등)를 자유롭게 추가하고 'ingredients'에 포함시키세요.
                         4. **예시 JSON은 2인분 기준이며, 각 재료의 quantity는 “예시 양 × (요청 인분 수 ÷ 2)” 공식을 적용해 비례 조정할 것.**
                         5. **알레르기 및 식이 제한(예: 견과류 알레르기 시 견과류 완전 배제, 락토-오보 식단 시 버터 대신 들기름 사용) 에 맞춰 부적합 재료는 반드시 제외하거나 대체 재료로 변경하세요.**
-                        
+
                         **[출력 형식 규칙]**
                         1) 요청한 "dishType"(%s)을 절대로 수정·누락하지 말 것.
                         2) 요청한 "tagNames" 배열 %s의 순서를 절대로 수정·누락하지 말 것.
@@ -154,12 +176,17 @@ public class PromptBuilder {
                         9) "instruction" 필드에는 반드시 “불 세기”, “시간”, “시각적 힌트”를 포함하세요.
                            예: “중불에서 3분간 볶아 재료의 겉면이 노릇해질 때까지 충분히 익힙니다.”
                         10) 각 단계의 instruction 끝에 도움이 되는 부가 팁을 한 문장으로 덧붙이세요. 예시: “...닭고기를 노릇하게 익힌 뒤 불을 끄고 1분간 그대로 두면 육즙이 더욱 살아납니다.”
-                        
-                        
+
+                        **[재료 필드 확장]**
+                        11) DB에 없는 재료에 대해서만 아래 두 필드를 포함하세요:
+                           - `customPrice`: 100g당 가격(원 단위, 정수)
+                           - `caloriesPerUnit`: 100g당 칼로리(kcal 단위, 정수)
+                        12) DB에 있는 재료는 `customPrice`, `caloriesPerUnit` 필드를 절대 포함하지 마세요.
+
                         --- 예시 JSON (이 구조와 요리 원리를 참고하여 생성) ---
                         %s
                         --- 예시 끝 ---
-                        
+
                         요청 조건:
                         - 요리 유형: %s
                         %s
@@ -167,10 +194,12 @@ public class PromptBuilder {
                         %s
                         - 주요 재료: %s
                         - 태그: %s
-                        
+
                         출력 형식: JSON 객체 하나만
                         """,
                 unitTable,
+                knownList,
+                unknownList,
                 persona,
                 request.getDishType(),
                 tags,


### PR DESCRIPTION
## 배경
AI 레시피 생성 시 DB에 없는 재료에만 100g당 가격(customPrice)과 칼로리(caloriesPerUnit)를
GPT가 내려줄 수 있도록 프롬프트를 개선해야 합니다.

## 변경 사항
1. `IngredientRepository`에 findAllByNameIn, findByName 메서드 추가  
2. `PromptBuilder` 생성자에 `IngredientRepository` 주입  
3. buildPrompt() 내부에서
   - 요청된 재료를 DB에 있는(known) / 없는(unknown) 목록으로 분리
   - 프롬프트 상단에 `DB에 이미 있는 재료`, `DB에 없는 재료` 명시
   - `[재료 필드 확장]` 섹션에 “DB에 없는 재료에만 customPrice·caloriesPerUnit 포함, DB에 있는 재료는 제외” 지시문 추가
   - few-shot 예시에서 신김치 항목에만 customPrice·caloriesPerUnit 예시 적용

