### PR TITLE
fix(auth): 리프레시 토큰 저장 시 만료 시간 설정

### DIFF
--- a/src/main/java/com/jdc/recipe_service/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/jdc/recipe_service/jwt/JwtTokenProvider.java
@@ -12,6 +12,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.UUID;
 
@@ -62,6 +65,14 @@ public class JwtTokenProvider {
                 .setExpiration(expiry)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public LocalDateTime getRefreshTokenExpiryAsLocalDateTime() {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
+        return Instant.ofEpochMilli(expiryDate.getTime())
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/com/jdc/recipe_service/service/AuthService.java
+++ b/src/main/java/com/jdc/recipe_service/service/AuthService.java
@@ -22,6 +22,8 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResp
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -46,9 +48,12 @@ public class AuthService {
 
         String accessToken = jwtTokenProvider.createAccessToken(user);
         String refreshToken = jwtTokenProvider.createRefreshToken();
+
+        LocalDateTime refreshTokenExpiry = jwtTokenProvider.getRefreshTokenExpiryAsLocalDateTime();
         refreshTokenRepository.save(RefreshToken.builder()
                 .user(user)
                 .token(refreshToken)
+                .expiredAt(refreshTokenExpiry)
                 .build()
         );
         log.info("[AuthService] JWT tokens created");
@@ -74,7 +79,7 @@ public class AuthService {
                 .authorizationUri(clientRegistration.getProviderDetails().getAuthorizationUri())
                 .redirectUri(redirectUri)
                 .scopes(clientRegistration.getScopes())
-                .state("state-dummy") // state 값은 필수지만 여기서는 중요하지 않음
+                .state("state-dummy")
                 .build();
 
         OAuth2AuthorizationResponse authResponse = OAuth2AuthorizationResponse


### PR DESCRIPTION
### 문제 원인
- OAuth2 로그인 성공 후, RefreshToken 엔티티를 데이터베이스에 저장하는 과정에서 expired_at 필드에 값을 설정하지 않아서 데이터베이스의 NOT NULL 제약 조건에 위배되어 DataIntegrityViolationException이 발생함

### 해결 방안
- JwtTokenProvider 수정: 리프레시 토큰의 만료 시간을 LocalDateTime으로 계산하여 반환하는 getRefreshTokenExpiryAsLocalDateTime() 메서드를 추가함

- AuthService 수정: RefreshToken 엔티티를 생성할 때 위 메서드를 호출하여 expiredAt 필드를 명시적으로 설정한 후 데이터베이스에 저장하도록 변경함