### PR TITLE
feat(ws): 핸드쉐이크 경로 JWT 필터 예외 처리

### DIFF
--- a/src/main/java/com/jdc/recipe_service/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/jdc/recipe_service/jwt/JwtAuthenticationFilter.java
@@ -85,7 +85,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return path.equals("/") || path.equals("/login")
                 || path.startsWith("/css/") || path.startsWith("/js/")
                 || path.startsWith("/images/") || path.startsWith("/oauth2")
-                || path.startsWith("/h2-console") || path.equals("/favicon.ico");
+                || path.startsWith("/h2-console") || path.equals("/favicon.ico")
+                || path.startsWith("/ws/notifications");
     }
 
 }


### PR DESCRIPTION
- JwtAuthenticationFilter.shouldNotFilter()에 `/ws/notifications` 경로 추가  
  - WebSocket 핸드쉐이크 요청이 JWT 필터를 우회하도록 설정  
- 프론트에서 쿠키 기반 인증 정보(withCredentials)로 정상 처리되도록 수정