### PR TITLE
Feature/ws ticket auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,7 @@ jobs:
           OPENSEARCH_HOST: ${{ secrets.OPENSEARCH_HOST }}
           REPLICATE_TOKEN: ${{ secrets.REPLICATE_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
       - name: Deploy to ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.security:spring-security-messaging'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	implementation 'mysql:mysql-connector-java:8.0.33'

--- a/ecs-task-definition-template.json
+++ b/ecs-task-definition-template.json
@@ -37,7 +37,8 @@
         { "name": "APP_S3_PRESIGNED_URL_EXPIRATION_MINUTES", "value": "${APP_S3_PRESIGNED_URL_EXPIRATION_MINUTES}" },
         { "name": "OPENSEARCH_HOST", "value": "${OPENSEARCH_HOST}" },
         { "name": "REPLICATE_TOKEN", "value": "${REPLICATE_TOKEN}" },
-        { "name": "OPENAI_API_KEY", "value": "${OPENAI_API_KEY}" }
+        { "name": "OPENAI_API_KEY", "value": "${OPENAI_API_KEY}" },
+        { "name": "REDIS_PASSWORD", "value": "${REDIS_PASSWORD}" }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/src/main/java/com/jdc/recipe_service/config/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/jdc/recipe_service/config/JwtHandshakeInterceptor.java
@@ -1,20 +1,21 @@
 package com.jdc.recipe_service.config;
 
-import com.jdc.recipe_service.jwt.JwtTokenProvider;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.server.ServerHttpRequest;
-import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
 
-import java.util.Arrays;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 
 @Slf4j
@@ -22,45 +23,37 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 
-    private final JwtTokenProvider tokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final UserDetailsService userDetailsService;
 
     @Override
     public boolean beforeHandshake(@NonNull ServerHttpRequest request,
                                    @NonNull ServerHttpResponse response,
                                    @NonNull WebSocketHandler wsHandler,
                                    @NonNull Map<String, Object> attributes) {
-        if (!(request instanceof ServletServerHttpRequest servletRequest)) {
+        if (!(request instanceof ServletServerHttpRequest servlet)) {
             log.warn("Handshake failed: Not a servlet request.");
             return false;
         }
 
-        HttpServletRequest httpRequest = servletRequest.getServletRequest();
-        String token = null;
-
-        token = httpRequest.getParameter("token");
-        if (token != null) {
-            log.debug("Handshake: 쿼리 파라미터에서 토큰 발견.");
+        HttpServletRequest httpReq = servlet.getServletRequest();
+        String ticket = httpReq.getParameter("token");
+        if (ticket == null) {
+            log.warn("Handshake failed: Missing ticket parameter.");
+            return false;
         }
 
-        if (token == null && httpRequest.getCookies() != null) {
-            token = Arrays.stream(httpRequest.getCookies())
-                    .filter(c -> "accessToken".equals(c.getName()))
-                    .map(Cookie::getValue)
-                    .findFirst()
-                    .orElse(null);
-            if (token != null) {
-                log.debug("Handshake: 쿠키에서 토큰 발견.");
-            }
-        }
-
-        if (token != null && tokenProvider.validateToken(token)) {
-            Authentication auth = tokenProvider.getAuthentication(token);
+        String username = redisTemplate.opsForValue().get(ticket);
+        if (username != null && redisTemplate.delete(ticket)) {
+            UserDetails user = userDetailsService.loadUserByUsername(username);
+            Authentication auth = new UsernamePasswordAuthenticationToken(
+                    user, null, user.getAuthorities());
             attributes.put("user", auth);
-            log.info("Handshake 성공. 사용자: {}", auth.getName());
+            log.info("Handshake successful for user: {}", username);
             return true;
         }
 
-        log.warn("Handshake 실패: 유효한 토큰을 찾을 수 없습니다.");
+        log.warn("Handshake failed: Invalid or expired ticket {}", ticket);
         return false;
     }
 

--- a/src/main/java/com/jdc/recipe_service/config/RedisConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.jdc.recipe_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory cf) {
+        RedisTemplate<String, String> rt = new RedisTemplate<>();
+        rt.setConnectionFactory(cf);
+        rt.setKeySerializer(new StringRedisSerializer());
+        rt.setValueSerializer(new StringRedisSerializer());
+        return rt;
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -105,7 +105,8 @@ public class SecurityConfig {
                                     "/api/token/logout/all",
                                     "/api/me/fridge/items/bulk",
                                     "/api/recipes/*/private",
-                                    "/api/recipes/*/finalize"
+                                    "/api/recipes/*/finalize",
+                                    "/api/ws-ticket"
                             ).authenticated()
 
                             // 5) 보호된 PUT
@@ -231,7 +232,8 @@ public class SecurityConfig {
                                 "/api/token/logout",
                                 "/api/token/logout/all",
                                 "/api/recipes/*/private",
-                                "/api/recipes/*/finalize"
+                                "/api/recipes/*/finalize",
+                                "/api/ws-ticket"
                         ).authenticated()
 
                         // 5) 인증 필요 PUT

--- a/src/main/java/com/jdc/recipe_service/controller/WebSocketTicketController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/WebSocketTicketController.java
@@ -1,0 +1,30 @@
+package com.jdc.recipe_service.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@RestController
+@RequiredArgsConstructor
+public class WebSocketTicketController {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @PostMapping("/api/ws-ticket")
+    public ResponseEntity<Map<String, String>> issueWebSocketTicket(
+            @AuthenticationPrincipal UserDetails user
+    ) {
+        String ticket = UUID.randomUUID().toString();
+        redisTemplate.opsForValue()
+                .set(ticket, user.getUsername(), 30, TimeUnit.SECONDS);
+        return ResponseEntity.ok(Map.of("ticket", ticket));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  data:
+    redis:
+      host: haemeok-redis-cluster.nimena.apn2.cache.amazonaws.com
+      port: 6379
+      password: ${REDIS_PASSWORD}
   profiles:
     active: prod
   mvc:


### PR DESCRIPTION
# WebSocket 티켓 방식으로 인증 전환

## 요약
- 기존 JWT 직접 검증 기반 핸드쉐이크를 **“짧은 유효기간(30초) 일회성 티켓”** 방식으로 전환
- Redis에 티켓 저장/검증 로직 추가
- WebSocketTicketController → POST /api/ws-ticket
- JwtHandshakeInterceptor → Redis(ticket) 검증 및 Authentication 심기
- SecurityConfig → /api/ws-ticket 엔드포인트 인증 필터링
- CI/CD 설정(deploy.yml, ecs-task-definition-template.json) → REDIS_PASSWORD 시크릿 주입

## 변경 내역
1. **의존성**: Redis 스타터 추가  
2. **설정**:  
   - RedisTemplate 빈 등록  
   - application.yml에 Redis 연결 정보(prod)  
3. **API**:  
   - WebSocketTicketController 생성  
4. **핸드쉐이크**:  
   - JwtHandshakeInterceptor에서 ticket 검증 로직으로 교체  
5. **보안**:  
   - SecurityConfig에 POST /api/ws-ticket 인증 적용  
6. **CI/CD**:  
   - deploy.yml, ecs-task-definition-template.json에 REDIS_PASSWORD 환경변수 및 시크릿 참조 추가