### PR TITLE
fix(authservice): OAuth2AuthorizeRequest에 redirect_uri 속성 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/service/AuthService.java
+++ b/src/main/java/com/jdc/recipe_service/service/AuthService.java
@@ -56,12 +56,19 @@ public class AuthService {
         Authentication principal =
                 new UsernamePasswordAuthenticationToken(registrationId, null, List.of());
 
+        String redirectUri = registration.getRedirectUri();
+
         OAuth2AuthorizeRequest authRequest = OAuth2AuthorizeRequest.withClientRegistrationId(registrationId)
                 .principal(principal)
                 .attribute(OAuth2ParameterNames.CODE, code)
+                .attribute(OAuth2ParameterNames.REDIRECT_URI, redirectUri)
                 .build();
 
         OAuth2AuthorizedClient client = authorizedClientManager.authorize(authRequest);
+
+        if (client == null) {
+            throw new IllegalStateException("Failed to authorize client for registration ID: " + registrationId);
+        }
 
         OAuth2UserRequest userRequest =
                 new OAuth2UserRequest(registration, client.getAccessToken());


### PR DESCRIPTION
## 배경
- OAuth2AuthorizedClientManager.authorize() 호출 시  
  redirect_uri가 누락되어 ClientAuthorizationRequiredException 발생  

## 변경사항
1. `ClientRegistration registration = clients.findByRegistrationId(provider);`  
2. `String redirectUri = registration.getRedirectUri();` 로 리디렉트 URI 조회  
3. `OAuth2AuthorizeRequest` 생성 시  
   ```java
   OAuth2AuthorizeRequest authRequest = OAuth2AuthorizeRequest.withClientRegistrationId(provider)
       .principal(principal)
       .attribute(OAuth2ParameterNames.CODE, code)
       .attribute(OAuth2ParameterNames.REDIRECT_URI, redirectUri)
       .build();