### PR TITLE
feat(websocket): 핸드쉐이크 단계에서 JWT 인증 적용 및 STOMP 메시지 보안 강화

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/jdc/recipe_service/config/JwtHandshakeInterceptor.java
@@ -2,48 +2,50 @@ package com.jdc.recipe_service.config;
 
 import com.jdc.recipe_service.jwt.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.lang.NonNull;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
 import java.util.Map;
 
+@Slf4j
+@RequiredArgsConstructor
 public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 
     private final JwtTokenProvider tokenProvider;
 
-    public JwtHandshakeInterceptor(JwtTokenProvider tokenProvider) {
-        this.tokenProvider = tokenProvider;
-    }
-
     @Override
     public boolean beforeHandshake(@NonNull ServerHttpRequest request,
-                                   @NonNull org.springframework.http.server.ServerHttpResponse response,
+                                   @NonNull ServerHttpResponse response,
                                    @NonNull WebSocketHandler wsHandler,
-                                   @NonNull Map<String, Object> attributes) throws Exception {
-        if (!(request instanceof ServletServerHttpRequest servletRequest)) {
-            return true;
-        }
-        HttpServletRequest httpReq = servletRequest.getServletRequest();
-        String token = httpReq.getParameter("token");
-        if (token == null) {
-            String bearer = httpReq.getHeader("Authorization");
-            if (bearer != null && bearer.startsWith("Bearer ")) {
-                token = bearer.substring(7);
+                                   @NonNull Map<String, Object> attributes) {
+
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            HttpServletRequest httpRequest = servletRequest.getServletRequest();
+            String token = httpRequest.getParameter("token");
+            log.debug("Attempting handshake with token from query param: {}", token);
+
+            if (token != null && tokenProvider.validateToken(token)) {
+                Authentication auth = tokenProvider.getAuthentication(token);
+                attributes.put("user", auth);
+                log.info("Handshake successful for user: {}", auth.getName());
+                return true;
             }
         }
-        if (token != null && tokenProvider.validateToken(token)) {
-            var auth = tokenProvider.getAuthentication(token);
-            attributes.put("user", auth.getPrincipal());
-        }
-        return true;
+
+        log.warn("Handshake failed: Invalid or missing token.");
+        return false;
     }
 
     @Override
     public void afterHandshake(@NonNull ServerHttpRequest request,
-                               @NonNull org.springframework.http.server.ServerHttpResponse response,
+                               @NonNull ServerHttpResponse response,
                                @NonNull WebSocketHandler wsHandler,
                                Exception exception) {
     }

--- a/src/main/java/com/jdc/recipe_service/config/PrincipalHandshakeHandler.java
+++ b/src/main/java/com/jdc/recipe_service/config/PrincipalHandshakeHandler.java
@@ -2,6 +2,7 @@ package com.jdc.recipe_service.config;
 
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.lang.NonNull;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 
@@ -15,7 +16,10 @@ public class PrincipalHandshakeHandler extends DefaultHandshakeHandler {
             @NonNull WebSocketHandler wsHandler,
             @NonNull Map<String, Object> attributes
     ) {
-        Object principal = attributes.get("user");
-        return (principal instanceof Principal ? (Principal) principal : super.determineUser(request, wsHandler, attributes));
+        Object user = attributes.get("user");
+        if (user instanceof Authentication) {
+            return (Authentication) user;
+        }
+        return super.determineUser(request, wsHandler, attributes);
     }
 }

--- a/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
@@ -4,17 +4,7 @@ import com.jdc.recipe_service.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.messaging.simp.stomp.StompCommand;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
-import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.MessageHeaderAccessor;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.core.Authentication;
-import org.springframework.util.StringUtils;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -36,40 +26,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/notifications")
                 .setAllowedOriginPatterns("http://localhost:5173", "https://www.haemeok.com")
+                .addInterceptors(new JwtHandshakeInterceptor(jwtTokenProvider))
+                .setHandshakeHandler(new PrincipalHandshakeHandler())
                 .withSockJS();
-    }
-
-    @Override
-    public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(new ChannelInterceptor() {
-            @Override
-            public Message<?> preSend(Message<?> message, MessageChannel channel) {
-                StompHeaderAccessor accessor =
-                        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-
-                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
-                    log.debug("STOMP CONNECT attempt");
-
-                    String bearerToken = accessor.getFirstNativeHeader("Authorization");
-                    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-                        String token = bearerToken.substring(7);
-                        log.debug("Token found, attempting to authenticate.");
-
-                        if (jwtTokenProvider.validateToken(token)) {
-                            Authentication auth = jwtTokenProvider.getAuthentication(token);
-                            accessor.setUser(auth);
-                            log.info("STOMP user authenticated: {}", auth.getName());
-                        } else {
-                            log.warn("Invalid JWT token received.");
-                            throw new BadCredentialsException("Invalid token");
-                        }
-                    } else {
-                        log.warn("STOMP CONNECT without token.");
-                        throw new BadCredentialsException("Missing token");
-                    }
-                }
-                return message;
-            }
-        });
     }
 }

--- a/src/main/resources/static/test-ws.html
+++ b/src/main/resources/static/test-ws.html
@@ -48,13 +48,12 @@
             return;
         }
         log('Opening Web Socket...');
-        const socket = new SockJS('/ws/notifications');
+        const socket = new SockJS('/ws/notifications?token=' + token);
         client = Stomp.over(socket);
 
-        client.connect(
-            {Authorization: 'Bearer ' + token},
+        client.connect({},
             frame => {
-                log('✅ 연결 성공: ' + (frame.headers['user-name'] || 'unknown'));
+                log('✅ 연결 성공: ' + (frame.headers['user-name'] || '인증 성공'));
                 client.subscribe('/user/queue/notifications', msg => {
                     log('🔔 알림 수신: ' + msg.body);
                 });


### PR DESCRIPTION
 **개요**
WebSocket(STOMP) 의 CONNECT 핸드쉐이크 단계에서 JWT 인증·인가를 처리하고, STOMP 메시지 보안 설정 강화

**변경사항**
1. **WebSocketConfig.java**
   - `registerStompEndpoints()` 에 `JwtHandshakeInterceptor` 와 `PrincipalHandshakeHandler` 등록
   - 기존 `configureClientInboundChannel()` 제거

2. **JwtHandshakeInterceptor.java** (신규)
   - HTTP 핸드쉐이크 요청에서 쿼리파라미터 또는 Authorization 헤더로 받은 JWT 검증
   - 검증 통과 시 세션 속성(attributes)에 `Principal` 저장

3. **PrincipalHandshakeHandler.java** (신규)
   - 핸드쉐이크 시 `attributes.get("user")` 에 심긴 `Principal` 을 WebSocket 세션의 사용자로 설정

4. **WebSocketSecurityConfig.java**
   - `simpTypeMatchers(SUBSCRIBE, MESSAGE).authenticated()` 추가
   - CONNECT/HEARTBEAT/DISCONNECT/UNSUBSCRIBE 은 `permitAll()`

5. **test-ws.html** (가이드)
   - 더 이상 `?token=` 쿼리파라미터 불필요
   - `client.connect({ Authorization: 'Bearer <token>' }, …)` 로 STOMP CONNECT 헤더에 JWT 전달