### PR TITLE
feat: ai model claude

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,7 @@ jobs:
           REPLICATE_TOKEN: ${{ secrets.REPLICATE_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       - name: Deploy to ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -83,8 +83,6 @@ dependencies {
 	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
-	implementation 'com.openai:openai-java:2.8.1'
-
 	implementation(platform("io.github.resilience4j:resilience4j-bom:2.0.2"))
 	implementation("io.github.resilience4j:resilience4j-spring-boot3")
 	implementation("io.github.resilience4j:resilience4j-circuitbreaker")
@@ -94,6 +92,13 @@ dependencies {
 	implementation "org.springframework.retry:spring-retry"
 
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	implementation 'com.openai:openai-java:2.8.1'
+
+	implementation 'com.anthropic:anthropic-java:0.3.0'
+	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 }
 
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile

--- a/ecs-task-definition-template.json
+++ b/ecs-task-definition-template.json
@@ -38,7 +38,8 @@
         { "name": "OPENSEARCH_HOST", "value": "${OPENSEARCH_HOST}" },
         { "name": "REPLICATE_TOKEN", "value": "${REPLICATE_TOKEN}" },
         { "name": "OPENAI_API_KEY", "value": "${OPENAI_API_KEY}" },
-        { "name": "REDIS_PASSWORD", "value": "${REDIS_PASSWORD}" }
+        { "name": "REDIS_PASSWORD", "value": "${REDIS_PASSWORD}" },
+        { "name": "ANTHROPIC_API_KEY", "value": "${ANTHROPIC_API_KEY}" }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/src/main/java/com/jdc/recipe_service/config/AnthropicConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/AnthropicConfig.java
@@ -1,0 +1,18 @@
+package com.jdc.recipe_service.config;
+
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.client.okhttp.AnthropicOkHttpClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AnthropicConfig {
+
+    @Bean
+    public AnthropicClient anthropicClient(@Value("${anthropic.api-key}") String apiKey) {
+        return AnthropicOkHttpClient.builder()
+                .apiKey(apiKey)
+                .build();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
+++ b/src/main/java/com/jdc/recipe_service/service/OpenAiClientService.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-@Service
+//@Service
 @RequiredArgsConstructor
 public class OpenAiClientService {
 

--- a/src/main/java/com/jdc/recipe_service/service/RecipeService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeService.java
@@ -53,7 +53,8 @@ public class RecipeService {
     private final ObjectMapper objectMapper;
     private final ActionImageService actionImageService;
     private final SurveyService surveyService;
-    private final OpenAiClientService aiService;
+//    private final OpenAiClientService aiService;
+    private final ClaudeClientService claudeClientService;
     private final UnitService unitService;
     private final PromptBuilder promptBuilder;
     private final ApplicationEventPublisher publisher;
@@ -191,7 +192,7 @@ public class RecipeService {
 
         for (int attempt = 1; attempt <= MAX_TRIES; attempt++) {
             try {
-                generatedDto = aiService.generateRecipeJson(prompt).join();
+                generatedDto = claudeClientService.generateRecipeJson(prompt).join();
                 break;
             } catch (RuntimeException e) {
                 if (attempt == MAX_TRIES) {

--- a/src/main/java/com/jdc/recipe_service/util/ClaudeClientService.java
+++ b/src/main/java/com/jdc/recipe_service/util/ClaudeClientService.java
@@ -1,0 +1,162 @@
+package com.jdc.recipe_service.util;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jdc.recipe_service.domain.dto.recipe.RecipeCreateRequestDto;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import io.github.resilience4j.timelimiter.annotation.TimeLimiter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class ClaudeClientService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${anthropic.api-key}")
+    private String apiKey;
+
+    private static final String API_URL = "https://api.anthropic.com/v1/messages";
+
+    @Retry(name = "aiGenerate", fallbackMethod = "fallbackGenerate")
+    @CircuitBreaker(name = "aiGenerate", fallbackMethod = "fallbackGenerate")
+    @TimeLimiter(name = "aiGenerate", fallbackMethod = "fallbackGenerate")
+    public CompletableFuture<RecipeCreateRequestDto> generateRecipeJson(String prompt) {
+        return CompletableFuture.supplyAsync(() -> {
+            RequestBody body = new RequestBody(
+                    "claude-3-sonnet-20240229",
+                    List.of(new Message("user", prompt)),
+                    1800,
+                    0.0,
+                    "너는 한국요리 전문가야. 오직 JSON 객체로만 응답해. 다른 부가적인 설명은 절대 추가하지 마."
+            );
+
+            // 2) 헤더
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("x-api-key", apiKey);
+            headers.set("anthropic-version", "2023-06-01"); // 필수
+
+            HttpEntity<RequestBody> entity = new HttpEntity<>(body, headers);
+
+            // 3) 호출
+            ResponseEntity<ResponseBody> res;
+            try {
+                res = restTemplate.exchange(API_URL, HttpMethod.POST, entity, ResponseBody.class);
+            } catch (RuntimeException e) {
+                throw new CustomException(
+                        ErrorCode.AI_RECIPE_GENERATION_FAILED,
+                        "Claude API 호출 실패: " + e.getMessage(), e
+                );
+            }
+
+            ResponseBody response = res.getBody();
+            if (response == null || response.content == null || response.content.isEmpty()) {
+                throw new CustomException(
+                        ErrorCode.AI_RECIPE_GENERATION_FAILED,
+                        "Claude API 응답이 비어 있습니다."
+                );
+            }
+
+            StringBuilder sb = new StringBuilder();
+            for (ContentBlock block : response.content) {
+                if ("text".equals(block.type) && block.text != null) {
+                    sb.append(block.text);
+                    if (!block.text.endsWith("\n")) sb.append('\n');
+                }
+            }
+            String raw = sb.toString().trim();
+            if (raw.isEmpty()) {
+                throw new CustomException(
+                        ErrorCode.AI_RECIPE_GENERATION_FAILED,
+                        "Claude API 응답에서 텍스트 블록을 찾지 못했습니다."
+                );
+            }
+
+            String json = extractJson(raw);
+            if (json.isEmpty()) {
+                throw new CustomException(
+                        ErrorCode.AI_RECIPE_GENERATION_FAILED,
+                        "AI 응답에서 유효한 JSON 객체를 찾을 수 없습니다."
+                );
+            }
+
+            try {
+                return objectMapper.readValue(json, RecipeCreateRequestDto.class);
+            } catch (Exception e) {
+                throw new CustomException(
+                        ErrorCode.INTERNAL_SERVER_ERROR,
+                        "AI JSON 파싱 실패: " + e.getMessage(), e
+                );
+            }
+        });
+    }
+
+    /** 응답 문자열에서 최상위 JSON 객체만 추출 */
+    private String extractJson(String response) {
+        Pattern pattern = Pattern.compile("\\{.*\\}", Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(response);
+        if (matcher.find()) return matcher.group();
+        return "";
+    }
+
+    private CompletableFuture<RecipeCreateRequestDto> fallbackGenerate(String prompt, Throwable ex) {
+        return CompletableFuture.failedFuture(
+                new CustomException(
+                        ErrorCode.AI_RECIPE_GENERATION_FAILED,
+                        "AI 레시피 생성 실패 (최대 재시도/서킷/타임아웃): " + ex.getMessage(),
+                        ex
+                )
+        );
+    }
+
+    @Data @AllArgsConstructor @NoArgsConstructor
+    private static class RequestBody {
+        public String model;
+
+        public List<Message> messages;
+
+        @JsonProperty("max_tokens")
+        public Integer maxTokens;
+
+        public Double temperature;
+
+        public String system;
+    }
+
+    @Data @AllArgsConstructor @NoArgsConstructor
+    private static class Message {
+        public String role;
+        public String content;
+    }
+
+    @Data @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class ResponseBody {
+        public String id;
+        public String type;
+        public List<ContentBlock> content;
+    }
+
+    @Data @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class ContentBlock {
+        public String type;
+        public String text;
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -76,6 +76,9 @@ cloud:
 openai:
   api-key: ${OPENAI_API_KEY}
 
+anthropic:
+  api-key: ${ANTHROPIC_API_KEY}
+
 logging:
   level:
     com.jdc.recipe_service.service.AsyncImageService: WARN
@@ -94,4 +97,4 @@ resilience4j:
   timelimiter:
     instances:
       aiGenerate:
-        timeout-duration: 60s
+        timeout-duration: 120s


### PR DESCRIPTION
기존 OpenAI(GPT-4-Turbo) 모델의 높은 비용과 응답 시간으로 인해 발생하는 Vercel 타임아웃 문제를 해결하기 위해, AI 레시피 생성 모델을 Anthropic사의 Claude 3 Sonnet으로 교체합니다.

주요 변경 사항:
- RestTemplate을 사용하여 Claude API를 직접 호출하는 ClaudeClientService 신규 구현
- RestTemplate의 타임아웃 설정을 위한 RestTemplateConfig 추가
- RecipeService에서 AI 서비스 호출 대상을 ClaudeClientService로 변경
- 기존 OpenAiClientService 및 관련 설정은 유지 (향후 A/B 테스트나 롤백을 위해)