### PR TITLE
feat(auth): 쿠키 도메인(.haemeok.com) 및 SameSite=Lax 설정

### DIFF
--- a/src/main/java/com/jdc/recipe_service/controller/AuthController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/AuthController.java
@@ -62,20 +62,22 @@ public class AuthController {
         refreshTokenRepository.save(savedToken);
 
         ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", newRefreshToken)
+                .domain(".haemeok.com")
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
                 .maxAge(7 * 24 * 60 * 60)
-                .sameSite("None")
+                .sameSite("Lax")
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
         ResponseCookie accessCookie = ResponseCookie.from("accessToken", newAccessToken)
+                .domain(".haemeok.com")
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
                 .maxAge(15*60)
-                .sameSite("None")
+                .sameSite("Lax")
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
 
@@ -104,11 +106,21 @@ public class AuthController {
                     .ifPresent(refreshTokenRepository::delete);
 
             ResponseCookie deleteRefresh = ResponseCookie.from("refreshToken", "")
-                    .httpOnly(true).secure(true)
-                    .path("/").maxAge(0).sameSite("None").build();
-            ResponseCookie deleteAccess  = ResponseCookie.from("accessToken", "")
-                    .httpOnly(true).secure(true)
-                    .path("/").maxAge(0).sameSite("None").build();
+                    .domain(".haemeok.com")
+                    .path("/")
+                    .httpOnly(true)
+                    .secure(true)
+                    .maxAge(0)
+                    .sameSite("Lax")
+                    .build();
+            ResponseCookie deleteAccess = ResponseCookie.from("accessToken", "")
+                    .domain(".haemeok.com")
+                    .path("/")
+                    .httpOnly(true)
+                    .secure(true)
+                    .maxAge(0)
+                    .sameSite("Lax")
+                    .build();
 
             response.addHeader(HttpHeaders.SET_COOKIE, deleteRefresh.toString());
             response.addHeader(HttpHeaders.SET_COOKIE, deleteAccess.toString());
@@ -139,11 +151,21 @@ public class AuthController {
         refreshTokenRepository.deleteByUserId(userId);
 
         ResponseCookie deleteRefresh = ResponseCookie.from("refreshToken", "")
-                .httpOnly(true).secure(true)
-                .path("/").maxAge(0).sameSite("None").build();
-        ResponseCookie deleteAccess  = ResponseCookie.from("accessToken", "")
-                .httpOnly(true).secure(true)
-                .path("/").maxAge(0).sameSite("None").build();
+                .domain(".haemeok.com")
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+        ResponseCookie deleteAccess = ResponseCookie.from("accessToken", "")
+                .domain(".haemeok.com")
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, deleteRefresh.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, deleteAccess.toString());

--- a/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -55,19 +55,21 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
         }
 
         ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
+                .domain(".haemeok.com")
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
                 .maxAge(7 * 24 * 60 * 60)
-                .sameSite("None")
+                .sameSite("Lax")
                 .build();
 
         ResponseCookie accessCookie = ResponseCookie.from("accessToken", accessToken)
+                .domain(".haemeok.com")
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
                 .maxAge(15 * 60)
-                .sameSite("None")
+                .sameSite("Lax")
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());


### PR DESCRIPTION
- OAuth2AuthenticationSuccessHandler  
  • refreshToken, accessToken 쿠키 생성 시  
    – domain(".haemeok.com") 추가  
    – sameSite("Lax")로 변경  
- AuthController  
  • /refresh, /logout, /logout/all 엔드포인트에서  
    – 쿠키 발급/삭제 시 domain(".haemeok.com") 및 sameSite("Lax") 설정 적용  
