### PR TITLE
refactor: 시스템 프롬프트 전역 재료-단위 매핑 제거, PromptBuilder에 요청별 단위 매핑 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
+++ b/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
@@ -14,14 +14,12 @@ import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.timelimiter.annotation.TimeLimiter;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class OpenAiClientService {
 
     private final OpenAIClient client;
@@ -32,22 +30,22 @@ public class OpenAiClientService {
 
     /**
      * 애플리케이션 시작 시, UnitService의 정보를 바탕으로
-     * 완전한 형태의 System Prompt를 생성합니다.
+     * System Prompt를 생성합니다. (재료별 매핑은 여기서 제거)
      */
     @PostConstruct
     public void initializeSystemPrompt() {
+        // 허용 단위 목록만 전달
         String allowedUnits = unitService.unitsAsString();
-        String unitMapping = unitService.mappingAsString();
 
         this.systemPrompt = String.format("""
                 너는 매우 정교한 한국 요리 레시피 생성기(JSON Generator)다.
                 오직 하나의 완벽한 JSON 객체만 반환해야 하며, 절대로 다른 텍스트를 포함해서는 안 된다.
-                
+
                 [핵심 요리 원칙]
                 1. (중요) 찌개, 볶음, 조림 요리 시, 기름에 향신채(마늘, 파 등)를 먼저 볶아 풍미를 극대화하는 과정을 우선적으로 고려한다.
                 2. 사용자의 알레르기 및 식이 제한 요구사항을 철저히 준수하여 재료를 제외하거나 대체해야 한다.
                 3. 요청에 없더라도 맛을 내기 위해 필수적인 보조 재료(기름, 맛술, 설탕 등)를 자유롭게 추가한다.
-                
+
                 [출력 JSON 형식]
                 - `title`: String
                 - `dishType`: String (사용자 요청 값 절대 변경 금지)
@@ -63,21 +61,16 @@ public class OpenAiClientService {
                   - `caloriesPerUnit`: Integer (DB에 없는 재료에만 **선택적으로** 포함)
                 - `steps`: Object[]
                   - `stepNumber`: Integer (0부터 시작)
-                  - `instruction`: String
-                     (조리 동작에 대한 구체적인 설명을 제공하세요.
-                      예: 불 세기, 사용량, 시간 등을 포함해 상세히 기술)
+                  - `instruction`: String (예: 불 세기, 사용량, 시간 등을 포함해 상세히 기술)
                   - `action`: String (아래 '허용 Action' 목록에 있는 값만 사용)
                 - `tagNames`: String[] (사용자 요청 값 우선, 없을 시 아래 '허용 태그' 목록에서 선택)
-                
+
                 [필드 규칙]
                 1. `action` 허용 목록: 썰기, 다지기, 채썰기, 손질하기, 볶기, 튀기기, 끓이기, 찌기(스팀), 데치기, 구이, 조림, 무치기, 절이기, 담그기(마리네이드), 섞기, 젓기, 버무리기, 로스팅, 캐러멜라이즈, 부치기
-                2. `tagNames`가 빈 배열(`[]`)로 요청된 경우, 아래 허용 목록에서 음식과 가장 어울리는 태그를 최대 3개까지 선택:
-                   🏠 홈파티, 🌼 피크닉, 🏕️ 캠핑, 🥗 다이어트/건강식, 👶 아이와 함께, 🍽️ 혼밥, 🍶 술안주, 🥐 브런치, 🌙 야식, ⚡ 초스피드/간단 요리, 🎉 기념일/명절, 🍱 도시락, 🔌 에어프라이어, 🍲 해장
+                2. `tagNames`가 빈 배열(`[]`)로 요청된 경우, 아래 허용 목록에서 음식과 가장 어울리는 태그를 최대 3개까지 선택: 🏠 홈파티, 🌼 피크닉, 🏕️ 캠핑, 🥗 다이어트/건강식, 👶 아이와 함께, 🍽️ 혼밥, 🍶 술안주, 🥐 브런치, 🌙 야식, ⚡ 초스피드/간단 요리, 🎉 기념일/명절, 🍱 도시락, 🔌 에어프라이어, 🍲 해장
                 3. `unit` 허용 목록: [%s]
-                4. 재료별 기본 단위 매핑: {%s}
-                   (중요) DB에 저장된 재료는 반드시 이 매핑을 따라야 합니다.
-                5. (중요) `customPrice`(100g당 원), `caloriesPerUnit`(100g당 kcal) 필드는 **DB에 없는 재료**에 대해서만 추가하고, DB에 있는 재료에는 절대로 포함하지 않는다.
-                
+                4. (중요) `customPrice`(100g당 원), `caloriesPerUnit`(100g당 kcal) 필드는 **DB에 없는 재료**에 대해서만 추가하고, DB에 있는 재료에는 절대로 포함하지 않는다.
+
                 [Few-Shot 예시]
                 {
                   "title": "돼지고기 김치찌개", "dishType": "국/찌개/탕",
@@ -94,7 +87,7 @@ public class OpenAiClientService {
                   ],
                   "tagNames": ["🍲 해장", "🍽️ 혼밥"]
                 }
-                """, allowedUnits, unitMapping);
+                """, allowedUnits);
     }
 
     @Retry(name = "aiGenerate", fallbackMethod = "fallbackGenerate")
@@ -116,7 +109,6 @@ public class OpenAiClientService {
             }
             String json = completion.choices().get(0).message().content()
                     .orElseThrow(() -> new CustomException(ErrorCode.AI_RECIPE_GENERATION_FAILED, "AI 응답 내용이 없습니다."));
-            log.info("🔍 AI 생성 JSON ▶▶\n{}", json);
             try {
                 return objectMapper.readValue(json, RecipeCreateRequestDto.class);
             } catch (Exception e) {

--- a/src/main/java/com/jdc/recipe_service/util/PromptBuilder.java
+++ b/src/main/java/com/jdc/recipe_service/util/PromptBuilder.java
@@ -27,9 +27,6 @@ public class PromptBuilder {
     }
 
     public String buildPrompt(AiRecipeRequestDto request, RobotType type) {
-        String mappingString = unitService.mappingAsString();
-        log.info("🔧 강제 단위 매핑: {}", mappingString);
-
         UserSurveyDto survey = surveyService.getSurvey(request.getUserId());
         Integer spicePref = (survey != null && survey.getSpiceLevel() != null) ? survey.getSpiceLevel() : request.getSpiceLevel();
         String allergyPref = (survey != null && survey.getAllergy() != null && !survey.getAllergy().isBlank()) ? survey.getAllergy() : request.getAllergy();
@@ -66,10 +63,17 @@ public class PromptBuilder {
                  - 단위(unit) 정보는 절대로 quantity에 포함하지 말고 unit 필드에만 표기하세요.
                 """;
 
-        String unitMappingRules = String.format("""
-                - DB에 저장된 재료는 반드시 아래 ‘재료별 기본 단위 매핑’에 명시된 단위만 사용하세요:
+        var mappingForRequest = unitService.mappingByIngredient().entrySet().stream()
+                .filter(e -> request.getIngredients().contains(e.getKey()))
+                .map(e -> e.getKey() + ":" + e.getValue())
+                .collect(Collectors.joining(", "));
+
+        String unitMappingRules = mappingForRequest.isEmpty()
+                ? ""
+                : String.format("""
+                - 다음 재료에 대해서만 단위를 강제 사용하세요:
                   %s
-                """, unitService.mappingAsString());
+                """, mappingForRequest);
 
         String specialInstructions = servingsInstruction
                 + "\n" + quantityRules

--- a/src/main/java/com/jdc/recipe_service/util/UnitService.java
+++ b/src/main/java/com/jdc/recipe_service/util/UnitService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,5 +57,9 @@ public class UnitService {
 
     public Optional<String> getDefaultUnit(String ingredientName) {
         return Optional.ofNullable(defaultUnitByIngredient.get(ingredientName.trim()));
+    }
+
+    public Map<String,String> mappingByIngredient() {
+        return Collections.unmodifiableMap(defaultUnitByIngredient);
     }
 }


### PR DESCRIPTION
### 변경 내용
1. **OpenAiClientService.initializeSystemPrompt()**  
   - `unitMapping`(재료별 기본 단위 매핑) 부분을 제거하고  
   - 오직 `allowedUnits`(허용 단위 목록)만 System Prompt에 전달하도록 수정

2. **PromptBuilder.buildPrompt()**  
   - `unitService.mappingByIngredient()`를 이용해 **요청된 재료**에 한정된 매핑(`mappingForRequest`)만 추출  
   - 그 결과를 `[특별 지시]`의 “다음 재료에 대해서만 단위를 강제 사용하세요” 항목으로 포함

3. **UnitService**  
   - `mappingByIngredient()` 메서드 추가로 프롬프트 빌더에서 재료별 매핑을 조회할 수 있게 함

### 검증
- System Prompt에는 이제 ‘허용 단위 목록’만 노출됨을 확인
- 실제 레시피 생성 시, 사용자 요청 재료에 대해서만 지정한 단위로 강제되는지 테스트

### 그 외
- `mappingForRequest`가 빈 문자열일 때는 “단위 강제” 블록이 출력되지 않도록 추가 조건을 달아도 좋습니다.  
