### PR TITLE
feat(notification): AI 레시피 완료 알림 등록 간소화

### DIFF
--- a/src/main/java/com/jdc/recipe_service/service/RecipeService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeService.java
@@ -177,25 +177,18 @@ public class RecipeService {
         }
 
         if (sourceType == RecipeSourceType.AI) {
-            TransactionSynchronizationManager.registerSynchronization(
-                    new TransactionSynchronization() {
-                        @Override
-                        public void afterCommit() {
-                            asyncImageService.generateAndUploadAiImageAsync(recipe.getId());
+            asyncImageService.generateAndUploadAiImageAsync(recipe.getId());
 
-                            notificationService.createNotification(
-                                    NotificationCreateDto.builder()
-                                            .userId(recipe.getUser().getId())
-                                            .actorId(null)
-                                            .type(NotificationType.AI_RECIPE_DONE)
-                                            .content("AI 레시피 생성이 완료되었습니다.")
-                                            .relatedType(NotificationRelatedType.RECIPE)
-                                            .relatedId(recipe.getId())
-                                            .relatedUrl("/recipes/" + recipe.getId())
-                                            .build()
-                            );
-                        }
-                    }
+            notificationService.createNotification(
+                    NotificationCreateDto.builder()
+                            .userId(recipe.getUser().getId())
+                            .actorId(null)
+                            .type(NotificationType.AI_RECIPE_DONE)
+                            .content("AI 레시피 생성이 완료되었습니다.")
+                            .relatedType(NotificationRelatedType.RECIPE)
+                            .relatedId(recipe.getId())
+                            .relatedUrl("/recipes/" + recipe.getId())
+                            .build()
             );
         }
 


### PR DESCRIPTION
# 내용
- createUserRecipeAndGenerateUrls()에서 TransactionSynchronizationManager.registerSynchronization 블록 제거
- 같은 트랜잭션 내에서 asyncImageService 호출 직후 notificationService.createNotification(...) 직접 호출하도록 수정