### PR TITLE
refactor: recipe service structure

### DIFF
--- a/src/main/java/com/jdc/recipe_service/controller/CommentController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/CommentController.java
@@ -57,7 +57,7 @@ public class CommentController {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
         ReplyDto created = commentService.createReply(
-                recipeId, parentId, requestDto, userDetails.getUser().getId());
+                recipeId, parentId, requestDto, userDetails.getUser());
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 

--- a/src/main/java/com/jdc/recipe_service/domain/dto/recipe/AiRecipeRequestDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/recipe/AiRecipeRequestDto.java
@@ -12,12 +12,11 @@ public class AiRecipeRequestDto {
     private Long userId;
 
     private List<String> ingredients;
-    private List<String> tagNames;
     private String dishType;
     private Integer cookingTime;
     private Double servings;
 
+    private List<String> tagNames;
     private Integer spiceLevel;
     private String allergy;
-    private String dietType;
 }

--- a/src/main/java/com/jdc/recipe_service/domain/repository/CommentLikeRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/CommentLikeRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
@@ -19,7 +20,7 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
     @Query("SELECT cl.comment.id FROM CommentLike cl WHERE cl.user.id = :userId AND cl.comment.id IN :commentIds")
     List<Long> findLikedCommentIdsByUser(@Param("userId") Long userId, @Param("commentIds") List<Long> commentIds);
 
