### PR TITLE
feat(auth): 익명 인증 객체 적용

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -14,6 +14,9 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.*;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -283,25 +286,22 @@ public class SecurityConfig {
         src.registerCorsConfiguration("/**", cfg);
         return src;
     }
-
     @Bean
-    public OAuth2AuthorizedClientService authorizedClientService(
-            ClientRegistrationRepository clients) {
-        return new InMemoryOAuth2AuthorizedClientService(clients);
+    public OAuth2AuthorizedClientRepository authorizedClientRepository() {
+        return new HttpSessionOAuth2AuthorizedClientRepository();
     }
-
     @Bean
     public OAuth2AuthorizedClientManager authorizedClientManager(
-            ClientRegistrationRepository clients,
-            OAuth2AuthorizedClientService clientService) {
+            ClientRegistrationRepository clientRegistrationRepository,
+            OAuth2AuthorizedClientRepository authorizedClientRepository) {
 
-        OAuth2AuthorizedClientProvider provider = OAuth2AuthorizedClientProviderBuilder.builder()
+        var provider = OAuth2AuthorizedClientProviderBuilder.builder()
                 .authorizationCode()
                 .refreshToken()
                 .build();
 
-        var manager = new AuthorizedClientServiceOAuth2AuthorizedClientManager(
-                clients, clientService
+        var manager = new DefaultOAuth2AuthorizedClientManager(
+                clientRegistrationRepository, authorizedClientRepository
         );
         manager.setAuthorizedClientProvider(provider);
         return manager;


### PR DESCRIPTION
 - SecurityConfig에 OAuth2AuthorizedClientRepository(HttpSessionOAuth2AuthorizedClientRepository) 빈 등록
 - SecurityConfig의 authorizedClientManager 빈을 DefaultOAuth2AuthorizedClientManager로 대체
