### PR TITLE
feat(ai-recipe): AI 레시피 이벤트 발행 및 리스너 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/event/AiRecipeCreatedEvent.java
+++ b/src/main/java/com/jdc/recipe_service/event/AiRecipeCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.jdc.recipe_service.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class AiRecipeCreatedEvent {
+    private final Long recipeId;
+    private final Long userId;
+}

--- a/src/main/java/com/jdc/recipe_service/event/AiRecipeEventListener.java
+++ b/src/main/java/com/jdc/recipe_service/event/AiRecipeEventListener.java
@@ -1,0 +1,44 @@
+package com.jdc.recipe_service.event;
+
+import com.jdc.recipe_service.domain.dto.notification.NotificationCreateDto;
+import com.jdc.recipe_service.domain.type.NotificationRelatedType;
+import com.jdc.recipe_service.domain.type.NotificationType;
+import com.jdc.recipe_service.service.AsyncImageService;
+import com.jdc.recipe_service.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AiRecipeEventListener {
+    private final AsyncImageService asyncImageService;
+    private final NotificationService notificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onAiRecipeCreated(AiRecipeCreatedEvent event) {
+        asyncImageService.generateAndUploadAiImageAsync(event.getRecipeId())
+                .thenRun(() -> {
+                    notificationService.createNotification(
+                            NotificationCreateDto.builder()
+                                    .userId(event.getUserId())
+                                    .actorId(null)
+                                    .type(NotificationType.AI_RECIPE_DONE)
+                                    .content("AI 레시피 생성이 완료되었습니다.")
+                                    .relatedType(NotificationRelatedType.RECIPE)
+                                    .relatedId(event.getRecipeId())
+                                    .relatedUrl("/recipes/" + event.getRecipeId())
+                                    .build()
+                    );
+                })
+                .exceptionally(ex -> {
+                    log.error("AI 레시피 생성 후 알림 처리 실패", ex);
+                    return null;
+                });
+    }
+}


### PR DESCRIPTION
# AI 레시피 생성 이벤트 기반 이미지 처리 및 알림 구조 도입
1. **RecipeService**  
   - AI 레시피 생성 플로우에 `AiRecipeCreatedEvent` 발행 로직 추가  
   - 기존 `asyncImageService`·`notificationService` 직접 호출 제거  

2. **Event 정의**  
   - `AiRecipeCreatedEvent` 클래스 추가 (recipeId, userId 보관)  

3. **이벤트 리스너**  
   - `AiRecipeEventListener` 추가  
     - `@Async @TransactionalEventListener(AFTER_COMMIT)`  
     - 이벤트 수신 후 `AsyncImageService.generateAndUploadAiImageAsync` 실행  
     - 이미지 생성 완료 시 `NotificationService.createNotification` 호출  

4. **기대 효과**  
   - 레시피 저장 TX 커밋 직후 이벤트 기반으로 후속 작업 분리  
   - 트랜잭션 경계와 비동기 시점 명확화  
   - WebSocket 알림도 기존 `NotificationEventListener` 로 연동되어 자동 푸시  