### PR TITLE
fix(websocket): WebSocket 핸드셰이크 인증 로직 수정

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/WebSocketConfig.java
@@ -1,6 +1,5 @@
 package com.jdc.recipe_service.config;
 
-import com.jdc.recipe_service.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +13,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/queue", "/topic");
@@ -26,7 +25,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/notifications")
                 .setAllowedOriginPatterns("http://localhost:3000","http://localhost:5173", "https://www.haemeok.com")
-                .addInterceptors(new JwtHandshakeInterceptor(jwtTokenProvider))
+                .addInterceptors(jwtHandshakeInterceptor)
                 .setHandshakeHandler(new PrincipalHandshakeHandler())
                 .withSockJS();
     }


### PR DESCRIPTION
## 문제 원인
로컬 환경(localhost)에서 운영 API 서버로 WebSocket 연결 시, 브라우저의 SameSite=Lax 쿠키 정책으로 인해 accessToken 쿠키가 전송되지 않음 
이로 인해 JwtHandshakeInterceptor가 토큰을 찾지 못하고 핸드셰이크를 거부하여 실시간 알림 기능이 동작하지 않음

## 해결 방안
프론트엔드 변경 (요청사항): WebSocket 연결 URL에 accessToken을 쿼리 파라미터(?token=...)로 담아 보내도록 수정

- JwtHandshakeInterceptor 수정: URL 쿼리 파라미터에서 토큰을 우선적으로 읽도록 로직을 추가함 
기존 쿠키 방식은 하위 호환성을 위해 Fallback으로 유지함
 또한, 일관적인 관리를 위해 Spring @Component로 등록함

- WebSocketConfig 수정: 인터셉터를 new로 직접 생성하는 대신, Spring 컨테이너가 관리하는 Bean을 주입받아 사용하도록 변경하여 의존성 주입 원칙을 따르도록 함