### PR TITLE
fix(auth): AuthService의 ClientAuthorizationRequiredException 해결

### DIFF
--- a/src/main/java/com/jdc/recipe_service/service/AuthService.java
+++ b/src/main/java/com/jdc/recipe_service/service/AuthService.java
@@ -8,8 +8,10 @@ import com.jdc.recipe_service.jwt.JwtTokenProvider;
 import com.jdc.recipe_service.security.oauth.CustomOAuth2User;
 import com.jdc.recipe_service.security.oauth.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
@@ -53,8 +55,9 @@ public class AuthService {
     private OAuth2User exchangeCodeAndLoadUser(String registrationId, String code, String env) {
         ClientRegistration registration = clients.findByRegistrationId(registrationId);
 
-        Authentication principal =
-                new UsernamePasswordAuthenticationToken(registrationId, null, List.of());
+        Authentication principal = new AnonymousAuthenticationToken(
+                "key", "anonymous", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
+        );
 
         String redirectUri;
         if ("local".equalsIgnoreCase(env)) {


### PR DESCRIPTION
- OAuth2AuthorizedClientManager는 인증되지 않은 흐름에서도 Authentication principal 객체를 요구하므로, 이 값이 없어 예외가 발생

- AnonymousAuthenticationToken을 임시 principal로 제공하여 OAuth2 클라이언트 인증이 정상적으로 진행되도록 수정