### PR TITLE
feat(websocket): STOMP CONNECT에 JWT 인증 추가 및 SUBSCRIBE/MESSAGE 보안 적용

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
@@ -3,11 +3,18 @@ package com.jdc.recipe_service.config;
 import com.jdc.recipe_service.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
-import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -24,13 +31,30 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/notifications")
-                .setAllowedOriginPatterns(
-                        "http://localhost:5173",
-                        "https://www.haemeok.com"
-                )
-                .addInterceptors(new JwtHandshakeInterceptor(jwtTokenProvider))
-                .setHandshakeHandler(new PrincipalHandshakeHandler())
-                .withSockJS()
-                .setInterceptors(new JwtHandshakeInterceptor(jwtTokenProvider));
+                .setAllowedOriginPatterns("http://localhost:5173", "https://www.haemeok.com")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor =
+                        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                    String bearer = accessor.getFirstNativeHeader("Authorization");
+                    if (bearer != null && bearer.startsWith("Bearer ")) {
+                        String token = bearer.substring(7);
+                        if (jwtTokenProvider.validateToken(token)) {
+                            Authentication auth = jwtTokenProvider.getAuthentication(token);
+                            accessor.setUser(auth);
+                        }
+                    }
+                }
+                return message;
+            }
+        });
     }
 }

--- a/src/main/java/com/jdc/recipe_service/config/WebSocketSecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/WebSocketSecurityConfig.java
@@ -15,8 +15,11 @@ public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBro
                 .simpTypeMatchers(
                         SimpMessageType.CONNECT,
                         SimpMessageType.HEARTBEAT,
+                        SimpMessageType.UNSUBSCRIBE,
                         SimpMessageType.DISCONNECT
                 ).permitAll()
+                .simpTypeMatchers(SimpMessageType.SUBSCRIBE, SimpMessageType.MESSAGE)
+                .authenticated()
                 .simpSubscribeDestMatchers("/user/queue/**").authenticated()
                 .simpDestMatchers("/app/**").authenticated()
                 .anyMessage().denyAll();

--- a/src/main/resources/static/test-ws.html
+++ b/src/main/resources/static/test-ws.html
@@ -48,11 +48,11 @@
             return;
         }
         log('Opening Web Socket...');
-        const socket = new SockJS('/ws/notifications?token=' + encodeURIComponent(token));
+        const socket = new SockJS('/ws/notifications');
         client = Stomp.over(socket);
 
         client.connect(
-            {},
+            {Authorization: 'Bearer ' + token},
             frame => {
                 log('✅ 연결 성공: ' + (frame.headers['user-name'] || 'unknown'));
                 client.subscribe('/user/queue/notifications', msg => {


### PR DESCRIPTION
## PR 개요
WebSocket(STOMP) 연결 과정에 JWT 기반 인증·인가를 적용해 메시지 레벨 보안을 강화

## 주요 변경사항
1. ChannelInterceptor 추가 (WebSocketConfig.configureClientInboundChannel)
   - CONNECT 프레임 헤더의 `Authorization: Bearer <JWT>` 를 파싱
   - JwtTokenProvider로 토큰 검증 후 Authentication을 `StompHeaderAccessor#setUser()`에 설정

2. 메시지 보안 설정 보완 (WebSocketSecurityConfig.configureInbound)
   - SUBSCRIBE 및 MESSAGE 타입의 STOMP 메시지에 인증 요구
   - CONNECT·HEARTBEAT·UNSUBSCRIBE·DISCONNECT만 permitAll

3. 테스트 페이지 수정 (test-ws.html)
   - `client.connect({ Authorization: 'Bearer '+token })` 로 JWT를 CONNECT 헤더에 포함