### PR TITLE
feat: PromptBuilder에 quantity 포맷 검증 지시 추가 및 OpenAiClientService에 AI JSON INFO 로깅 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
+++ b/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
@@ -14,12 +14,14 @@ import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.timelimiter.annotation.TimeLimiter;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OpenAiClientService {
 
     private final OpenAIClient client;
@@ -114,6 +116,7 @@ public class OpenAiClientService {
             }
             String json = completion.choices().get(0).message().content()
                     .orElseThrow(() -> new CustomException(ErrorCode.AI_RECIPE_GENERATION_FAILED, "AI 응답 내용이 없습니다."));
+            log.info("🔍 AI 생성 JSON ▶▶\n{}", json);
             try {
                 return objectMapper.readValue(json, RecipeCreateRequestDto.class);
             } catch (Exception e) {

--- a/src/main/java/com/jdc/recipe_service/util/PromptBuilder.java
+++ b/src/main/java/com/jdc/recipe_service/util/PromptBuilder.java
@@ -54,26 +54,34 @@ public class PromptBuilder {
                 ? String.format("Few-Shot 예시는 2인분 기준이다. 너는 반드시 %.1f인분에 맞게 각 재료의 quantity를 비례하여 조정해야 한다. (계산식: 예시 양 × (%.1f ÷ 2))", request.getServings(), request.getServings())
                 : "인분 수가 제공되지 않았으므로, 2인분 기준으로 레시피를 생성해줘.";
 
+        String quantityRules = """
+                - quantity 필드는 오직 숫자(소수점 구분 ‘.’)만 포함하세요. 분수(1/2) 대신 0.5 형태로 변환할 것.
+                 - 단위(unit) 정보는 절대로 quantity에 포함하지 말고 unit 필드에만 표기하세요.
+                """;
+
+        String specialInstructions = servingsInstruction + "\n" + quantityRules;
+
+
         return String.format("""
-            아래 요청 조건에 맞춰 레시피 JSON을 생성해줘.
-
-            [페르소나]
-            %s
-
-            [요청 조건]
-            - DB에 이미 있는 재료: [%s]
-            - DB에 없는 재료: [%s]
-            - 요리 유형: %s
-            - 희망 조리 시간: %s
-            - 인분 수: %s
-            - 매운맛 선호도: %s/5
-            - 알레르기 정보: %s
-            - 주요 재료: %s
-            - 요청 태그: %s
-            
-            [특별 지시]
-            %s
-            """,
+                        아래 요청 조건에 맞춰 레시피 JSON을 생성해줘.
+                        
+                        [페르소나]
+                        %s
+                        
+                        [요청 조건]
+                        - DB에 이미 있는 재료: [%s]
+                        - DB에 없는 재료: [%s]
+                        - 요리 유형: %s
+                        - 희망 조리 시간: %s
+                        - 인분 수: %s
+                        - 매운맛 선호도: %s/5
+                        - 알레르기 정보: %s
+                        - 주요 재료: %s
+                        - 요청 태그: %s
+                        
+                        [특별 지시]
+                        %s
+                        """,
                 persona,
                 knownList,
                 unknownList,
@@ -86,7 +94,7 @@ public class PromptBuilder {
                 allergyPref != null && !allergyPref.isBlank() ? allergyPref : "없음",
                 String.join(", ", request.getIngredients()),
                 tagsJson,
-                servingsInstruction
+                specialInstructions
         );
     }
 }


### PR DESCRIPTION
…SON INFO 로깅 추가## 변경 배경
- AI가 반환하는 `ingredients[].quantity` 포맷(분수, 단위 혼합 등)이 백엔드 검증을 통과하지 못해 400 에러 발생
- AI가 생성한 원시 JSON을 바로 확인할 수 있는 로깅이 필요

## 주요 변경 사항
1. **PromptBuilder**
   - `[특별 지시]` 블록에 quantity 포맷 검증 규칙 추가  
     - 오직 숫자(소수점 ‘.’)만 허용, 분수(1/2) 대신 0.5 형태로 변환  
     - 단위는 절대로 `quantity`에 포함하지 않고 `unit` 필드로만 표기  
2. **OpenAiClientService**
   - AI가 생성한 JSON을 `log.info(...)`로 출력하도록 변경  
   - `@Slf4j` 애노테이션 유지, INFO 레벨에서도 항상 노출  
3. **로그 설정**
   - `application.properties`에 별도 설정 없이도 `com.jdc.recipe_service.service` 패키지 INFO 레벨 로깅 활성화

## 테스트
- 로컬 서버 재배포 후, AI 호출 시 콘솔에 JSON 출력 확인  
- 수량 포맷 규칙이 프롬프트에 제대로 반영되어 “0.5” 등 숫자 형태로 생성되는지 검증  
