### PR TITLE
config: 톰캣 native 헤더 처리 및 WebSocket 핸드셰이크용 ForwardedHeaderFilter 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/WebConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/WebConfig.java
@@ -1,7 +1,9 @@
 package com.jdc.recipe_service.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -21,5 +23,14 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
         configurer.setDefaultTimeout(600_000);
+    }
+
+    /**
+     * X-Forwarded-* 헤더를 HttpServletRequest에 반영해 줍니다.
+     * 톰캣 native 모드 RemoteIpValve 설정을 적용하려면 반드시 필요합니다.
+     */
+    @Bean
+    public ForwardedHeaderFilter forwardedHeaderFilter() {
+        return new ForwardedHeaderFilter();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,15 +6,22 @@ spring:
       request-timeout: 600000   # 10분 (밀리초)
 
 server:
-  forward-headers-strategy: framework
+  forward-headers-strategy: native
+
+  # ▶ 내장 톰캣 RemoteIpValve 설정
+  tomcat:
+    # 프록시가 전달하는 실제 클라이언트 IP 헤더
+    remote-ip-header: X-Forwarded-For
+    # 프록시가 전달하는 프로토콜 헤더 (http/https)
+    protocol-header: X-Forwarded-Proto
+    # 신뢰할 프록시 IP 범위 (정규식)
+    internal-proxies: 127\.0\.0\.1|192\.168\.0\.\d+
 
 springdoc:
   api-docs:
     enabled: true
-    # v3/api-docs/ 로 노출
     path: /v3/api-docs
   swagger-ui:
-    # UI가 여기서 스펙을 직접 읽어가도록
     url: /v3/api-docs
     path: /swagger-ui
 


### PR DESCRIPTION
## 변경 배경
- 프록시(ALB/Nginx) 뒤에서 넘어오는 X-Forwarded-* 헤더를
  HTTP 요청 뿐만 아니라 SockJS/WebSocket 핸드셰이크에도
  올바르게 반영하기 위해 설정을 조정

## 주요 변경사항
1. application.yml
   - `server.forward-headers-strategy` 를 `native` 로 변경  
   - 톰캣 RemoteIpValve 활성화를 위한 설정 추가
     - `tomcat.remote-ip-header: X-Forwarded-For`
     - `tomcat.protocol-header: X-Forwarded-Proto`
     - `tomcat.internal-proxies: 127\.0\.0\.1|192\.168\.0\.\d+`
2. `WebConfig` 클래스 수정
   - `ForwardedHeaderFilter` 빈 등록으로 Spring MVC 및
     SockJS 핸드셰이크에도 X-Forwarded 헤더 적용

## 확인 사항
- 애플리케이션 로그에서 RemoteIpValve 활성화 여부  
- 브라우저 Network 탭에서 `wss://…/ws/notifications` 로 연결되는지  
- 프록시 레벨(SSL/ALB/Nginx)에서 Upgrade 헤더가 통과되는지
