### PR TITLE
fix(websocket): 핸드쉐이크 핸들러 중복 등록 제거 및 PrincipalHandshakeHandler 적용

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/PrincipalHandshakeHandler.java
+++ b/src/main/java/com/jdc/recipe_service/config/PrincipalHandshakeHandler.java
@@ -1,0 +1,21 @@
+package com.jdc.recipe_service.config;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.lang.NonNull;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import java.security.Principal;
+import java.util.Map;
+
+public class PrincipalHandshakeHandler extends DefaultHandshakeHandler {
+    @Override
+    protected Principal determineUser(
+            @NonNull ServerHttpRequest request,
+            @NonNull WebSocketHandler wsHandler,
+            @NonNull Map<String, Object> attributes
+    ) {
+        Object principal = attributes.get("user");
+        return (principal instanceof Principal ? (Principal) principal : super.determineUser(request, wsHandler, attributes));
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
@@ -28,8 +28,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                         "http://localhost:5173",
                         "https://www.haemeok.com"
                 )
-                .setHandshakeHandler(new DefaultHandshakeHandler())
                 .addInterceptors(new JwtHandshakeInterceptor(jwtTokenProvider))
+                .setHandshakeHandler(new PrincipalHandshakeHandler())
                 .withSockJS();
     }
 }


### PR DESCRIPTION
- registry.addEndpoint() 에서 setHandshakeHandler 를 두 번 호출하던 부분 제거
- JwtHandshakeInterceptor 를 먼저 등록하고, 단일 PrincipalHandshakeHandler 로 인증된 Principal 설정
- 핸드쉐이크 단계에서 attributes 에 담긴 “user” 속성을 WebSocket Principal 로 연결