### PR TITLE
feat(security):localhost 포트 3000 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -272,6 +272,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfig() {
         CorsConfiguration cfg = new CorsConfiguration();
         cfg.setAllowedOrigins(Arrays.asList(
+                "http://localhost:3000",
                 "http://localhost:5173",
                 "https://www.haemeok.com"
         ));

--- a/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
@@ -25,7 +25,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/notifications")
-                .setAllowedOriginPatterns("http://localhost:5173", "https://www.haemeok.com")
+                .setAllowedOriginPatterns("http://localhost:3000","http://localhost:5173", "https://www.haemeok.com")
                 .addInterceptors(new JwtHandshakeInterceptor(jwtTokenProvider))
                 .setHandshakeHandler(new PrincipalHandshakeHandler())
                 .withSockJS();

--- a/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.net.URI;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -69,8 +70,12 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
         String referer = request.getHeader("Referer");
 
         String redirectBase;
-        if (referer != null && referer.contains("localhost")) {
-            redirectBase = "http://localhost:5173";
+        if (referer != null && referer.startsWith("http://localhost")) {
+            URI uri = URI.create(referer);
+            redirectBase = uri.getScheme() + "://" + uri.getHost();
+            if (uri.getPort() != -1) {
+                redirectBase += ":" + uri.getPort();
+            }
         } else {
             redirectBase = "https://www.haemeok.com";
         }


### PR DESCRIPTION
- Referer 헤더에서 localhost 호스트와 포트를 파싱하도록 리다이렉트 로직 개선
  • java.net.URI를 사용해 scheme, host, port를 동적으로 추출  
  • 기존 하드코딩(5173) 대신, 개발환경에서 사용하는 모든 localhost 포트(3000, 5173 등) 자동 대응  
- 배포 환경에서는 기존대로 https://www.haemeok.com 으로 리다이렉트 유지  