### PR TITLE
feat(auth): BFF 아키텍처 도입에 따른 OAuth2 콜백 처리 리팩토링

### DIFF
--- a/src/main/java/com/jdc/recipe_service/controller/OAuthController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/OAuthController.java
@@ -1,0 +1,51 @@
+package com.jdc.recipe_service.controller;
+
+import com.jdc.recipe_service.domain.dto.auth.AuthTokens;
+import com.jdc.recipe_service.domain.dto.auth.CodeDto;
+import com.jdc.recipe_service.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login/oauth2/code/{provider}")
+    public ResponseEntity<Void> oauthCallback(
+            @PathVariable String provider,
+            @RequestBody CodeDto codeDto,
+            @RequestHeader(value = "X-Env", defaultValue = "prod") String env) {
+
+        AuthTokens tokens = authService.handleLogin(provider,codeDto.getCode());
+
+        boolean isLocal = "local".equalsIgnoreCase(env);
+
+        var accessB = ResponseCookie.from("accessToken", tokens.getAccessToken())
+                .path("/")
+                .httpOnly(true)
+                .sameSite("Lax")
+                .maxAge(15 * 60);
+
+        var refreshB = ResponseCookie.from("refreshToken", tokens.getRefreshToken())
+                .path("/")
+                .httpOnly(true)
+                .sameSite("Lax")
+                .maxAge(7 * 24 * 60 * 60);
+
+        if (!isLocal) {
+            accessB.secure(true).domain(".haemeok.com");
+            refreshB.secure(true).domain(".haemeok.com");
+        }
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessB.build().toString())
+                .header(HttpHeaders.SET_COOKIE, refreshB.build().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/auth/AuthTokens.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/auth/AuthTokens.java
@@ -1,0 +1,11 @@
+package com.jdc.recipe_service.domain.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AuthTokens {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/auth/CodeDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/auth/CodeDto.java
@@ -1,0 +1,8 @@
+package com.jdc.recipe_service.domain.dto.auth;
+
+import lombok.Data;
+
+@Data
+public class CodeDto {
+    private String code;
+}

--- a/src/main/java/com/jdc/recipe_service/service/AuthService.java
+++ b/src/main/java/com/jdc/recipe_service/service/AuthService.java
@@ -1,0 +1,70 @@
+package com.jdc.recipe_service.service;
+
+import com.jdc.recipe_service.domain.entity.RefreshToken;
+import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.repository.RefreshTokenRepository;
+import com.jdc.recipe_service.domain.dto.auth.AuthTokens;
+import com.jdc.recipe_service.jwt.JwtTokenProvider;
+import com.jdc.recipe_service.security.oauth.CustomOAuth2User;
+import com.jdc.recipe_service.security.oauth.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final ClientRegistrationRepository clients;
+    private final OAuth2AuthorizedClientManager authorizedClientManager;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    /**
+     * provider: "google", "kakao" 또는 "naver"
+     * code: OAuth2 인증 서버가 보낸 인가 코드
+     */
+    public AuthTokens handleLogin(String provider,String code) {
+        OAuth2User oAuth2User = exchangeCodeAndLoadUser(provider, code);
+        User user = ((CustomOAuth2User) oAuth2User).getUser();
+
+        String accessToken  = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+        refreshTokenRepository.save(RefreshToken.builder()
+                .user(user)
+                .token(refreshToken)
+                .build()
+        );
+
+        return new AuthTokens(accessToken, refreshToken);
+    }
+
+    private OAuth2User exchangeCodeAndLoadUser(String registrationId, String code) {
+        ClientRegistration registration = clients.findByRegistrationId(registrationId);
+
+        Authentication principal =
+                new UsernamePasswordAuthenticationToken(registrationId, null, List.of());
+
+        OAuth2AuthorizeRequest authRequest = OAuth2AuthorizeRequest.withClientRegistrationId(registrationId)
+                .principal(principal)
+                .attribute(OAuth2ParameterNames.CODE, code)
+                .build();
+
+        OAuth2AuthorizedClient client = authorizedClientManager.authorize(authRequest);
+
+        OAuth2UserRequest userRequest =
+                new OAuth2UserRequest(registration, client.getAccessToken());
+        return customOAuth2UserService.loadUser(userRequest);
+    }
+}


### PR DESCRIPTION
배경
- 기존 Spring `oauth2Login` 을 제거하고, Next.js BFF → Spring API 방식으로 OAuth2 code 전달
- Next.js 서버에서 code를 받아 Spring에서 토큰을 발급·쿠키 설정하도록 변경

주요 변경 사항
1. SecurityConfig.java
   • .oauth2Login() 관련 설정 제거  
   • POST "/login/oauth2/code/**" permitAll()  
   • OAuth2AuthorizedClientService / OAuth2AuthorizedClientManager 빈 추가  

2. DTO 추가
   • CodeDto (인가 코드 수신용)  
   • AuthTokens (액세스·리프레시 토큰 반환용)  

3. AuthService.java
   • handleLogin(provider, code) 구현  
   • OAuth2AuthorizedClientManager 통해 code ↔ 액세스 토큰 교환  
   • CustomOAuth2UserService로 사용자 로딩  
   • JWT + RefreshToken 생성/저장  

4. OAuthController.java
   • "/login/oauth2/code/{provider}" 엔드포인트로 통합 처리  
   • X-Env 헤더로 로컬/운영 분기, Secure/Domain 속성 적용  
   • HttpOnly 쿠키 세팅 후 빈 응답  
