### PR TITLE
chore(deploy): 쿠키 기반 토큰 인증 웹소켓 적용

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/jdc/recipe_service/config/JwtHandshakeInterceptor.java
@@ -1,6 +1,7 @@
 package com.jdc.recipe_service.config;
 
 import com.jdc.recipe_service.jwt.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +13,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
+import java.util.Arrays;
 import java.util.Map;
 
 @Slf4j
@@ -28,8 +30,15 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 
         if (request instanceof ServletServerHttpRequest servletRequest) {
             HttpServletRequest httpRequest = servletRequest.getServletRequest();
-            String token = httpRequest.getParameter("token");
-            log.debug("Attempting handshake with token from query param: {}", token);
+            String token = null;
+            if (httpRequest.getCookies() != null) {
+                token = Arrays.stream(httpRequest.getCookies())
+                        .filter(c -> "accessToken".equals(c.getName()))
+                        .map(Cookie::getValue)
+                        .findFirst()
+                        .orElse(null);
+            }
+            log.debug("Attempting handshake with token from cookie: {}", token);
 
             if (token != null && tokenProvider.validateToken(token)) {
                 Authentication auth = tokenProvider.getAuthentication(token);


### PR DESCRIPTION
- JwtHandshakeInterceptor.java
• beforeHandshake()에서 쿼리 파라미터(getParameter("token")) 대신 HTTP-쿠키의 accessToken을 읽도록 변경
• token 추출 로직: httpRequest.getCookies() → "accessToken" 필터링
• 로그 메시지 수정: "from query param" → "from cookie"
• 토큰 검증(validateToken) 및 인증 정보(getAuthentication) 저장 로직은 그대로 유지