-    CommentLike findByCommentIdAndUserId(Long commentId, Long userId);
+    Optional<CommentLike> findByCommentIdAndUserId(Long commentId, Long userId);
 
     @Query("SELECT cl.comment.id AS commentId, COUNT(cl) AS likeCount " +
             "FROM CommentLike cl " +

--- a/src/main/java/com/jdc/recipe_service/service/CommentLikeService.java
+++ b/src/main/java/com/jdc/recipe_service/service/CommentLikeService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class CommentLikeService {
@@ -22,10 +24,10 @@ public class CommentLikeService {
 
     @Transactional
     public boolean toggleLike(Long commentId, Long userId) {
-        CommentLike existing = commentLikeRepository.findByCommentIdAndUserId(commentId, userId);
+        Optional<CommentLike> existing = commentLikeRepository.findByCommentIdAndUserId(commentId, userId);
 
-        if (existing != null) {
-            commentLikeRepository.delete(existing);
+        if (existing.isPresent()) {
+            commentLikeRepository.delete(existing.get());
             return false;
         }
 

--- a/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
+++ b/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
@@ -38,58 +38,61 @@ public class OpenAiClientService {
         String unitMapping = unitService.mappingAsString();
 
         this.systemPrompt = String.format("""
-            너는 매우 정교한 한국 요리 레시피 생성기(JSON Generator)다.
-            오직 하나의 완벽한 JSON 객체만 반환해야 하며, 절대로 다른 텍스트를 포함해서는 안 된다.
-
-            [핵심 요리 원칙]
-            1. (중요) 찌개, 볶음, 조림 요리 시, 기름에 향신채(마늘, 파 등)를 먼저 볶아 풍미를 극대화하는 과정을 우선적으로 고려한다.
-            2. 사용자의 알레르기 및 식이 제한 요구사항을 철저히 준수하여 재료를 제외하거나 대체해야 한다.
-            3. 요청에 없더라도 맛을 내기 위해 필수적인 보조 재료(기름, 맛술, 설탕 등)를 자유롭게 추가한다.
-
-            [출력 JSON 형식]
-            - `title`: String
-            - `dishType`: String (사용자 요청 값 절대 변경 금지)
-            - `description`: String
-            - `cookingTime`: Integer (분 단위)
-            - `cookingTools`: String[]
-            - `servings`: Double
-            - `ingredients`: Object[]
-              - `name`: String
-              - `quantity`: String
-              - `unit`: String (아래 '허용 단위' 목록에 있는 값만 사용)
-              - `customPrice`: Integer (DB에 없는 재료에만 **선택적으로** 포함)
-              - `caloriesPerUnit`: Integer (DB에 없는 재료에만 **선택적으로** 포함)
-            - `steps`: Object[]
-              - `stepNumber`: Integer (0부터 시작)
-              - `instruction`: String
-              - `action`: String (아래 '허용 Action' 목록에 있는 값만 사용)
-            - `tagNames`: String[] (사용자 요청 값 우선, 없을 시 아래 '허용 태그' 목록에서 선택)
-
-            [필드 규칙]
-            1. `action` 허용 목록: 썰기, 다지기, 채썰기, 손질하기, 볶기, 튀기기, 끓이기, 찌기(스팀), 데치기, 구이, 조림, 무치기, 절이기, 담그기(마리네이드), 섞기, 젓기, 버무리기, 로스팅, 캐러멜라이즈, 부치기
-            2. `tagNames`가 빈 배열(`[]`)로 요청된 경우, 아래 허용 목록에서 음식과 가장 어울리는 태그를 최대 3개까지 선택:
-               🏠 홈파티, 🌼 피크닉, 🏕️ 캠핑, 🥗 다이어트/건강식, 👶 아이와 함께, 🍽️ 혼밥, 🍶 술안주, 🥐 브런치, 🌙 야식, ⚡ 초스피드/간단 요리, 🎉 기념일/명절, 🍱 도시락, 🔌 에어프라이어, 🍲 해장
-            3. `unit` 허용 목록: [%s]
-            4. 재료별 기본 단위 매핑: {%s}
-            5. (중요) `customPrice`(100g당 원), `caloriesPerUnit`(100g당 kcal) 필드는 **DB에 없는 재료**에 대해서만 추가하고, DB에 있는 재료에는 절대로 포함하지 않는다.
-
-            [Few-Shot 예시]
-            {
-              "title": "돼지고기 김치찌개", "dishType": "국/찌개/탕",
-              "description": "기름에 김치와 돼지고기를 충분히 볶아내어 깊고 진한 국물 맛이 일품인 정통 김치찌개입니다.",
-              "cookingTime": 30, "servings": 2.0, "cookingTools": ["냄비", "도마", "칼"],
-              "ingredients": [
-                { "name": "돼지고기", "quantity": "150", "unit": "g" },
-                { "name": "신김치", "quantity": "200", "unit": "g", "customPrice": 300, "caloriesPerUnit": 15 },
-                { "name": "두부", "quantity": "0.5", "unit": "모" }
-              ],
-              "steps": [
-                { "stepNumber": 0, "instruction": "돼지고기와 김치는 먹기 좋게 썹니다.", "action": "썰기" },
-                { "stepNumber": 1, "instruction": "냄비에 기름을 두르고 돼지고기를 볶습니다.", "action": "볶기" }
-              ],
-              "tagNames": ["🍲 해장", "🍽️ 혼밥"]
-            }
-            """, allowedUnits, unitMapping);
+                너는 매우 정교한 한국 요리 레시피 생성기(JSON Generator)다.
+                오직 하나의 완벽한 JSON 객체만 반환해야 하며, 절대로 다른 텍스트를 포함해서는 안 된다.
+                
+                [핵심 요리 원칙]
+                1. (중요) 찌개, 볶음, 조림 요리 시, 기름에 향신채(마늘, 파 등)를 먼저 볶아 풍미를 극대화하는 과정을 우선적으로 고려한다.
+                2. 사용자의 알레르기 및 식이 제한 요구사항을 철저히 준수하여 재료를 제외하거나 대체해야 한다.
+                3. 요청에 없더라도 맛을 내기 위해 필수적인 보조 재료(기름, 맛술, 설탕 등)를 자유롭게 추가한다.
+                
+                [출력 JSON 형식]
+                - `title`: String
+                - `dishType`: String (사용자 요청 값 절대 변경 금지)
+                - `description`: String
+                - `cookingTime`: Integer (분 단위)
+                - `cookingTools`: String[]
+                - `servings`: Double
+                - `ingredients`: Object[]
+                  - `name`: String
+                  - `quantity`: String
+                  - `unit`: String (아래 '허용 단위' 목록에 있는 값만 사용)
+                  - `customPrice`: Integer (DB에 없는 재료에만 **선택적으로** 포함)
+                  - `caloriesPerUnit`: Integer (DB에 없는 재료에만 **선택적으로** 포함)
+                - `steps`: Object[]
+                  - `stepNumber`: Integer (0부터 시작)
+                  - `instruction`: String
+                     (조리 동작에 대한 구체적인 설명을 제공하세요.
+                      예: 불 세기, 사용량, 시간 등을 포함해 상세히 기술)
+                  - `action`: String (아래 '허용 Action' 목록에 있는 값만 사용)
+                - `tagNames`: String[] (사용자 요청 값 우선, 없을 시 아래 '허용 태그' 목록에서 선택)
+                
+                [필드 규칙]
+                1. `action` 허용 목록: 썰기, 다지기, 채썰기, 손질하기, 볶기, 튀기기, 끓이기, 찌기(스팀), 데치기, 구이, 조림, 무치기, 절이기, 담그기(마리네이드), 섞기, 젓기, 버무리기, 로스팅, 캐러멜라이즈, 부치기
+                2. `tagNames`가 빈 배열(`[]`)로 요청된 경우, 아래 허용 목록에서 음식과 가장 어울리는 태그를 최대 3개까지 선택:
+                   🏠 홈파티, 🌼 피크닉, 🏕️ 캠핑, 🥗 다이어트/건강식, 👶 아이와 함께, 🍽️ 혼밥, 🍶 술안주, 🥐 브런치, 🌙 야식, ⚡ 초스피드/간단 요리, 🎉 기념일/명절, 🍱 도시락, 🔌 에어프라이어, 🍲 해장
+                3. `unit` 허용 목록: [%s]
+                4. 재료별 기본 단위 매핑: {%s}
+                   (중요) DB에 저장된 재료는 반드시 이 매핑을 따라야 합니다.
+                5. (중요) `customPrice`(100g당 원), `caloriesPerUnit`(100g당 kcal) 필드는 **DB에 없는 재료**에 대해서만 추가하고, DB에 있는 재료에는 절대로 포함하지 않는다.
+                
+                [Few-Shot 예시]
+                {
+                  "title": "돼지고기 김치찌개", "dishType": "국/찌개/탕",
+                  "description": "기름에 김치와 돼지고기를 충분히 볶아내어 깊고 진한 국물 맛이 일품인 정통 김치찌개입니다.",
+                  "cookingTime": 30, "servings": 2.0, "cookingTools": ["냄비", "도마", "칼"],
+                  "ingredients": [
+                    { "name": "돼지고기", "quantity": "150", "unit": "g" },
+                    { "name": "신김치", "quantity": "200", "unit": "g", "customPrice": 300, "caloriesPerUnit": 15 },
+                    { "name": "두부", "quantity": "0.5", "unit": "모" }
+                  ],
+                  "steps": [
+                    { "stepNumber": 0, "instruction": "돼지고기는 2cm 두께로 썰고, 김치는 3cm 길이로 한 입 크기로 잘라 준비합니다.", "action": "썰기" },
+                    { "stepNumber": 1, "instruction": "중간 불로 달군 냄비에 식용유 1큰술을 두르고 돼지고기를 넣어 2분간 볶아 겉면이 노릇해지면, 김치를 넣고 3분간 더 볶아 감칠맛을 높입니다.", "action": "볶기" }
+                  ],
+                  "tagNames": ["🍲 해장", "🍽️ 혼밥"]
+                }
+                """, allowedUnits, unitMapping);
     }
 
     @Retry(name = "aiGenerate", fallbackMethod = "fallbackGenerate")

--- a/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
+++ b/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
@@ -4,17 +4,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jdc.recipe_service.domain.dto.recipe.RecipeCreateRequestDto;
 import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.util.UnitService;
 import com.openai.client.OpenAIClient;
 import com.openai.models.ChatModel;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.timelimiter.annotation.TimeLimiter;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @Service
@@ -23,69 +24,102 @@ public class OpenAiClientService {
 
     private final OpenAIClient client;
     private final ObjectMapper objectMapper;
+    private final UnitService unitService;
+
+    private String systemPrompt;
 
     /**
-     * Resilience4j로 재시도, 서킷브레이커, 타임리미터 적용.
-     * @param prompt AI에게 보낼 프롬프트
-     * @return CompletableFuture로 감싼 RecipeCreateRequestDto
+     * 애플리케이션 시작 시, UnitService의 정보를 바탕으로
+     * 완전한 형태의 System Prompt를 생성합니다.
      */
+    @PostConstruct
+    public void initializeSystemPrompt() {
+        String allowedUnits = unitService.unitsAsString();
+        String unitMapping = unitService.mappingAsString();
+
+        this.systemPrompt = String.format("""
+            너는 매우 정교한 한국 요리 레시피 생성기(JSON Generator)다.
+            오직 하나의 완벽한 JSON 객체만 반환해야 하며, 절대로 다른 텍스트를 포함해서는 안 된다.
+
+            [핵심 요리 원칙]
+            1. (중요) 찌개, 볶음, 조림 요리 시, 기름에 향신채(마늘, 파 등)를 먼저 볶아 풍미를 극대화하는 과정을 우선적으로 고려한다.
+            2. 사용자의 알레르기 및 식이 제한 요구사항을 철저히 준수하여 재료를 제외하거나 대체해야 한다.
+            3. 요청에 없더라도 맛을 내기 위해 필수적인 보조 재료(기름, 맛술, 설탕 등)를 자유롭게 추가한다.
+
+            [출력 JSON 형식]
+            - `title`: String
+            - `dishType`: String (사용자 요청 값 절대 변경 금지)
+            - `description`: String
+            - `cookingTime`: Integer (분 단위)
+            - `cookingTools`: String[]
+            - `servings`: Double
+            - `ingredients`: Object[]
+              - `name`: String
+              - `quantity`: String
+              - `unit`: String (아래 '허용 단위' 목록에 있는 값만 사용)
+              - `customPrice`: Integer (DB에 없는 재료에만 **선택적으로** 포함)
+              - `caloriesPerUnit`: Integer (DB에 없는 재료에만 **선택적으로** 포함)
+            - `steps`: Object[]
+              - `stepNumber`: Integer (0부터 시작)
+              - `instruction`: String
+              - `action`: String (아래 '허용 Action' 목록에 있는 값만 사용)
+            - `tagNames`: String[] (사용자 요청 값 우선, 없을 시 아래 '허용 태그' 목록에서 선택)
+
+            [필드 규칙]
+            1. `action` 허용 목록: 썰기, 다지기, 채썰기, 손질하기, 볶기, 튀기기, 끓이기, 찌기(스팀), 데치기, 구이, 조림, 무치기, 절이기, 담그기(마리네이드), 섞기, 젓기, 버무리기, 로스팅, 캐러멜라이즈, 부치기
+            2. `tagNames`가 빈 배열(`[]`)로 요청된 경우, 아래 허용 목록에서 음식과 가장 어울리는 태그를 최대 3개까지 선택:
+               🏠 홈파티, 🌼 피크닉, 🏕️ 캠핑, 🥗 다이어트/건강식, 👶 아이와 함께, 🍽️ 혼밥, 🍶 술안주, 🥐 브런치, 🌙 야식, ⚡ 초스피드/간단 요리, 🎉 기념일/명절, 🍱 도시락, 🔌 에어프라이어, 🍲 해장
+            3. `unit` 허용 목록: [%s]
+            4. 재료별 기본 단위 매핑: {%s}
+            5. (중요) `customPrice`(100g당 원), `caloriesPerUnit`(100g당 kcal) 필드는 **DB에 없는 재료**에 대해서만 추가하고, DB에 있는 재료에는 절대로 포함하지 않는다.
+
+            [Few-Shot 예시]
+            {
+              "title": "돼지고기 김치찌개", "dishType": "국/찌개/탕",
+              "description": "기름에 김치와 돼지고기를 충분히 볶아내어 깊고 진한 국물 맛이 일품인 정통 김치찌개입니다.",
+              "cookingTime": 30, "servings": 2.0, "cookingTools": ["냄비", "도마", "칼"],
+              "ingredients": [
+                { "name": "돼지고기", "quantity": "150", "unit": "g" },
+                { "name": "신김치", "quantity": "200", "unit": "g", "customPrice": 300, "caloriesPerUnit": 15 },
+                { "name": "두부", "quantity": "0.5", "unit": "모" }
+              ],
+              "steps": [
+                { "stepNumber": 0, "instruction": "돼지고기와 김치는 먹기 좋게 썹니다.", "action": "썰기" },
+                { "stepNumber": 1, "instruction": "냄비에 기름을 두르고 돼지고기를 볶습니다.", "action": "볶기" }
+              ],
+              "tagNames": ["🍲 해장", "🍽️ 혼밥"]
+            }
+            """, allowedUnits, unitMapping);
+    }
+
     @Retry(name = "aiGenerate", fallbackMethod = "fallbackGenerate")
     @CircuitBreaker(name = "aiGenerate", fallbackMethod = "fallbackGenerate")
     @TimeLimiter(name = "aiGenerate", fallbackMethod = "fallbackGenerate")
-    public CompletableFuture<RecipeCreateRequestDto> generateRecipeJson(String prompt) {
+    public CompletableFuture<RecipeCreateRequestDto> generateRecipeJson(String userPrompt) {
         return CompletableFuture.supplyAsync(() -> {
             var params = ChatCompletionCreateParams.builder()
                     .model(ChatModel.GPT_4_TURBO)
                     .temperature(0.0)
                     .maxCompletionTokens(1500L)
-                    .addSystemMessage("너는 한국요리 전문가야. 오직 JSON 객체로만 응답해.")
-                    .addUserMessage(prompt)
+                    .addSystemMessage(this.systemPrompt)
+                    .addUserMessage(userPrompt)
                     .build();
 
-            ChatCompletion completion;
-            try {
-                completion = client.chat().completions().create(params);
-            } catch (RuntimeException e) {
-                throw new CustomException(
-                        ErrorCode.AI_RECIPE_GENERATION_FAILED,
-                        "AI 호출 실패: " + e.getMessage(), e
-                );
+            ChatCompletion completion = client.chat().completions().create(params);
+            if (completion.choices().isEmpty()) {
+                throw new CustomException(ErrorCode.AI_RECIPE_GENERATION_FAILED, "AI 응답이 비어 있습니다.");
             }
-
-            List<ChatCompletion.Choice> choices = completion.choices();
-            if (choices.isEmpty()) {
-                throw new CustomException(
-                        ErrorCode.AI_RECIPE_GENERATION_FAILED,
-                        "AI 응답이 비어 있습니다."
-                );
-            }
-
-            String json = choices.get(0)
-                    .message()
-                    .content()
-                    .orElseThrow(() -> new CustomException(
-                            ErrorCode.AI_RECIPE_GENERATION_FAILED,
-                            "AI 응답 내용이 없습니다."
-                    ));
-
+            String json = completion.choices().get(0).message().content()
+                    .orElseThrow(() -> new CustomException(ErrorCode.AI_RECIPE_GENERATION_FAILED, "AI 응답 내용이 없습니다."));
             try {
                 return objectMapper.readValue(json, RecipeCreateRequestDto.class);
             } catch (Exception e) {
-                throw new CustomException(
-                        ErrorCode.INTERNAL_SERVER_ERROR,
-                        "AI JSON 파싱 실패: " + e.getMessage(), e
-                );
+                throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "AI JSON 파싱 실패: " + e.getMessage(), e);
             }
         });
     }
 
     private CompletableFuture<RecipeCreateRequestDto> fallbackGenerate(String prompt, Throwable ex) {
-        return CompletableFuture.failedFuture(
-                new CustomException(
-                        ErrorCode.AI_RECIPE_GENERATION_FAILED,
-                        "AI 레시피 생성 실패 (최대 재시도/서킷/타임아웃): " + ex.getMessage(),
-                        ex
-                )
-        );
+        return CompletableFuture.failedFuture(new CustomException(ErrorCode.AI_RECIPE_GENERATION_FAILED, "AI 레시피 생성 실패: " + ex.getMessage(), ex));
     }
 }

--- a/src/main/java/com/jdc/recipe_service/service/RecipeIngredientService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeIngredientService.java
@@ -12,6 +12,7 @@ import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.mapper.RecipeIngredientMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RecipeIngredientService {
     private final IngredientRepository ingredientRepository;
     private final RecipeIngredientRepository recipeIngredientRepository;
@@ -39,7 +41,7 @@ public class RecipeIngredientService {
                 throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "재료 이름이 비어있습니다.");
             }
             if (sourceType == RecipeSourceType.AI && (dto.getCustomUnit() == null || dto.getCustomUnit().isBlank())) {
-                System.err.println("경고: AI가 생성한 재료 '" + dto.getName() + "'의 단위 정보(customUnit)가 누락되었습니다.");
+                log.warn("경고: AI가 생성한 재료 '" + dto.getName() + "'의 단위 정보(customUnit)가 누락되었습니다.");
             }
 
             String nameKey = dto.getName().toLowerCase().trim();
@@ -58,11 +60,11 @@ public class RecipeIngredientService {
                 unitPrice = (masterIngredient.getPrice() != null) ? BigDecimal.valueOf(masterIngredient.getPrice()) : BigDecimal.ZERO;
                 unitForRecipeItem = (dto.getCustomUnit() != null && !dto.getCustomUnit().isBlank()) ? dto.getCustomUnit() : masterIngredient.getUnit();
             } else {
-                unitForRecipeItem = dto.getCustomUnit(); // 새로운 재료의 단위는 DTO의 customUnit 사용 (AI의 unit 또는 사용자의 customUnit)
+                unitForRecipeItem = dto.getCustomUnit();
                 if (sourceType == RecipeSourceType.AI) {
                     unitPrice = BigDecimal.ZERO;
                     if (unitForRecipeItem == null || unitForRecipeItem.isBlank()) {
-                        System.err.println("재확인 경고: AI 신규 재료 '" + dto.getName() + "'의 단위(customUnit)가 없습니다.");
+                        log.warn("재확인 경고: AI 신규 재료 '" + dto.getName() + "'의 단위(customUnit)가 없습니다.");
                     }
                 } else {
                     if (dto.getCustomPrice() == null || unitForRecipeItem == null || unitForRecipeItem.isBlank()) {

--- a/src/main/java/com/jdc/recipe_service/service/RecipeRatingService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeRatingService.java
@@ -52,7 +52,7 @@ public class RecipeRatingService {
                         .build()
                 );
 
-        RecipeRating saved = ratingRepository.save(rating);
+        ratingRepository.save(rating);
 
         updateRecipeAverageRating(recipe);
 
@@ -81,12 +81,12 @@ public class RecipeRatingService {
         }
 
         cookingRecordService.createRecordFromRating(
-                userId, recipeId, saved.getId()
+                userId, recipeId, rating.getId()
         );
 
         return new RecipeRatingResponseDto(
-                saved.getId(),
-                saved.getRating()
+                rating.getId(),
+                rating.getRating()
         );
     }
 

--- a/src/main/java/com/jdc/recipe_service/service/RecipeUploadService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeUploadService.java
@@ -20,33 +20,8 @@ public class RecipeUploadService {
     @Value("${app.s3.bucket-name}")
     private String bucketName;
 
-    @Value("${app.s3.upload-base-path}")
-    private String basePath;
-
     @Value("${app.s3.presigned-url-expiration-minutes}")
     private long expirationMinutes;
-
-    public PresignedUrlResponse generatePresignedUrlsForCreate(Long recipeId, Long userId, List<FileInfoRequest> files) {
-        List<PresignedUrlResponseItem> uploads = files.stream().map(file -> {
-            String fileKey = generateFileKey(userId, recipeId, file);
-
-            PutObjectRequest objectRequest = PutObjectRequest.builder()
-                    .bucket(bucketName)
-                    .key(fileKey)
-                    .contentType(file.getContentType())
-                    .build();
-
-            PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
-                    .signatureDuration(Duration.ofMinutes(expirationMinutes))
-                    .putObjectRequest(objectRequest)
-                    .build();
-
-            String presignedUrl = s3Presigner.presignPutObject(presignRequest).url().toString();
-            return new PresignedUrlResponseItem(fileKey, presignedUrl);
-        }).toList();
-
-        return new PresignedUrlResponse(recipeId, uploads);
-    }
 
     public UpdatePresignedUrlResponse generatePresignedUrlsForUpdate(Long recipeId, Long userId, List<FileInfoRequest> files) {
         List<PresignedUrlResponseItem> uploads = files.stream().map(file -> {

--- a/src/main/java/com/jdc/recipe_service/service/SurveyService.java
+++ b/src/main/java/com/jdc/recipe_service/service/SurveyService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,9 +32,11 @@ public class SurveyService {
     public UserSurveyDto saveOrUpdate(Long userId, UserSurveyDto dto) {
         User user = userRepository.getReferenceById(userId);
 
-        boolean isNew = surveyRepository.findByUserId(userId).isEmpty();
+        Optional<UserSurvey> optionalSurvey = surveyRepository.findByUserId(userId);
 
-        UserSurvey survey = surveyRepository.findByUserId(userId)
+        boolean isNew = optionalSurvey.isEmpty();
+
+        UserSurvey survey = optionalSurvey
                 .orElseGet(() -> SurveyMapper.toEntity(user, dto));
 
         survey.updateFromDto(dto);

--- a/src/main/java/com/jdc/recipe_service/util/ActionImageService.java
+++ b/src/main/java/com/jdc/recipe_service/util/ActionImageService.java
@@ -2,11 +2,13 @@
 package com.jdc.recipe_service.util;
 
         import com.jdc.recipe_service.domain.type.RobotType;
+        import lombok.extern.slf4j.Slf4j;
         import org.springframework.stereotype.Component;
 
         import java.util.Set;
 
 @Component
+@Slf4j
 public class ActionImageService {
 
     private static final String BASE_PATH = "images/actions";
@@ -30,6 +32,7 @@ public class ActionImageService {
      */
     public String generateImageKey(RobotType robotType, String action) {
         if (!isSupportedAction(action)) {
+            log.warn("지원하지 않는 조리 액션입니다: {}", action);
             return null;
         }
         String typeFolder = robotType.name().toLowerCase();

--- a/src/main/java/com/jdc/recipe_service/util/S3Util.java
+++ b/src/main/java/com/jdc/recipe_service/util/S3Util.java
@@ -10,9 +10,6 @@ import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
-import java.io.InputStream;
-import java.net.URL;
-import java.net.URLConnection;
 import java.time.Duration;
 import java.util.List;
 
@@ -88,27 +85,6 @@ public class S3Util {
         } catch (S3Exception e) {
             return false;
         }
-    }
-
-    public String uploadFromUrl(String externalUrl, String s3Key) throws Exception {
-        ensureBucketExists();
-        URL url = new URL(externalUrl);
-        URLConnection conn = url.openConnection();
-        String contentType = conn.getContentType();
-        long contentLength = conn.getContentLengthLong();
-        InputStream inputStream = conn.getInputStream();
-
-        PutObjectRequest putReq = PutObjectRequest.builder()
-                .bucket(bucketName)
-                .key(s3Key)
-                .contentType(contentType)
-                .contentLength(contentLength)
-                .build();
-
-        s3Client.putObject(putReq, RequestBody.fromInputStream(inputStream, contentLength));
-        inputStream.close();
-
-        return s3Key;
     }
 
     /**

--- a/src/main/java/com/jdc/recipe_service/util/UnitService.java
+++ b/src/main/java/com/jdc/recipe_service/util/UnitService.java
@@ -40,7 +40,7 @@ public class UnitService {
                     .toList();
 
         } catch (Exception e) {
-            throw new RuntimeException("units.csv 로드 실패", e);
+            throw new IllegalStateException("units.csv 로드 실패", e);
         }
     }
 
@@ -55,6 +55,6 @@ public class UnitService {
     }
 
     public Optional<String> getDefaultUnit(String ingredientName) {
-        return Optional.ofNullable(defaultUnitByIngredient.get(ingredientName));
+        return Optional.ofNullable(defaultUnitByIngredient.get(ingredientName.trim()));
     }
 }

--- a/src/test/java/com/jdc/recipe_service/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/CommentLikeServiceTest.java
@@ -51,7 +51,7 @@ class CommentLikeServiceTest {
         ReflectionTestUtils.setField(existing, "id", 200L);
 
         when(commentLikeRepository.findByCommentIdAndUserId(100L, 10L))
-                .thenReturn(existing);
+                .thenReturn(Optional.of(existing));
 
         boolean result = commentLikeService.toggleLike(100L, 10L);
         assertFalse(result);


### PR DESCRIPTION
**Title:** refactor: 종합 리팩토링 및 기능 개선

### 주요 변경 사항

1. **RecipeService 구조 개선 및 marketPrice 계산 로직 통합**
   - create/update/delete 등 주요 메서드 정리 및 중복 제거  
   - marketPrice 계산 로직을 `calculateMarketPrice()` 메서드로 통합  
   - `DEFAULT_MARGIN_PERCENT(30)` 상수로 추출  
   - 레시피 수정 시 `totalCost` 변경 시에만 marketPrice 재계산  
   - `flush`/`clear` 위치 명확히 설정하여 엔티티 상태 일관성 확보  

2. **AI 프롬프트 경량화 및 PromptBuilder 단순화**
   - **OpenAiClientService**  
     - 하드코딩된 `SYSTEM_PROMPT` 제거  
     - `@PostConstruct initializeSystemPrompt()` 에서 `UnitService` 로부터 `allowedUnits`/`unitMapping` 동적 생성  
     - JSON 예시 및 출력 규칙을 함수 호출 기반으로 위임  
   - **PromptBuilder**  
     - `UnitService` 의존성 제거  
     - `buildPrompt()` 메서드는 매 요청마다 변하는 정보(페르소나, 재료 목록, dishType, 조리 시간, 인분, 매운맛·알레르기·태그 등)만 포함  

3. **기타 리팩토링 & 개선 사항**
   - RecipeIngredientService 리팩토링 및 로깅 개선  
   - 댓글/대댓글 생성 시 User 객체 직접 전달 방식 통일 및 중복 로직 정리  
   - 태그 저장/수정 시 null 방어 로직 추가 및 안정성 개선  
   - 미사용 메서드 `uploadFromUrl` 및 presigned URL 생성 메서드 제거  
   - ActionImageService에 지원하지 않는 조리 액션 로깅 추가  
   - SurveyService 중복 `findByUserId` 호출 제거  
   - UnitService 예외 처리 개선 및 `getDefaultUnit()` 안정성 향상  
   - rating 저장 시 불필요한 변수 제거로 코드 간결화  
   - CommentLikeService.toggleLike()에서 `Optional<CommentLike>` 기반 삭제 처리로 개선  
   - RecipeSearchService  
     - 중복 정렬 로직 `sortRecipes()` 메서드로 분리  
     - `generateImageUrl()` 적용 위치 일관화  

### 테스트
- RecipeServiceTest, RecipeSearchServiceTest, CommentLikeServiceTest 등 단위 테스트 통과  
- 기존 기능과 동작 동일성 수동 검증 완료
