### PR TITLE
feat(security): STOMP CONNECT/HEARTBEAT/DISCONNECT 프레임 허용 설정 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/WebSocketSecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/WebSocketSecurityConfig.java
@@ -1,6 +1,7 @@
 package com.jdc.recipe_service.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.security.config.annotation.web.messaging.MessageSecurityMetadataSourceRegistry;
 import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
 import org.springframework.security.config.annotation.web.socket.EnableWebSocketSecurity;
@@ -11,6 +12,11 @@ public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBro
     @Override
     protected void configureInbound(MessageSecurityMetadataSourceRegistry messages) {
         messages
+                .simpTypeMatchers(
+                        SimpMessageType.CONNECT,
+                        SimpMessageType.HEARTBEAT,
+                        SimpMessageType.DISCONNECT
+                ).permitAll()
                 .simpSubscribeDestMatchers("/user/queue/**").authenticated()
                 .simpDestMatchers("/app/**").authenticated()
                 .anyMessage().denyAll();


### PR DESCRIPTION
 WebSocketSecurityConfig 에 simpTypeMatchers(CONNECT, HEARTBEAT, DISCONNECT).permitAll() 추가
- /user/queue/**, /app/** 구독·발행은 인증된 사용자만 허용