### PR TITLE
feat: AI 생성 모델을 OpenAI에서 Anthropic Claude로 교체

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,7 @@ jobs:
           REPLICATE_TOKEN: ${{ secrets.REPLICATE_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       - name: Deploy to ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -83,8 +83,6 @@ dependencies {
 	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
-	implementation 'com.openai:openai-java:2.8.1'
-
 	implementation(platform("io.github.resilience4j:resilience4j-bom:2.0.2"))
 	implementation("io.github.resilience4j:resilience4j-spring-boot3")
 	implementation("io.github.resilience4j:resilience4j-circuitbreaker")
@@ -94,6 +92,13 @@ dependencies {
 	implementation "org.springframework.retry:spring-retry"
 
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	implementation 'com.openai:openai-java:2.8.1'
+
+	implementation 'com.anthropic:anthropic-java:0.3.0'
+	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 }
 
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile

--- a/ecs-task-definition-template.json
+++ b/ecs-task-definition-template.json
@@ -38,7 +38,8 @@
         { "name": "OPENSEARCH_HOST", "value": "${OPENSEARCH_HOST}" },
         { "name": "REPLICATE_TOKEN", "value": "${REPLICATE_TOKEN}" },
         { "name": "OPENAI_API_KEY", "value": "${OPENAI_API_KEY}" },
-        { "name": "REDIS_PASSWORD", "value": "${REDIS_PASSWORD}" }
+        { "name": "REDIS_PASSWORD", "value": "${REDIS_PASSWORD}" },
+        { "name": "ANTHROPIC_API_KEY", "value": "${ANTHROPIC_API_KEY}" }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
+++ b/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-@Service
+//@Service
 @RequiredArgsConstructor
 public class OpenAiClientService {
 

--- a/src/main/java/com/jdc/recipe_service/service/RecipeService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeService.java
@@ -53,7 +53,8 @@ public class RecipeService {
     private final ObjectMapper objectMapper;
     private final ActionImageService actionImageService;
     private final SurveyService surveyService;
-    private final OpenAiClientService aiService;
+//    private final OpenAiClientService aiService;
+    private final ClaudeClientService claudeClientService;
     private final UnitService unitService;
     private final PromptBuilder promptBuilder;
     private final ApplicationEventPublisher publisher;
@@ -191,7 +192,7 @@ public class RecipeService {
 
         for (int attempt = 1; attempt <= MAX_TRIES; attempt++) {
             try {
-                generatedDto = aiService.generateRecipeJson(prompt).join();
+                generatedDto = claudeClientService.generateRecipeJson(prompt).join();
                 break;
             } catch (RuntimeException e) {
                 if (attempt == MAX_TRIES) {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -76,6 +76,9 @@ cloud:
 openai:
   api-key: ${OPENAI_API_KEY}
 
+anthropic:
+  api-key: ${ANTHROPIC_API_KEY}
+
 logging:
   level:
     com.jdc.recipe_service.service.AsyncImageService: WARN
@@ -94,4 +97,4 @@ resilience4j:
   timelimiter:
     instances:
       aiGenerate:
-        timeout-duration: 60s
+        timeout-duration: 120s


### PR DESCRIPTION
기존 OpenAI(GPT-4-Turbo) 모델의 높은 비용과 응답 시간으로 인해 발생하는 Vercel 타임아웃 문제를 해결하기 위해, AI 레시피 생성 모델을 Anthropic사의 Claude 3 Sonnet으로 교체합니다.

주요 변경 사항:
- RestTemplate을 사용하여 Claude API를 직접 호출하는 ClaudeClientService 신규 구현
- RestTemplate의 타임아웃 설정을 위한 RestTemplateConfig 추가
- RecipeService에서 AI 서비스 호출 대상을 ClaudeClientService로 변경
- 기존 OpenAiClientService 및 관련 설정은 유지 (향후 A/B 테스트나 롤백을 위해)