### PR TITLE
feat(notification): 댓글·대댓글·좋아요·AI 레시피 완료 알림 트리거 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/domain/dto/notification/NotificationCreateDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/notification/NotificationCreateDto.java
@@ -1,5 +1,6 @@
 package com.jdc.recipe_service.domain.dto.notification;
 
+import com.jdc.recipe_service.domain.type.NotificationRelatedType;
 import com.jdc.recipe_service.domain.type.NotificationType;
 import lombok.*;
 
@@ -13,7 +14,7 @@ public class NotificationCreateDto {
     private Long actorId;
     private NotificationType type;
     private String content;
-    private String relatedType;
+    private NotificationRelatedType relatedType;
     private Long relatedId;
     private String relatedUrl;
 }

--- a/src/main/java/com/jdc/recipe_service/domain/dto/notification/NotificationDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/notification/NotificationDto.java
@@ -1,6 +1,7 @@
 package com.jdc.recipe_service.domain.dto.notification;
 
 import com.jdc.recipe_service.domain.entity.Notification;
+import com.jdc.recipe_service.domain.type.NotificationRelatedType;
 import com.jdc.recipe_service.domain.type.NotificationType;
 import lombok.*;
 
@@ -17,7 +18,7 @@ public class NotificationDto {
     private Long actorId;
     private NotificationType type;
     private String content;
-    private String relatedType;
+    private NotificationRelatedType relatedType;
     private Long relatedId;
     private String relatedUrl;
     private boolean isRead;

--- a/src/main/java/com/jdc/recipe_service/domain/entity/Notification.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/Notification.java
@@ -2,6 +2,7 @@ package com.jdc.recipe_service.domain.entity;
 
 import com.jdc.recipe_service.domain.entity.common.BaseTimeEntity;
 import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.type.NotificationRelatedType;
 import com.jdc.recipe_service.domain.type.NotificationType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -43,8 +44,9 @@ public class Notification extends BaseTimeEntity {
     @Column(length = 255, nullable = false)
     private String content;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "related_type", length = 32)
-    private String relatedType;
+    private NotificationRelatedType relatedType;
 
     @Column(name = "related_id")
     private Long relatedId;

--- a/src/main/java/com/jdc/recipe_service/domain/type/NotificationRelatedType.java
+++ b/src/main/java/com/jdc/recipe_service/domain/type/NotificationRelatedType.java
@@ -1,0 +1,6 @@
+package com.jdc.recipe_service.domain.type;
+
+public enum NotificationRelatedType {
+    RECIPE,
+    COMMENT
+}

--- a/src/main/java/com/jdc/recipe_service/domain/type/NotificationType.java
+++ b/src/main/java/com/jdc/recipe_service/domain/type/NotificationType.java
@@ -5,4 +5,6 @@ public enum NotificationType {
     NEW_REPLY,
     AI_RECIPE_DONE,
     NEW_FAVORITE,
+    NEW_RECIPE_LIKE,
+    NEW_COMMENT_LIKE
 }


### PR DESCRIPTION
## 요약
댓글, 대댓글, 레시피 좋아요, AI 레시피 생성 완료 이벤트에 대해 실시간 알림을 전송하도록 로직을 삽입합니다.

## 주요 변경사항
- **CommentService**  
  - `createComment` → `NotificationType.NEW_COMMENT` 알림 전송  
  - `createReply`   → `NotificationType.NEW_REPLY` 알림 전송  
- **RecipeLikeService**  
  - `toggleLike`   → `NotificationType.NEW_RECIPE_LIKE` 알림 전송  
- **RecipeService (AI 레시피 생성 메서드)**  
  - `afterCommit()` 블록에서 `NotificationType.AI_RECIPE_DONE` 알림 전송  

## 테스트 계획
1. 댓글/대댓글 작성 시 `/user/queue/notifications` 구독 클라이언트에서 알림 수신 확인  
2. 레시피 좋아요 후 알림 수신 확인  
3. AI 레시피 생성 완료 후 알림 수신 확인  