### PR TITLE
refactor(auth): OAuth2 토큰 교환 로직 리팩토링 및 안정화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.1'
+	id 'org.springframework.boot' version '3.4.3'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -13,6 +13,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.*;
+import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository;
@@ -287,6 +290,11 @@ public class SecurityConfig {
         return src;
     }
     @Bean
+    public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient() {
+        return new DefaultAuthorizationCodeTokenResponseClient();
+    }
+    /*
+    @Bean
     public OAuth2AuthorizedClientService authorizedClientService(
             ClientRegistrationRepository clientRegistrations) {
         return new InMemoryOAuth2AuthorizedClientService(clientRegistrations);
@@ -307,5 +315,7 @@ public class SecurityConfig {
         manager.setAuthorizedClientProvider(provider);
         return manager;
     }
+
+     */
 }
 

--- a/src/main/java/com/jdc/recipe_service/service/AuthService.java
+++ b/src/main/java/com/jdc/recipe_service/service/AuthService.java
@@ -9,43 +9,42 @@ import com.jdc.recipe_service.security.oauth.CustomOAuth2User;
 import com.jdc.recipe_service.security.oauth.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
-    private final ClientRegistrationRepository clients;
-    private final OAuth2AuthorizedClientManager authorizedClientManager;
+    private final ClientRegistrationRepository clientRegistrationRepository;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient;
+
     /**
      * provider: "google", "kakao" 또는 "naver"
      * code: OAuth2 인증 서버가 보낸 인가 코드
      */
-    public AuthTokens handleLogin(String provider,String code, String env) {
+    public AuthTokens handleLogin(String provider, String code, String env) {
         log.info("[AuthService] handleLogin start: provider={}, code={}, env={}", provider, code, env);
+
         OAuth2User oAuth2User = exchangeCodeAndLoadUser(provider, code, env);
         User user = ((CustomOAuth2User) oAuth2User).getUser();
         log.info("[AuthService] OAuth2User loaded: userId={}", user.getId());
 
-        String accessToken  = jwtTokenProvider.createAccessToken(user);
+        String accessToken = jwtTokenProvider.createAccessToken(user);
         String refreshToken = jwtTokenProvider.createRefreshToken();
         refreshTokenRepository.save(RefreshToken.builder()
                 .user(user)
@@ -58,12 +57,8 @@ public class AuthService {
     }
 
     private OAuth2User exchangeCodeAndLoadUser(String registrationId, String code, String env) {
-        ClientRegistration registration = clients.findByRegistrationId(registrationId);
+        ClientRegistration clientRegistration = clientRegistrationRepository.findByRegistrationId(registrationId);
         log.info("[AuthService] Found ClientRegistration for {}", registrationId);
-
-        Authentication principal = new AnonymousAuthenticationToken(
-                "key", "anonymous", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
-        );
 
         String redirectUri;
         if ("local".equalsIgnoreCase(env)) {
@@ -73,24 +68,29 @@ public class AuthService {
         }
         log.info("[AuthService] Using redirectUri={}", redirectUri);
 
-        OAuth2AuthorizeRequest authRequest = OAuth2AuthorizeRequest.withClientRegistrationId(registrationId)
-                .principal(principal)
-                .attribute(OAuth2ParameterNames.CODE, code)
-                .attribute(OAuth2ParameterNames.REDIRECT_URI, redirectUri)
+        OAuth2AuthorizationRequest authRequest = OAuth2AuthorizationRequest
+                .authorizationCode()
+                .clientId(clientRegistration.getClientId())
+                .authorizationUri(clientRegistration.getProviderDetails().getAuthorizationUri())
+                .redirectUri(redirectUri)
+                .scopes(clientRegistration.getScopes())
+                .state("state-dummy") // state 값은 필수지만 여기서는 중요하지 않음
                 .build();
-        log.info("[AuthService] Built OAuth2AuthorizeRequest attributes={}", authRequest.getAttributes());
 
-        OAuth2AuthorizedClient client = authorizedClientManager.authorize(authRequest);
+        OAuth2AuthorizationResponse authResponse = OAuth2AuthorizationResponse
+                .success(code)
+                .redirectUri(redirectUri)
+                .state("state-dummy")
+                .build();
 
-        if (client == null) {
-            log.error("[AuthService] authorize(...) returned null for {}", registrationId);
-            throw new IllegalStateException("Failed to authorize client for registration ID: " + registrationId);
-        }
-        log.info("[AuthService] AuthorizedClient received: accessToken={}, expiresAt={}",
-                client.getAccessToken().getTokenValue().substring(0,10) + "...",
-                client.getAccessToken().getExpiresAt());
-        OAuth2UserRequest userRequest =
-                new OAuth2UserRequest(registration, client.getAccessToken());
+        OAuth2AuthorizationCodeGrantRequest grantRequest =
+                new OAuth2AuthorizationCodeGrantRequest(clientRegistration, new OAuth2AuthorizationExchange(authRequest, authResponse));
+
+        log.info("[AuthService] Requesting access token directly...");
+        OAuth2AccessToken accessToken = accessTokenResponseClient.getTokenResponse(grantRequest).getAccessToken();
+        log.info("[AuthService] Access token received successfully.");
+
+        OAuth2UserRequest userRequest = new OAuth2UserRequest(clientRegistration, accessToken);
         return customOAuth2UserService.loadUser(userRequest);
     }
 }


### PR DESCRIPTION
변경 파일
- src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
- src/main/java/com/jdc/recipe_service/service/AuthService.java

주요 변경 사항
1. SecurityConfig.java  
   - 기존 `authorizedClientService` / `authorizedClientManager` 빈 주석 처리  
   - `accessTokenResponseClient()` 빈 추가 (`DefaultAuthorizationCodeTokenResponseClient` 사용)  
   - HttpSessionOAuth2AuthorizedClientRepository 관련 코드를 더 이상 사용하지 않도록 정리  

2. AuthService.java  
   - `AuthorizedClientManager` 호출을 완전히 제거  
   - `OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>` 주입 후  
     - `OAuth2AuthorizationRequest`·`OAuth2AuthorizationResponse` 직접 생성  
     - `DefaultAuthorizationCodeTokenResponseClient` 통해 액세스 토큰 교환  
     - 교환된 토큰으로 `CustomOAuth2UserService`를 직접 호출해 사용자 정보 로드  
