### PR TITLE
feat(websocket): 메시징 보안 규칙 단순화로 연결 오류 해결

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/WebSocketSecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/WebSocketSecurityConfig.java
@@ -18,11 +18,7 @@ public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBro
                         SimpMessageType.UNSUBSCRIBE,
                         SimpMessageType.DISCONNECT
                 ).permitAll()
-                .simpTypeMatchers(SimpMessageType.SUBSCRIBE, SimpMessageType.MESSAGE)
-                .authenticated()
-                .simpSubscribeDestMatchers("/user/queue/**").authenticated()
-                .simpDestMatchers("/app/**").authenticated()
-                .anyMessage().denyAll();
+                .anyMessage().authenticated();
     }
     @Override protected boolean sameOriginDisabled() { return true; }
 }


### PR DESCRIPTION
- 핸드셰이크 인증 성공 후에도 STOMP 연결이 실패하는 문제를 해결하기 위해 WebSocketSecurityConfig의 인바운드 메시지 규칙을 단순화

- 기존의 복잡한 메시지 경로별 규칙 대신, 핸드셰이크를 통해 인증된 사용자는 모든 메시지 유형을 허용하도록 .anyMessage().authenticated()로 변경하여 문제를 해결.