### PR TITLE
feat(notification): 알림 API 페이징 기능 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/controller/NotificationController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/NotificationController.java
@@ -4,6 +4,10 @@ import com.jdc.recipe_service.domain.dto.notification.NotificationDto;
 import com.jdc.recipe_service.security.CustomUserDetails;
 import com.jdc.recipe_service.service.NotificationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -17,17 +21,18 @@ public class NotificationController {
     private final NotificationService service;
 
     @GetMapping
-    public List<NotificationDto> getAll(
+    public Page<NotificationDto> getAll(
             @AuthenticationPrincipal CustomUserDetails user,
-            @RequestParam(required = false) Boolean read
+            @RequestParam(required = false) Boolean read,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pg
     ) {
         Long uid = user.getId();
         if (read == null) {
-            return service.getNotifications(uid);
+            return service.getNotifications(uid, pg);
         } else if (read) {
-            return service.getReadNotifications(uid);
+            return service.getReadNotifications(uid, pg);
         } else {
-            return service.getUnreadNotifications(uid);
+            return service.getUnreadNotifications(uid, pg);
         }
     }
 

--- a/src/main/java/com/jdc/recipe_service/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/NotificationRepository.java
@@ -1,14 +1,17 @@
 package com.jdc.recipe_service.domain.repository;
 
 import com.jdc.recipe_service.domain.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
+    Page<Notification> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
     List<Notification> findByUserIdAndIsReadFalse(Long userId);
-    List<Notification> findByUserIdAndIsReadFalseOrderByCreatedAtDesc(Long userId);
-    List<Notification> findByUserIdAndIsReadTrueOrderByCreatedAtDesc(Long userId);
+    Page<Notification> findByUserIdAndIsReadFalseOrderByCreatedAtDesc(Long userId, Pageable pageable);
+    Page<Notification> findByUserIdAndIsReadTrueOrderByCreatedAtDesc(Long userId, Pageable pageable);
     void deleteByUserId(Long userId);
     long countByUserIdAndIsReadFalse(Long userId);
 }

--- a/src/main/java/com/jdc/recipe_service/service/NotificationService.java
+++ b/src/main/java/com/jdc/recipe_service/service/NotificationService.java
@@ -11,6 +11,8 @@ import com.jdc.recipe_service.domain.type.NotificationType;
 import com.jdc.recipe_service.event.NotificationSavedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,28 +63,23 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
-    public List<NotificationDto> getNotifications(Long userId) {
-        return notificationRepo.findByUserIdOrderByCreatedAtDesc(userId)
-                .stream()
-                .map(NotificationDto::fromEntity)
-                .collect(Collectors.toList());
+    public Page<NotificationDto> getNotifications(Long userId, Pageable pg) {
+        return notificationRepo
+                .findByUserIdOrderByCreatedAtDesc(userId, pg)
+                .map(NotificationDto::fromEntity);
     }
     @Transactional(readOnly = true)
-    public List<NotificationDto> getUnreadNotifications(Long userId) {
+    public Page<NotificationDto> getUnreadNotifications(Long userId, Pageable pg) {
         return notificationRepo
-                .findByUserIdAndIsReadFalseOrderByCreatedAtDesc(userId)
-                .stream()
-                .map(NotificationDto::fromEntity)
-                .toList();
+                .findByUserIdAndIsReadFalseOrderByCreatedAtDesc(userId, pg)
+                .map(NotificationDto::fromEntity);
     }
 
     @Transactional(readOnly = true)
-    public List<NotificationDto> getReadNotifications(Long userId) {
+    public Page<NotificationDto> getReadNotifications(Long userId, Pageable pg) {
         return notificationRepo
-                .findByUserIdAndIsReadTrueOrderByCreatedAtDesc(userId)
-                .stream()
-                .map(NotificationDto::fromEntity)
-                .toList();
+                .findByUserIdAndIsReadTrueOrderByCreatedAtDesc(userId, pg)
+                .map(NotificationDto::fromEntity);
     }
 
     @Transactional


### PR DESCRIPTION
**제목**: 알림 조회 API에 페이징 기능 추가

**변경 사항**  
1. Repository 조회 메서드가 `Pageable` 을 받아 `Page<Notification>` 을 반환  
2. Service 계층에서 `Page<NotificationDto>` 를 반환  
3. Controller에서 Spring Data `Pageable` 을 지원하여  
   - `GET /api/notifications?page=<번호>&size=<개수>&sort=createdAt,desc&read=<true|false>` 형태로 호출 가능  
4. 기본 페이지 크기 20, `createdAt` 내림차순 정렬

**내용** 
- **NotificationRepository**  
  - `findByUserIdOrderByCreatedAtDesc`,  
    `findByUserIdAndIsReadFalseOrderByCreatedAtDesc`,  
    `findByUserIdAndIsReadTrueOrderByCreatedAtDesc` 메서드 반환 타입을 `List<Notification>` → `Page<Notification>` 으로 변경  
  - 모든 조회 메서드에 `Pageable` 파라미터 추가

- **NotificationService**  
  - `getNotifications`, `getUnreadNotifications`, `getReadNotifications` 메서드 오버로드하여 `Pageable` 인자를 받도록 수정  
  - `Page<Notification>` → `Page<NotificationDto>` 로 매핑

- **NotificationController**  
  - `@PageableDefault(size=20, sort="createdAt", direction = Sort.Direction.DESC)` 를 이용해 기본 페이징 설정  
  - 반환 타입을 `List<NotificationDto>` → `Page<NotificationDto>` 로 변경  
  - 기존의 `read` 파라미터와 함께 `page`, `size`, `sort` 쿼리 파라미터 자동 지원