### PR TITLE
feat(websocket): OAuth2 루트 리다이렉트

### DIFF
--- a/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -86,6 +86,6 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
             redirectBase = "https://www.haemeok.com";
         }
 
-        response.sendRedirect(redirectBase + "/oauth2/redirect");
+        response.sendRedirect(redirectBase);
     }
 }

--- a/src/main/resources/static/test-ws.html
+++ b/src/main/resources/static/test-ws.html
@@ -9,14 +9,12 @@
         body { font-family: sans-serif; padding: 1rem; }
         #log { background: #f5f5f5; padding: .5rem; max-height: 300px; overflow-y: auto; }
         #controls { margin-bottom: 1rem; }
-        input { width: 60%; padding: .5rem; }
         button { padding: .5rem 1rem; }
     </style>
 </head>
 <body>
 <h1>WebSocket 알림 테스트</h1>
 <div id="controls">
-    <input id="tokenInput" placeholder="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." />
     <button id="connectBtn">연결하기</button>
 </div>
 <div id="log"></div>
@@ -33,25 +31,21 @@
     let client;
 
     document.getElementById('connectBtn').addEventListener('click', () => {
-        let raw = document.getElementById('tokenInput').value.trim();
-        if (!raw) {
-            alert('먼저 유효한 JWT 토큰을 입력하세요.');
-            return;
-        }
-        const jwt = raw.startsWith('Bearer ') ? raw.substring(7) : raw;
-        connectWebSocket(jwt);
-    });
-
-    function connectWebSocket(token) {
         if (client) {
             log('⚠️ 이미 연결되어 있습니다.');
             return;
         }
-        log('Opening Web Socket...');
-        const socket = new SockJS('/ws/notifications?token=' + token);
+        connectWebSocket();
+    });
+
+    function connectWebSocket() {
+        log('Opening WebSocket...');
+        // ▶ 토큰 쿼리 없이, 쿠키에 담긴 accessToken이 자동으로 전송됨
+        const socket = new SockJS('/ws/notifications');
         client = Stomp.over(socket);
 
-        client.connect({},
+        client.connect(
+            {},  // 헤더 대신 빈 객체
             frame => {
                 log('✅ 연결 성공: ' + (frame.headers['user-name'] || '인증 성공'));
                 client.subscribe('/user/queue/notifications', msg => {


### PR DESCRIPTION
- WebSocket 테스트 HTML (test-ws.html)  
  • tokenInput 및 토큰 쿼리 파라미터 제거  
  • SockJS 연결 시 `/ws/notifications`만 호출하여 쿠키 기반 인증 적용  
- OAuth2AuthenticationSuccessHandler.java  
  • `response.sendRedirect(redirectBase + "/oauth2/redirect")` → `response.sendRedirect(redirectBase)`로 변경