### PR TITLE
feat(search): 레시피 검색 정렬 기능에 평균 평점 및 조리 시간 필터 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/domain/repository/RecipeQueryRepositoryImpl.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/RecipeQueryRepositoryImpl.java
@@ -179,6 +179,10 @@ public class RecipeQueryRepositoryImpl implements RecipeQueryRepository {
             switch (order.getProperty()) {
                 case "likeCount":
                     return new OrderSpecifier<>(direction, recipe.likes.size());
+                case "cookingTime":
+                    return new OrderSpecifier<>(direction, recipe.cookingTime);
+                case "avgRating":
+                    return new OrderSpecifier<>(direction, recipe.avgRating);
                 case "createdAt":
                 default:
                     return new OrderSpecifier<>(direction, recipe.createdAt);

--- a/src/main/java/com/jdc/recipe_service/opensearch/dto/RecipeDocument.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/dto/RecipeDocument.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Data
@@ -23,4 +24,5 @@ public class RecipeDocument {
     private Boolean  isAiGenerated;
     private List<Long> ingredientIds;
     private Integer ingredientCount;
+    private BigDecimal avgRating;
 }

--- a/src/main/java/com/jdc/recipe_service/opensearch/service/RecipeIndexingService.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/service/RecipeIndexingService.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -123,7 +124,8 @@ public class RecipeIndexingService {
                     "imageUrl":    { "type":"keyword" },
                     "isAiGenerated":{ "type":"boolean" },
                     "ingredientIds":  { "type": "long" },
-                    "ingredientCount":{ "type": "integer" }
+                    "ingredientCount":{ "type": "integer" },
+                    "avgRating":      { "type": "double" }
                   }
                 }
                 """, XContentType.JSON);
@@ -197,6 +199,9 @@ public class RecipeIndexingService {
 
         int likeCount = likeRepository.countByRecipeId(recipe.getId());
 
+        BigDecimal rating = Optional.ofNullable(recipe.getAvgRating())
+                .orElse(BigDecimal.ZERO);
+
         return RecipeDocument.builder()
                 .id(recipe.getId())
                 .title(recipe.getTitle())
@@ -209,6 +214,7 @@ public class RecipeIndexingService {
                 .isAiGenerated(recipe.isAiGenerated())
                 .ingredientIds(ids)
                 .ingredientCount(ids.size())
+                .avgRating(rating)
                 .build();
     }
 


### PR DESCRIPTION
## 변경 사항
- OpenSearch 인덱스 매핑에 `avgRating` (double) 필드 추가
- `RecipeDocument` DTO에 `avgRating` 필드 추가 및 인덱싱 로직에 값 세팅
- QueryDSL 구현체(`RecipeQueryRepositoryImpl`)의 `getOrderSpecifier`에
  - `case "avgRating"` 분기 추가
  - `case "cookingTime"` 분기 추가
- Swagger/OpenAPI 문서에 `avgRating`, `cookingTime` 정렬 키 안내
