### PR TITLE
Feature/service optimization v2

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/RestClientConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/RestClientConfig.java
@@ -1,0 +1,25 @@
+package com.jdc.recipe_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+
+        requestFactory.setConnectTimeout(Duration.ofSeconds(10));
+        requestFactory.setReadTimeout(Duration.ofSeconds(180));
+
+        return RestClient.builder()
+                .baseUrl("https://api.anthropic.com/v1")
+                .requestFactory(requestFactory)
+                .build();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
 
                             // 1) 로컬 전용: H2 콘솔, JWT 발급용 엔드포인트
                             .requestMatchers("/h2-console/**", "/local-token").permitAll()
+                            .requestMatchers("/actuator/**").permitAll()
                             .requestMatchers(HttpMethod.POST, "/login/oauth2/code/**").permitAll()
 
                             // 2) 공개 GET (인증 없이 모두 허용)
@@ -73,7 +74,8 @@ public class SecurityConfig {
                                     "/api/dish-types",
                                     "/api/tags",
                                     "/api/users/*",
-                                    "/api/users/*/recipes"
+                                    "/api/users/*/recipes",
+                                    "/api/v2/recipes/**"
                             ).permitAll()
 
                             // 3) 보호된 GET (JWT 필요)
@@ -106,7 +108,8 @@ public class SecurityConfig {
                                     "/api/me/fridge/items/bulk",
                                     "/api/recipes/*/private",
                                     "/api/recipes/*/finalize",
-                                    "/api/ws-ticket"
+                                    "/api/ws-ticket",
+                                    "/api/v2/recipes/status"
                             ).authenticated()
 
                             // 5) 보호된 PUT
@@ -212,7 +215,8 @@ public class SecurityConfig {
                                 "/api/tags",
                                 "/api/users/*",
                                 "/api/users/*/recipes",
-                                "/api/search/**"
+                                "/api/search/**",
+                                "/api/v2/recipes/**"
                         ).permitAll()
 
                         // 4) 인증 필요 POST
@@ -233,7 +237,8 @@ public class SecurityConfig {
                                 "/api/token/logout/all",
                                 "/api/recipes/*/private",
                                 "/api/recipes/*/finalize",
-                                "/api/ws-ticket"
+                                "/api/ws-ticket",
+                                "/api/v2/recipes/status"
                         ).authenticated()
 
                         // 5) 인증 필요 PUT

--- a/src/main/java/com/jdc/recipe_service/controller/RecipeController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/RecipeController.java
@@ -32,6 +32,7 @@ public class RecipeController {
     @Operation(summary = "레시피 생성 + 이미지 Presigned URL 발급", description = "레시피 생성 요청과 함께 이미지 업로드용 Presigned URL을 발급합니다. source 값에 따라 AI 생성 또는 유저 입력을 구분합니다.")
     public ResponseEntity<PresignedUrlResponse> createRecipeWithImages(
             @Parameter(description = "레시피 생성 출처 (예: AI, USER)") @RequestParam(value = "source", required = false) String source,
+            @Parameter(description = "AI 모델 선택 (기본값: openai, 선택: claude)") @RequestParam(value = "aiModel", defaultValue = "openai") String aiModel,
             @Parameter(description = "AI 레시피 생성 시 사용할 로봇 타입 (예: CLASSIC, FUNNY 등)") @RequestParam(value = "robotType", required = false) RobotType robotTypeParam,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "레시피 생성 요청 DTO (이미지 키 포함)") @RequestBody @Valid RecipeWithImageUploadRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -42,13 +43,27 @@ public class RecipeController {
 
         RecipeSourceType sourceType = RecipeSourceType.fromNullable(source);
 
-        PresignedUrlResponse response = recipeService.createRecipeWithAiLogic(
-                sourceType,
-                robotTypeParam,
-                request,
-                userDetails.getUser().getId()
-        );
+        Long userId = userDetails.getUser().getId();
+        PresignedUrlResponse response;
 
+        if (sourceType == RecipeSourceType.AI) {
+            if ("claude".equalsIgnoreCase(aiModel)) {
+                response = recipeService.createRecipeWithAiLogicV2(
+                        robotTypeParam,
+                        request,
+                        userId
+                );
+            } else {
+                response = recipeService.createRecipeWithAiLogic(
+                        sourceType,
+                        robotTypeParam,
+                        request,
+                        userId
+                );
+            }
+        } else {
+            response = recipeService.createUserRecipeAndGenerateUrls(request, userId, sourceType);
+        }
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/src/main/java/com/jdc/recipe_service/controller/RecipeSearchControllerV2.java
+++ b/src/main/java/com/jdc/recipe_service/controller/RecipeSearchControllerV2.java
@@ -1,0 +1,94 @@
+package com.jdc.recipe_service.controller;
+
+import com.jdc.recipe_service.domain.dto.RecipeSearchCondition;
+import com.jdc.recipe_service.domain.dto.recipe.v2.RecipeDetailStaticDto;
+import com.jdc.recipe_service.domain.dto.recipe.v2.RecipeSimpleStaticDto;
+import com.jdc.recipe_service.domain.dto.recipe.v2.RecipeStatusDto;
+import com.jdc.recipe_service.domain.entity.Recipe;
+import com.jdc.recipe_service.domain.repository.RecipeRepository;
+import com.jdc.recipe_service.domain.type.RecipeImageStatus;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.security.CustomUserDetails;
+import com.jdc.recipe_service.service.RecipeSearchServiceV2;
+import com.jdc.recipe_service.service.RecipeStatusService;
+import com.jdc.recipe_service.util.DeferredResultHolder;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v2/recipes")
+@RequiredArgsConstructor
+@Tag(name = "레시피 검색 V2 API", description = "성능이 개선된 V2 레시피 API입니다.")
+public class RecipeSearchControllerV2 {
+
+    private final RecipeSearchServiceV2 recipeSearchServiceV2;
+    private final RecipeStatusService recipeStatusService;
+    private final RecipeRepository recipeRepository;
+    private final DeferredResultHolder deferredResultHolder;
+
+    @GetMapping("/{id}")
+    @Operation(summary = "레시피 상세 조회 (정적)", description = "레시피 ID를 기반으로 정적 상세 정보를 조회합니다.")
+    public DeferredResult<ResponseEntity<RecipeDetailStaticDto>> getRecipeDetail(
+            @PathVariable("id") Long recipeId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long currentUserId = userDetails != null ? userDetails.getUser().getId() : null;
+        DeferredResult<ResponseEntity<RecipeDetailStaticDto>> deferredResult = new DeferredResult<>();
+        Recipe recipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
+        boolean ai = Boolean.TRUE.equals(recipe.isAiGenerated());
+        RecipeImageStatus status = recipe.getImageStatus();
+        if (!ai || status == RecipeImageStatus.READY) {
+            RecipeDetailStaticDto staticDto = recipeSearchServiceV2.getRecipeDetail(recipeId, currentUserId);
+            deferredResult.setResult(ResponseEntity.ok(staticDto));
+            return deferredResult;
+        }
+        deferredResultHolder.add(recipeId, (DeferredResult<ResponseEntity<?>>)(Object) deferredResult);
+        return deferredResult;
+    }
+
+    @PostMapping("/status")
+    @Operation(summary = "레시피 상태 정보 조회 (동적)", description = "레시피 ID 목록으로 동적 정보(좋아요, 댓글 등)를 일괄 조회합니다.")
+    public ResponseEntity<Map<Long, RecipeStatusDto>> getStatuses(
+            @RequestBody List<Long> recipeIds,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails != null ? userDetails.getUser().getId() : null;
+        if (recipeIds == null || recipeIds.isEmpty()) {
+            return ResponseEntity.ok(Collections.emptyMap());
+        }
+        Map<Long, RecipeStatusDto> statuses = recipeStatusService.getStatuses(recipeIds, userId);
+        return ResponseEntity.ok(statuses);
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "조건 검색 (v1 스타일)", description = "제목, 디시타입, 태그명을 조합하여 레시피를 검색합니다.")
+    public ResponseEntity<Page<RecipeSimpleStaticDto>> search(
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) String dishType,
+            @RequestParam(required = false) List<String> tagNames,
+            @RequestParam(required = false) Boolean isAiGenerated,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails != null ? userDetails.getUser().getId() : null;
+        RecipeSearchCondition cond = new RecipeSearchCondition(q, dishType, tagNames, isAiGenerated);
+        Page<RecipeSimpleStaticDto> page = recipeSearchServiceV2.searchRecipes(cond, pageable, userId);
+        return ResponseEntity.ok(page);
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/recipe/v2/RecipeDetailStaticDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/recipe/v2/RecipeDetailStaticDto.java
@@ -1,0 +1,91 @@
+package com.jdc.recipe_service.domain.dto.recipe.v2;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.jdc.recipe_service.domain.dto.recipe.ingredient.RecipeIngredientDto;
+import com.jdc.recipe_service.domain.dto.recipe.step.RecipeStepDto;
+import com.jdc.recipe_service.domain.dto.user.UserDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecipeDetailStaticDto {
+
+    @Schema(description = "레시피 ID")
+    private Long id;
+
+    @Schema(description = "레시피 제목")
+    private String title;
+
+    @Schema(description = "요리 유형 (dishType)")
+    private String dishType;
+
+    @Schema(description = "레시피 설명")
+    private String description;
+
+    @Schema(description = "예상 조리 시간 (분 단위)")
+    private Integer cookingTime;
+
+    @Schema(description = "대표 이미지 URL")
+    private String imageUrl;
+
+    @Schema(description = "대표 이미지 Key")
+    private String imageKey;
+
+    @Schema(description = "대표 이미지 상태 정보( PENDING, ACTIVE)")
+    private String imageStatus;
+
+    @Schema(description = "유튜브 링크 URL")
+    private String youtubeUrl;
+
+    @Schema(description = "조리 도구 목록")
+    private List<String> cookingTools;
+
+    @Schema(description = "AI 생성 여부")
+    private boolean isAiGenerated;
+
+    @Schema(description = "공개 여부")
+    private boolean isPrivate;
+
+    @Schema(description = "레시피 인분 수")
+    private Integer servings;
+
+    @Schema(description = "작성자 정보")
+    private UserDto author;
+
+    @Schema(description = "태그 목록")
+    private List<String> tags;
+
+    @Schema(description = "재료 목록")
+    private List<RecipeIngredientDto> ingredients;
+
+    @Schema(description = "조리 단계 목록")
+    private List<RecipeStepDto> steps;
+
+    @Schema(description = "총 재료 비용")
+    private Integer totalIngredientCost;
+
+    @Schema(description = "총 칼로리")
+    private Double totalCalories;
+
+    @Schema(description = "예상 마켓 가격")
+    private Integer marketPrice;
+
+    @Schema(description = "절약 금액")
+    private Integer savings;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    @Schema(description = "생성일시 (UTC)")
+    private LocalDateTime createdAt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    @Schema(description = "업데이트일시 (UTC)")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/recipe/v2/RecipeSimpleStaticDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/recipe/v2/RecipeSimpleStaticDto.java
@@ -1,0 +1,55 @@
+package com.jdc.recipe_service.domain.dto.recipe.v2;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@Schema(description = "레시피 간략 정적 정보 DTO")
+public class RecipeSimpleStaticDto {
+
+    @Schema(description = "레시피 ID")
+    private Long id;
+
+    @Schema(description = "레시피 제목")
+    private String title;
+
+    @Schema(description = "레시피 대표 이미지 URL")
+    private String imageUrl;
+
+    @Schema(description = "작성자 ID")
+    private Long authorId;
+
+    @Schema(description = "작성자 닉네임")
+    private String authorName;
+
+    @Schema(description = "작성자 프로필 이미지")
+    private String profileImage;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    @Schema(description = "생성일시 (UTC)")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "예상 조리 시간 (분 단위)")
+    private Integer cookingTime;
+
+    @QueryProjection
+    public RecipeSimpleStaticDto(Long id, String title, String imageUrl, Long authorId, String authorName, String profileImage, LocalDateTime createdAt, Integer cookingTime) {
+        this.id = id;
+        this.title = title;
+        this.imageUrl = imageUrl;
+        this.authorId = authorId;
+        this.authorName = authorName;
+        this.profileImage = profileImage;
+        this.createdAt = createdAt;
+        this.cookingTime = cookingTime;
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/recipe/v2/RecipeStatusDto.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/recipe/v2/RecipeStatusDto.java
@@ -1,0 +1,21 @@
+package com.jdc.recipe_service.domain.dto.recipe.v2;
+
+import com.jdc.recipe_service.domain.dto.comment.CommentDto;
+import lombok.*;
+
+import java.util.List;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecipeStatusDto {
+    private long likeCount;
+    private boolean likedByCurrentUser;
+    private boolean favoriteByCurrentUser;
+    private Double avgRating;
+    private Integer myRating;
+    private long ratingCount;
+    private long commentCount;
+    private List<CommentDto> comments;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/repository/RecipeFavoriteRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/RecipeFavoriteRepository.java
@@ -5,9 +5,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface RecipeFavoriteRepository extends JpaRepository<RecipeFavorite, Long> {
@@ -20,4 +24,6 @@ public interface RecipeFavoriteRepository extends JpaRepository<RecipeFavorite, 
 
     void deleteByRecipeId(Long recipeId);
 
+    @Query("SELECT rf.recipe.id FROM RecipeFavorite rf WHERE rf.user.id = :userId AND rf.recipe.id IN :recipeIds")
+    Set<Long> findRecipeIdsByUserIdAndRecipeIdIn(@Param("userId") Long userId, @Param("recipeIds") List<Long> recipeIds);
 }

--- a/src/main/java/com/jdc/recipe_service/domain/repository/RecipeLikeRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/RecipeLikeRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface RecipeLikeRepository extends JpaRepository<RecipeLike, Long> {
@@ -24,6 +25,6 @@ public interface RecipeLikeRepository extends JpaRepository<RecipeLike, Long> {
     @Query("SELECT rl.recipe.id, COUNT(rl) FROM RecipeLike rl WHERE rl.recipe.id IN :recipeIds GROUP BY rl.recipe.id")
     List<Object[]> countLikesRaw(@Param("recipeIds") List<Long> recipeIds);
 
-
-
+    @Query("SELECT rl.recipe.id FROM RecipeLike rl WHERE rl.user.id = :userId AND rl.recipe.id IN :recipeIds")
+    Set<Long> findRecipeIdsByUserIdAndRecipeIdIn(@Param("userId") Long userId, @Param("recipeIds") List<Long> recipeIds);
 }

--- a/src/main/java/com/jdc/recipe_service/domain/repository/RecipeQueryRepositoryImplV2.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/RecipeQueryRepositoryImplV2.java
@@ -1,0 +1,174 @@
+package com.jdc.recipe_service.domain.repository;
+
+import com.jdc.recipe_service.domain.dto.recipe.QRecipeSimpleDto;
+import com.jdc.recipe_service.domain.dto.recipe.RecipeSimpleDto;
+import com.jdc.recipe_service.domain.dto.recipe.v2.QRecipeSimpleStaticDto;
+import com.jdc.recipe_service.domain.dto.recipe.v2.RecipeSimpleStaticDto;
+import com.jdc.recipe_service.domain.entity.QRecipe;
+import com.jdc.recipe_service.domain.entity.QRecipeLike;
+import com.jdc.recipe_service.domain.entity.QRecipeTag;
+import com.jdc.recipe_service.domain.type.DishType;
+import com.jdc.recipe_service.domain.type.TagType;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+
+@Repository
+@RequiredArgsConstructor
+public class RecipeQueryRepositoryImplV2 implements RecipeQueryRepositoryV2 {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Value("${app.s3.bucket-name}")
+    private String bucketName;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public String generateImageUrl(String key) {
+        return key == null ? null :
+                String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, key);
+    }
+
+    @Override
+    public Page<RecipeSimpleStaticDto> searchStatic(String title, DishType dishType, List<TagType> tagTypes, Boolean isAiGenerated, Pageable pageable, Long currentUserId) {
+        QRecipe recipe   = QRecipe.recipe;
+        QRecipeTag tag    = QRecipeTag.recipeTag;
+
+        BooleanExpression privacyCondition = recipe.isPrivate.eq(false);
+        BooleanExpression aiCondition      = (isAiGenerated != null)
+                ? recipe.isAiGenerated.eq(isAiGenerated)
+                : null;
+
+//        BooleanExpression adminExclude     = recipe.user.id.ne(7L);
+
+        var contentQuery = queryFactory
+                .select(new QRecipeSimpleStaticDto(
+                        recipe.id,
+                        recipe.title,
+                        recipe.imageKey,
+                        recipe.user.id,
+                        recipe.user.nickname,
+                        recipe.user.profileImage,
+                        recipe.createdAt,
+                        recipe.cookingTime
+                ))
+                .from(recipe)
+                .leftJoin(recipe.tags, tag)
+                .where(
+                        privacyCondition,
+                        titleContains(title),
+                        dishTypeEq(dishType),
+                        tagIn(tagTypes),
+                        aiCondition
+//                        ,adminExclude
+                )
+                .orderBy(getOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        List<RecipeSimpleStaticDto> content = contentQuery.fetch();
+
+        if (!content.isEmpty()) {
+            content.forEach(dto -> dto.setImageUrl(generateImageUrl(dto.getImageUrl())));
+        }
+
+        Long total = queryFactory
+                .select(recipe.countDistinct())
+                .from(recipe)
+                .leftJoin(recipe.tags, tag)
+                .where(
+                        privacyCondition,
+                        titleContains(title),
+                        dishTypeEq(dishType),
+                        tagIn(tagTypes),
+                        aiCondition
+//                        ,adminExclude
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0);
+    }
+
+
+    @Override
+    public Page<RecipeSimpleStaticDto> findAllSimpleStatic(Pageable pageable) {
+        QRecipe recipe = QRecipe.recipe;
+
+        BooleanExpression privacyCondition = recipe.isPrivate.eq(false);
+
+        List<RecipeSimpleStaticDto> content = queryFactory
+                .select(new QRecipeSimpleStaticDto(
+                        recipe.id,
+                        recipe.title,
+                        recipe.imageKey,
+                        recipe.user.id,
+                        recipe.user.nickname,
+                        recipe.user.profileImage,
+                        recipe.createdAt,
+                        recipe.cookingTime
+                ))
+                .from(recipe)
+                .where(privacyCondition)
+                .orderBy(getOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        if (!content.isEmpty()) {
+            content.forEach(dto -> dto.setImageUrl(generateImageUrl(dto.getImageUrl())));
+        }
+
+        Long total = queryFactory
+                .select(recipe.count())
+                .from(recipe)
+                .where(privacyCondition)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0);
+    }
+
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        QRecipe recipe = QRecipe.recipe;
+
+        return pageable.getSort().stream()
+                .map(o -> {
+                    Order dir = o.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                    switch (o.getProperty()) {
+                        case "cookingTime":
+                            return new OrderSpecifier<>(dir, recipe.cookingTime);
+                        case "createdAt":
+                        default:
+                            return new OrderSpecifier<>(dir, recipe.createdAt);
+                    }
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    private BooleanExpression dishTypeEq(DishType dishType) {
+        return (dishType != null) ? QRecipe.recipe.dishType.eq(dishType) : null;
+    }
+
+    private BooleanExpression tagIn(List<TagType> tagTypes) {
+        return (tagTypes != null && !tagTypes.isEmpty())
+                ? QRecipeTag.recipeTag.tag.in(tagTypes)
+                : null;
+    }
+
+    private BooleanExpression titleContains(String title) {
+        return StringUtils.hasText(title) ? QRecipe.recipe.title.containsIgnoreCase(title) : null;
+    }
+
+}

--- a/src/main/java/com/jdc/recipe_service/domain/repository/RecipeQueryRepositoryV2.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/RecipeQueryRepositoryV2.java
@@ -1,0 +1,14 @@
+package com.jdc.recipe_service.domain.repository;
+
+import com.jdc.recipe_service.domain.dto.recipe.v2.RecipeSimpleStaticDto;
+import com.jdc.recipe_service.domain.type.DishType;
+import com.jdc.recipe_service.domain.type.TagType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface RecipeQueryRepositoryV2 {
+    Page<RecipeSimpleStaticDto> searchStatic(String title, DishType dishType, List<TagType> tagTypes, Boolean isAiGenerated, Pageable pageable, Long currentUserId);
+    Page<RecipeSimpleStaticDto> findAllSimpleStatic(Pageable pageable);
+}

--- a/src/main/java/com/jdc/recipe_service/domain/repository/RecipeRatingRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/RecipeRatingRepository.java
@@ -8,7 +8,11 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public interface RecipeRatingRepository extends JpaRepository<RecipeRating, Long> {
     Optional<RecipeRating> findByUserAndRecipe(User user, Recipe recipe);
@@ -24,4 +28,15 @@ public interface RecipeRatingRepository extends JpaRepository<RecipeRating, Long
     @Transactional
     @Query("DELETE FROM RecipeRating r WHERE r.recipe.id = :recipeId")
     void deleteByRecipeId(@Param("recipeId") Long recipeId);
+
+    @Query("SELECT rr.recipe.id, rr.rating FROM RecipeRating rr WHERE rr.user.id = :userId AND rr.recipe.id IN :recipeIds")
+    List<Object[]> findRatingsByUserIdAndRecipeIdIn(@Param("userId") Long userId, @Param("recipeIds") List<Long> recipeIds);
+
+    default Map<Long, Integer> findRatingsMapByUserIdAndRecipeIdIn(Long userId, List<Long> recipeIds) {
+        return findRatingsByUserIdAndRecipeIdIn(userId, recipeIds).stream()
+                .collect(Collectors.toMap(
+                        arr -> (Long) arr[0],
+                        arr -> (Integer) arr[1]
+                ));
+    }
 }

--- a/src/main/java/com/jdc/recipe_service/opensearch/service/OpenSearchService.java
+++ b/src/main/java/com/jdc/recipe_service/opensearch/service/OpenSearchService.java
@@ -2,6 +2,7 @@ package com.jdc.recipe_service.opensearch.service;
 
 import com.jdc.recipe_service.domain.dto.RecipeSearchCondition;
 import com.jdc.recipe_service.domain.dto.recipe.RecipeSimpleDto;
+import com.jdc.recipe_service.domain.dto.recipe.v2.RecipeSimpleStaticDto;
 import com.jdc.recipe_service.domain.entity.Recipe;
 import com.jdc.recipe_service.domain.repository.RecipeLikeRepository;
 import com.jdc.recipe_service.domain.repository.RecipeRepository;
@@ -130,7 +131,7 @@ public class OpenSearchService {
                                 r.getTitle(),
                                 r.getImageKey() == null ? null
                                         : String.format("https://%s.s3.%s.amazonaws.com/%s",
-                                        bucketName,region,r.getImageKey()),
+                                        bucketName, region, r.getImageKey()),
                                 r.getUser().getId(),
                                 r.getUser().getNickname(),
                                 r.getUser().getProfileImage(),
@@ -154,5 +155,101 @@ public class OpenSearchService {
         }
     }
 
+    public Page<RecipeSimpleStaticDto> searchRecipesV2(RecipeSearchCondition cond, Pageable pg, Long uid) {
+        try {
+            BoolQueryBuilder bool = QueryBuilders.boolQuery();
+
+            if (cond.getTitle() != null && !cond.getTitle().isBlank()) {
+                String title = cond.getTitle().trim();
+                keywordService.record(title);
+                var titleQuery = QueryBuilders.boolQuery()
+                        .should(QueryBuilders.matchPhrasePrefixQuery("title.prefix", title))
+                        .should(QueryBuilders.matchQuery("title.infix", title));
+                bool.must(titleQuery);
+            }
+
+            if (cond.getDishType() != null && !cond.getDishType().isBlank()) {
+                bool.filter(QueryBuilders.termQuery("dishType", cond.getDishType()));
+            }
+
+            if (cond.getTagNames() != null && !cond.getTagNames().isEmpty()) {
+                for (String tag : cond.getTagNames()) {
+                    bool.filter(QueryBuilders.termQuery("tags", tag));
+                }
+            }
+
+            if (cond.getIsAiGenerated() != null) {
+                bool.filter(QueryBuilders.termQuery("isAiGenerated", cond.getIsAiGenerated()));
+            }
+
+            if (bool.must().isEmpty() && bool.filter().isEmpty()) {
+                bool.must(QueryBuilders.matchAllQuery());
+            }
+
+            SearchSourceBuilder src = new SearchSourceBuilder().query(bool).from((int) pg.getOffset()).size(pg.getPageSize());
+            pg.getSort().forEach(o -> src.sort(o.getProperty(), o.isAscending() ? SortOrder.ASC : SortOrder.DESC));
+
+            SearchResponse resp = client.search(new SearchRequest("recipes").source(src), RequestOptions.DEFAULT);
+            SearchHits hits = resp.getHits();
+
+            List<Long> ids = Arrays.stream(hits.getHits()).map(h -> Long.valueOf(h.getId())).collect(Collectors.toList());
+            if (ids.isEmpty()) {
+                return Page.empty(pg);
+            }
+
+            List<Recipe> recipes = recipeRepository.findAllById(ids);
+            Map<Long, Recipe> recipeMap = recipes.stream().collect(Collectors.toMap(Recipe::getId, Function.identity()));
+
+            List<RecipeSimpleStaticDto> list = ids.stream()
+                    .filter(recipeMap::containsKey)
+                    .map(id -> {
+                        Recipe r = recipeMap.get(id);
+                        return new RecipeSimpleStaticDto(
+                                r.getId(),
+                                r.getTitle(),
+                                r.getImageKey() == null ? null : String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, r.getImageKey()),
+                                r.getUser().getId(),
+                                r.getUser().getNickname(),
+                                r.getUser().getProfileImage(),
+                                r.getCreatedAt(),
+                                r.getCookingTime() == null ? 0 : r.getCookingTime()
+                        );
+                    })
+                    .collect(Collectors.toList());
+
+            return new PageImpl<>(list, pg, hits.getTotalHits().value);
+
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.SEARCH_FAILURE, "OpenSearch 조회 실패: " + e.getMessage());
+        }
+    }
+
+    private BoolQueryBuilder buildOpenSearchQuery(RecipeSearchCondition cond) {
+        BoolQueryBuilder bool = QueryBuilders.boolQuery();
+
+        if (cond.getTitle() != null && !cond.getTitle().isBlank()) {
+            String title = cond.getTitle().trim();
+            keywordService.record(title);
+            var titleQuery = QueryBuilders.boolQuery()
+                    .should(QueryBuilders.matchPhrasePrefixQuery("title.prefix", title))
+                    .should(QueryBuilders.matchQuery("title.infix", title));
+            bool.must(titleQuery);
+        }
+        if (cond.getDishType() != null && !cond.getDishType().isBlank()) {
+            bool.filter(QueryBuilders.termQuery("dishType", cond.getDishType()));
+        }
+        if (cond.getTagNames() != null && !cond.getTagNames().isEmpty()) {
+            for (String tag : cond.getTagNames()) {
+                bool.filter(QueryBuilders.termQuery("tags", tag));
+            }
+        }
+        if (cond.getIsAiGenerated() != null) {
+            bool.filter(QueryBuilders.termQuery("isAiGenerated", cond.getIsAiGenerated()));
+        }
+        if (bool.must().isEmpty() && bool.filter().isEmpty()) {
+            bool.must(QueryBuilders.matchAllQuery());
+        }
+        return bool;
+    }
 
 }

--- a/src/main/java/com/jdc/recipe_service/service/RecipeSearchServiceV2.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeSearchServiceV2.java
@@ -1,0 +1,234 @@
+package com.jdc.recipe_service.service;
+
+import com.jdc.recipe_service.domain.dto.RecipeSearchCondition;
+import com.jdc.recipe_service.domain.dto.recipe.ingredient.RecipeIngredientDto;
+import com.jdc.recipe_service.domain.dto.recipe.step.RecipeStepDto;
+import com.jdc.recipe_service.domain.dto.recipe.v2.RecipeDetailStaticDto;
+import com.jdc.recipe_service.domain.dto.recipe.v2.RecipeSimpleStaticDto;
+import com.jdc.recipe_service.domain.dto.user.UserDto;
+import com.jdc.recipe_service.domain.entity.QRecipe;
+import com.jdc.recipe_service.domain.entity.QRecipeTag;
+import com.jdc.recipe_service.domain.entity.Recipe;
+import com.jdc.recipe_service.domain.repository.*;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.mapper.RecipeIngredientMapper;
+import com.jdc.recipe_service.mapper.RecipeStepMapper;
+import com.jdc.recipe_service.mapper.StepIngredientMapper;
+import com.jdc.recipe_service.mapper.UserMapper;
+import com.jdc.recipe_service.opensearch.service.OpenSearchService;
+import com.jdc.recipe_service.util.SearchProperties;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestHighLevelClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeSearchServiceV2 {
+
+    private final OpenSearchService openSearchService;
+    private final SearchProperties searchProperties;
+    private final RestHighLevelClient client;
+    private static final Logger log = LoggerFactory.getLogger(RecipeSearchServiceV2.class);
+
+    private final RecipeRepository recipeRepository;
+    private final RecipeQueryRepositoryV2 recipeQueryRepositoryV2;
+    private final JPAQueryFactory queryFactory;
+    private final RecipeIngredientRepository recipeIngredientRepository;
+    private final RecipeStepRepository recipeStepRepository;
+    private final RecipeTagRepository recipeTagRepository;
+
+    @Value("${app.s3.bucket-name}")
+    private String bucketName;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+    private volatile boolean isOpenSearchHealthy = true;
+
+    public String generateImageUrl(String key) {
+        return key == null ? null : String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, key);
+    }
+
+    @Transactional(readOnly = true)
+    public RecipeDetailStaticDto getRecipeDetail(Long recipeId, Long currentUserId) {
+        Recipe basic = recipeRepository.findWithUserById(recipeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
+
+        if (basic.getIsPrivate() && (currentUserId == null || !basic.getUser().getId().equals(currentUserId))) {
+            throw new CustomException(ErrorCode.RECIPE_PRIVATE_ACCESS_DENIED);
+        }
+
+        UserDto authorDto = UserMapper.toSimpleDto(basic.getUser());
+        List<String> tagNames = recipeTagRepository.findByRecipeId(recipeId)
+                .stream()
+                .map(rt -> rt.getTag().getDisplayName())
+                .toList();
+
+        List<RecipeIngredientDto> ingredients = RecipeIngredientMapper.toDtoList(
+                recipeIngredientRepository.findByRecipeId(recipeId)
+        );
+
+        double rawTotal = ingredients.stream()
+                .mapToDouble(i -> i.getCalories() != null ? i.getCalories() : 0.0)
+                .sum();
+        double totalCalories = BigDecimal
+                .valueOf(rawTotal)
+                .setScale(2, RoundingMode.DOWN)
+                .doubleValue();
+
+        List<RecipeStepDto> steps = recipeStepRepository
+                .findWithIngredientsByRecipeIdOrderByStepNumber(recipeId)
+                .stream()
+                .map(step -> {
+                    var used = StepIngredientMapper.toDtoList(step.getStepIngredients());
+                    var url  = generateImageUrl(step.getImageKey());
+                    return RecipeStepMapper.toDto(step, used, url, step.getImageKey());
+                })
+                .toList();
+
+        int totalCost   = basic.getTotalIngredientCost() != null ? basic.getTotalIngredientCost() : 0;
+        int marketPrice = basic.getMarketPrice() != null ? basic.getMarketPrice() : 0;
+        int savings     = marketPrice - totalCost;
+
+        return RecipeDetailStaticDto.builder()
+                .id(recipeId)
+                .title(basic.getTitle())
+                .dishType(basic.getDishType().getDisplayName())
+                .description(basic.getDescription())
+                .cookingTime(basic.getCookingTime())
+                .imageUrl(generateImageUrl(basic.getImageKey()))
+                .imageKey(basic.getImageKey())
+                .imageStatus(basic.getImageStatus() != null ? basic.getImageStatus().name() : null)
+                .youtubeUrl(basic.getYoutubeUrl())
+                .cookingTools(new ArrayList<>(basic.getCookingTools()))
+                .servings(basic.getServings())
+                .isPrivate(basic.getIsPrivate())
+                .isAiGenerated(basic.isAiGenerated())
+                .author(authorDto)
+                .tags(tagNames)
+                .ingredients(ingredients)
+                .steps(steps)
+                .totalIngredientCost(totalCost)
+                .totalCalories(totalCalories)
+                .marketPrice(marketPrice)
+                .savings(savings)
+                .createdAt(basic.getCreatedAt())
+                .updatedAt(basic.getUpdatedAt())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<RecipeSimpleStaticDto> searchRecipes(RecipeSearchCondition condition, Pageable pageable, Long userId) {
+        if (shouldUseOpenSearch(condition)) {
+            log.info("V2 API: Using OpenSearch");
+            return openSearchService.searchRecipesV2(condition, pageable, userId);
+        } else {
+            log.info("V2 API: Using QueryDSL");
+            return searchWithQuerydslV2(condition, pageable, userId);
+        }
+    }
+
+    private Page<RecipeSimpleStaticDto> searchWithQuerydslV2(RecipeSearchCondition condition, Pageable pageable, Long userId) {
+        Sort.Order likeSort = pageable.getSort().getOrderFor("likeCount");
+        Sort.Order ratingSort = pageable.getSort().getOrderFor("avgRating");
+
+        if (likeSort != null) {
+            return searchRecipesSortedByDynamicField(condition, pageable, "likeCount", likeSort.getDirection());
+        }
+        if (ratingSort != null) {
+            return searchRecipesSortedByDynamicField(condition, pageable, "avgRating", ratingSort.getDirection());
+        }
+
+        return recipeQueryRepositoryV2.searchStatic(
+                condition.getTitle(),
+                condition.getDishTypeEnum(),
+                condition.getTagEnums(),
+                condition.getIsAiGenerated(),
+                pageable,
+                userId
+        );
+    }
+
+    private Page<RecipeSimpleStaticDto> searchRecipesSortedByDynamicField(RecipeSearchCondition cond, Pageable pageable, String property, Sort.Direction direction) {
+        QRecipe recipe = QRecipe.recipe;
+        QRecipeTag tag = QRecipeTag.recipeTag;
+        BooleanExpression whereClause = createWhereClauseForSearch(cond);
+        OrderSpecifier<?> orderSpecifier = "likeCount".equals(property)
+                ? (direction == Sort.Direction.ASC ? recipe.likes.size().asc() : recipe.likes.size().desc())
+                : (direction == Sort.Direction.ASC ? recipe.avgRating.asc() : recipe.avgRating.desc());
+
+        List<Long> sortedIds = queryFactory.select(recipe.id).from(recipe)
+                .leftJoin(recipe.tags, tag).where(whereClause)
+                .groupBy(recipe.id).orderBy(orderSpecifier, recipe.createdAt.desc())
+                .offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
+
+        if (sortedIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        List<RecipeSimpleStaticDto> content = recipeRepository.findAllSimpleStaticByIds(sortedIds);
+        Map<Long, RecipeSimpleStaticDto> contentMap = content.stream().collect(Collectors.toMap(RecipeSimpleStaticDto::getId, dto -> dto));
+        List<RecipeSimpleStaticDto> sortedContent = sortedIds.stream().map(contentMap::get).filter(Objects::nonNull).collect(Collectors.toList());
+
+        Long total = queryFactory.select(recipe.id.countDistinct()).from(recipe)
+                .leftJoin(recipe.tags, tag).where(whereClause).fetchOne();
+
+        return new PageImpl<>(sortedContent, pageable, total != null ? total : 0);
+    }
+
+    private BooleanExpression createWhereClauseForSearch(RecipeSearchCondition cond) {
+        QRecipe recipe = QRecipe.recipe;
+        QRecipeTag tag = QRecipeTag.recipeTag;
+        BooleanExpression privacy = recipe.isPrivate.eq(false);
+        BooleanExpression ai = (cond.getIsAiGenerated() != null) ? QRecipe.recipe.isAiGenerated.eq(cond.getIsAiGenerated()) : null;
+        BooleanExpression title = StringUtils.hasText(cond.getTitle()) ? recipe.title.containsIgnoreCase(cond.getTitle()) : null;
+        BooleanExpression dishType = (cond.getDishTypeEnum() != null) ? recipe.dishType.eq(cond.getDishTypeEnum()) : null;
+        BooleanExpression tags = (cond.getTagEnums() != null && !cond.getTagEnums().isEmpty()) ? tag.tag.in(cond.getTagEnums()) : null;
+        return privacy.and(ai).and(title).and(dishType).and(tags);
+    }
+
+    @Scheduled(initialDelay = 5000, fixedRate = 10000)
+    public void checkOpenSearchHealth() {
+        boolean currentHealth;
+        try {
+            currentHealth = client.ping(RequestOptions.DEFAULT);
+        } catch (Exception e) {
+            currentHealth = false;
+        }
+        if (this.isOpenSearchHealthy != currentHealth) {
+            log.info("OpenSearch Health Status Changed: {} -> {}", this.isOpenSearchHealthy, currentHealth);
+            this.isOpenSearchHealthy = currentHealth;
+        }
+    }
+
+    private boolean shouldUseOpenSearch(RecipeSearchCondition cond) {
+        String engine = searchProperties.getEngine();
+        if ("opensearch".equalsIgnoreCase(engine)) return true;
+        if ("querydsl".equalsIgnoreCase(engine)) return false;
+        if (this.isOpenSearchHealthy) {
+            return cond.getTitle() != null && !cond.getTitle().isBlank();
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/service/RecipeService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeService.java
@@ -54,9 +54,10 @@ public class RecipeService {
     private final ActionImageService actionImageService;
     private final SurveyService surveyService;
     private final OpenAiClientService aiService;
-    //private final ClaudeClientService claudeClientService;
+    private final ClaudeClientService claudeClientService;
     private final UnitService unitService;
     private final PromptBuilder promptBuilder;
+    private final PromptBuilderV2 promptBuilderV2;
     private final ApplicationEventPublisher publisher;
     private final DailyQuotaService dailyQuotaService;
 
@@ -187,6 +188,98 @@ public class RecipeService {
         return PresignedUrlResponse.builder()
                 .recipeId(recipe.getId())
                 .uploads(uploads)
+                .build();
+    }
+
+    @Transactional
+    public PresignedUrlResponse createRecipeWithAiLogicV2(
+            RobotType robotTypeParam,
+            RecipeWithImageUploadRequest request,
+            Long userId) {
+
+        if (request.getAiRequest() == null) {
+            throw new CustomException(
+                    ErrorCode.INVALID_INPUT_VALUE,
+                    "AI 레시피 생성을 위한 요청 정보(aiRequest)가 비어있습니다."
+            );
+        }
+
+        if (robotTypeParam == null) {
+            throw new CustomException(
+                    ErrorCode.INVALID_INPUT_VALUE,
+                    "AI 모드일 때는 robotType 파라미터가 필요합니다."
+            );
+        }
+
+        dailyQuotaService.consumeForUserOrThrow(userId);
+
+        try {
+            AiRecipeRequestDto aiReq = request.getAiRequest();
+            aiReq.setUserId(userId);
+
+            UserSurveyDto survey = surveyService.getSurvey(userId);
+            applySurveyInfoToAiRequest(aiReq, survey);
+
+            String prompt = promptBuilderV2.buildPrompt(aiReq, robotTypeParam);
+
+            RecipeWithImageUploadRequest processingRequest =
+                    buildRecipeFromClaudeAiRequest(prompt, aiReq, request.getFiles());
+
+            for (RecipeStepRequestDto step : processingRequest.getRecipe().getSteps()) {
+                String action = step.getAction();
+                if (action != null) {
+                    String key = actionImageService.generateImageKey(robotTypeParam, action);
+                    step.updateImageKey(key);
+                }
+            }
+
+            return createUserRecipeAndGenerateUrls(processingRequest, userId, RecipeSourceType.AI);
+
+        } catch (Exception e) {
+            dailyQuotaService.refundIfPolicyAllows(userId);
+            throw e;
+        }
+    }
+
+    @Transactional
+    public RecipeWithImageUploadRequest buildRecipeFromClaudeAiRequest(
+            String prompt,
+            AiRecipeRequestDto aiReq,
+            List<FileInfoRequest> originalFiles) {
+
+        RecipeCreateRequestDto generatedDto;
+        try {
+            generatedDto = claudeClientService.generateRecipeJson(prompt).join();
+        } catch (RuntimeException e) {
+            throw new CustomException(
+                    ErrorCode.AI_RECIPE_GENERATION_FAILED,
+                    "Claude AI 레시피 생성에 최종 실패했습니다: " + e.getMessage(), e
+            );
+        }
+
+        if (generatedDto == null) {
+            throw new CustomException(ErrorCode.AI_RECIPE_GENERATION_FAILED, "Claude AI 응답 결과가 null입니다.");
+        }
+
+        generatedDto.setIngredients(correctIngredientUnits(generatedDto.getIngredients()));
+
+        if (generatedDto.getSteps() == null || generatedDto.getSteps().isEmpty()) {
+            throw new CustomException(
+                    ErrorCode.AI_RECIPE_GENERATION_FAILED,
+                    "AI가 요리 단계를 생성하지 못했습니다. 다시 시도해 주세요."
+            );
+        }
+        if (generatedDto.getTagNames() == null || generatedDto.getTagNames().isEmpty()) {
+            throw new CustomException(
+                    ErrorCode.AI_RECIPE_GENERATION_FAILED,
+                    "AI가 태그 정보를 생성하지 못했습니다. 다시 시도해 주세요."
+            );
+        }
+
+        return RecipeWithImageUploadRequest.builder()
+                .aiRequest(aiReq)
+                .recipe(generatedDto)
+                .files(originalFiles)
                 .build();
     }
 
@@ -529,4 +622,3 @@ public class RecipeService {
     }
 
 }
-

--- a/src/main/java/com/jdc/recipe_service/service/RecipeStatusService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeStatusService.java
@@ -1,0 +1,66 @@
+package com.jdc.recipe_service.service;
+
+import com.jdc.recipe_service.domain.dto.comment.CommentDto;
+import com.jdc.recipe_service.domain.dto.recipe.v2.RecipeStatusDto;
+import com.jdc.recipe_service.domain.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeStatusService {
+
+    private final RecipeRepository recipeRepository;
+    private final RecipeLikeRepository recipeLikeRepository;
+    private final RecipeFavoriteRepository recipeFavoriteRepository;
+    private final RecipeRatingRepository recipeRatingRepository;
+    private final RecipeCommentRepository recipeCommentRepository;
+    private final CommentService commentService;
+
+    @Transactional(readOnly = true)
+    public Map<Long, RecipeStatusDto> getStatuses(List<Long> recipeIds, Long userId) {
+        if (recipeIds == null || recipeIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Set<Long> likedIds = (userId == null) ? Collections.emptySet() :
+                recipeLikeRepository.findRecipeIdsByUserIdAndRecipeIdIn(userId, recipeIds);
+        Set<Long> favoritedIds = (userId == null) ? Collections.emptySet() :
+                recipeFavoriteRepository.findRecipeIdsByUserIdAndRecipeIdIn(userId, recipeIds);
+        Map<Long, Integer> myRatings = (userId == null) ? Collections.emptyMap() :
+                recipeRatingRepository.findRatingsMapByUserIdAndRecipeIdIn(userId, recipeIds);
+
+        Map<Long, Long> likeCounts = recipeRepository.findLikeCountsMapByIds(recipeIds);
+        Map<Long, Long> commentCounts = recipeRepository.findCommentCountsMapByIds(recipeIds);
+        Map<Long, Double> avgRatings = recipeRepository.findAvgRatingsMapByIds(recipeIds);
+        Map<Long, Long> ratingCounts = recipeRepository.findRatingCountsMapByIds(recipeIds);
+
+        Map<Long, RecipeStatusDto> statusMap = new HashMap<>();
+        for (Long recipeId : recipeIds) {
+            List<CommentDto> comments = null;
+            if (recipeIds.size() == 1) {
+                comments = commentService.getTop3CommentsWithLikes(recipeId, userId);
+            }
+
+            RecipeStatusDto status = RecipeStatusDto.builder()
+                    .likeCount(likeCounts.getOrDefault(recipeId, 0L))
+                    .commentCount(commentCounts.getOrDefault(recipeId, 0L))
+                    .avgRating(avgRatings.getOrDefault(recipeId, 0.0))
+                    .ratingCount(ratingCounts.getOrDefault(recipeId, 0L))
+                    .likedByCurrentUser(likedIds.contains(recipeId))
+                    .favoriteByCurrentUser(favoritedIds.contains(recipeId))
+                    .myRating(myRatings.get(recipeId))
+                    .comments(comments)
+                    .build();
+            statusMap.put(recipeId, status);
+        }
+        return statusMap;
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/util/PromptBuilderV2.java
+++ b/src/main/java/com/jdc/recipe_service/util/PromptBuilderV2.java
@@ -1,0 +1,162 @@
+package com.jdc.recipe_service.util;
+
+import com.jdc.recipe_service.domain.dto.recipe.AiRecipeRequestDto;
+import com.jdc.recipe_service.domain.dto.user.UserSurveyDto;
+import com.jdc.recipe_service.domain.entity.Ingredient;
+import com.jdc.recipe_service.domain.repository.IngredientRepository;
+import com.jdc.recipe_service.domain.type.RobotType;
+import com.jdc.recipe_service.service.SurveyService;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class PromptBuilderV2 {
+
+    private final UnitService unitService;
+    private final IngredientRepository ingredientRepo;
+    private final SurveyService surveyService;
+
+    public PromptBuilderV2(UnitService unitService, IngredientRepository ingredientRepo, SurveyService surveyService) {
+        this.unitService = unitService;
+        this.ingredientRepo = ingredientRepo;
+        this.surveyService = surveyService;
+    }
+
+    public String buildPrompt(AiRecipeRequestDto request, RobotType type) {
+        UserSurveyDto survey = surveyService.getSurvey(request.getUserId());
+        Integer spicePref = (survey != null && survey.getSpiceLevel() != null)
+                ? survey.getSpiceLevel()
+                : request.getSpiceLevel();
+        String allergyPref = (survey != null && survey.getAllergy() != null && !survey.getAllergy().isBlank())
+                ? survey.getAllergy()
+                : request.getAllergy();
+        Set<String> themePrefs;
+        if (survey != null && survey.getTags() != null && !survey.getTags().isEmpty()) {
+            themePrefs = survey.getTags();
+        } else if (request.getTagNames() != null && !request.getTagNames().isEmpty()) {
+            themePrefs = new HashSet<>(request.getTagNames());
+        } else {
+            themePrefs = Collections.emptySet();
+        }
+
+        List<String> names = request.getIngredients();
+        List<String> known = ingredientRepo.findAllByNameIn(names)
+                .stream()
+                .map(Ingredient::getName)
+                .collect(Collectors.toList());
+        String knownList = known.isEmpty() ? "없음" : String.join(", ", known);
+
+
+        String persona;
+        switch (type) {
+            case CREATIVE -> persona = "너는 매우 창의적이고 새로운 조합을 즐기는 한국 요리 전문가야.";
+            case HEALTHY -> persona = "너는 영양 균형과 건강한 조리법을 최우선으로 생각하는 요리 전문가야.";
+            case GOURMET -> persona = "너는 풍부하고 깊은 맛을 탐닉하며, 프리미엄 재료로 고급스럽고 섬세한 요리를 선보이는 미식가야.";
+            default -> persona = "너는 '백종원'처럼 조리 원리를 잘 이해하고 맛의 깊이를 더하는 전문 한국 요리사야.";
+        }
+
+        String userRequestXml = String.format("""
+                <user_request>
+                  <dishType>%s</dishType>
+                  <mainIngredients>%s</mainIngredients>
+                  <cookingTime>%s</cookingTime>
+                  <servings>%s</servings>
+                  <spiceLevel>%s/5</spiceLevel>
+                  <allergyInfo>%s</allergyInfo>
+                  <themes>%s</themes>
+                  <knownIngredients>%s</knownIngredients>
+                </user_request>""",
+                request.getDishType(),
+                String.join(", ", request.getIngredients()),
+                (request.getCookingTime() != null && request.getCookingTime() > 0) ? request.getCookingTime() + "분 이내" : "AI가 적절히 판단",
+                (request.getServings() != null && request.getServings() > 0) ? request.getServings() + "인분" : "AI가 적절히 판단",
+                spicePref != null ? spicePref : "기본",
+                allergyPref != null && !allergyPref.isBlank() ? allergyPref : "없음",
+                themePrefs.isEmpty() ? "없음" : String.join(", ", themePrefs),
+                knownList
+        );
+
+        String fewShotExampleXml = """
+                <example>
+                  {
+                    "title": "돼지고기 김치찌개",
+                    "dishType": "국/찌개/탕",
+                    "description": "기름에 김치와 돼지고기를 충분히 볶아내어 깊고 진한 국물 맛이 일품인 정통 김치찌개입니다.",
+                    "cookingTime": 30,
+                    "cookingTools": ["냄비", "도마", "칼"],
+                    "servings": 2.0,
+                    "ingredients": [
+                       { "name": "돼지고기", "quantity": "150", "unit": "g" },
+                       { "name": "신김치",   "quantity": "200", "unit": "g", "customPrice": 300, "caloriesPerUnit": 15 },
+                       { "name": "김치국물", "quantity": "0.5", "unit": "컵" },
+                       { "name": "두부",     "quantity": "0.5", "unit": "모" },
+                       { "name": "대파",     "quantity": "0.5", "unit": "대" },
+                       { "name": "양파",     "quantity": "0.25", "unit": "개" },
+                       { "name": "들기름",   "quantity": "1",   "unit": "큰술" },
+                       { "name": "고춧가루", "quantity": "1",   "unit": "큰술" },
+                       { "name": "다진마늘", "quantity": "0.5", "unit": "큰술" },
+                       { "name": "설탕",     "quantity": "0.5", "unit": "큰술" },
+                       { "name": "멸치육수", "quantity": "500", "unit": "ml" }
+                    ],
+                    "steps": [
+                      { "stepNumber": 0, "instruction": "돼지고기는 한입 크기로, 김치는 2cm 폭으로 썰고, 양파는 채썰고 대파는 어슷썹니다. 두부는 1.5cm 두께로 준비합니다.", "action": "손질하기" },
+                      { "stepNumber": 1, "instruction": "중불로 달군 냄비에 들기름 1큰술을 두르고 돼지고기를 넣어 겉면이 익을 때까지 볶습니다.", "action": "볶기" },
+                      { "stepNumber": 2, "instruction": "김치를 넣고 3~5분간 충분히 볶아 신맛을 부드럽게 만들고 풍미를 끌어올립니다.", "action": "볶기" },
+                      { "stepNumber": 3, "instruction": "멸치육수 500ml와 김치국물 0.5컵을 붓고, 고춧가루·다진마늘·설탕을 넣어 10분간 끓입니다.", "action": "끓이기" },
+                      { "stepNumber": 4, "instruction": "양파와 두부를 넣고 5분 더 끓인 뒤, 마지막에 대파를 넣어 한소끔 더 끓여 마무리합니다.", "action": "끓이기" }
+                    ],
+                    "tagNames": ["🍲 해장", "🍽️ 혼밥"]
+                  }
+                </example>
+                """;
+
+        String rulesXml = String.format("""
+                <rules>
+                  **[최상위 규칙]**
+                  1.  당신은 <user_request>를 분석하고, 아래의 모든 규칙을 준수하여 **단 하나의 JSON 객체만**을 생성해야 합니다.
+                  2.  JSON 외에 어떤 설명, 주석, 마커(예: ```json)도 절대 포함해서는 안 됩니다.
+
+                  **[콘텐츠 생성 규칙]**
+                  1.  **요리 원리 준수**: 찌개·볶음 등에서는 기름에 주재료나 향신채를 먼저 볶아 풍미의 기초를 다지는 과정을 최우선으로 고려하세요.
+                  2.  **재료 추가**: 요청에 없더라도 맛을 내기 위해 필수적인 보조 재료(기름, 맛술, 설탕 등)는 자유롭게 추가하고 'ingredients' 목록에 포함하세요.
+                  3.  **인분 수 비례 조정**: 'ingredients'의 `quantity`는 <example>의 양을 기준으로 사용자의 요청 인분 수에 비례하여 조정하세요. (예: 요청이 4인분이면 예시의 2배)
+                  4.  **알레르기 정보 반영**: 사용자의 알레르기 유발 재료는 반드시 제외하거나 안전한 재료로 대체하세요.
+                  5.  **단계별 설명**: 각 단계는 핵심 행동 위주로 간결하고 명확하게 작성하고, 불 세기, 순서, 시간 등 구체적인 지시를 포함하세요.
+
+                  **[JSON 필드 규칙]**
+                  1.  `dishType`: <user_request>의 `dishType` 값('%s')을 그대로 사용해야 합니다.
+                  2.  `tagNames`: <user_request>의 `themes`가 비어있지 않다면, 그 값을 순서대로 사용하세요. 비어있다면, 음식과 어울리는 태그를 아래 목록에서 최대 3개 선택하세요.
+                      - 허용 태그 목록: 🏠 홈파티, 🌼 피크닉, 🏕️ 캠핑, 🥗 다이어트 / 건강식, 👶 아이와 함께, 🍽️ 혼밥, 🍶 술안주, 🥐 브런치, 🌙 야식, ⚡ 초스피드 / 간단 요리, 🎉 기념일 / 명절, 🍱 도시락, 🔌 에어프라이어, 🍲 해장
+                  3.  `unit`: 재료의 단위는 반드시 아래 목록 중 하나여야 합니다. [%s]
+                  4.  `action`: `steps`의 `action`은 반드시 아래 목록 중 하나여야 합니다.
+                      - 허용 동사 목록: 썰기, 다지기, 채썰기, 손질하기, 볶기, 튀기기, 끓이기, 찌기(스팀), 데치기, 구이, 조림, 무치기, 절이기, 담그기(마리네이드), 섞기, 젓기, 버무리기, 로스팅, 캐러멜라이즈, 부치기
+                  5.  `customPrice`, `caloriesPerUnit`: <user_request>의 `knownIngredients` 목록에 없는 재료에 대해서만 이 두 필드를 추정하여 포함하세요. DB에 이미 있는 재료에는 절대 포함하면 안 됩니다.
+                  6.  모든 필드는 의미 있는 한글 값이어야 하며, 빈 값("")이나 null이 될 수 없습니다.
+                </rules>
+                """, request.getDishType(), unitService.unitsAsString());
+
+        return String.format("""
+                        %s
+                        
+                        당신은 지금부터 아래의 지시사항에 따라 사용자 요청에 맞는 레시피 JSON을 생성해야 합니다.
+                        
+                        %s
+                        
+                        %s
+                        
+                        %s
+                        
+                        위 규칙과 예시를 참고하여 <user_request>에 대한 레시피 JSON을 생성하세요.
+                        """,
+                persona,
+                rulesXml,
+                userRequestXml,
+                fewShotExampleXml
+        );
+    }
+}


### PR DESCRIPTION
#### 개요 (Description)

본 PR은 서비스의 핵심 기능인 AI 레시피 생성과 레시피 조회의 성능 및 효율을 개선하기 위한 두 가지 주요 업데이트를 포함합니다.

1.  **AI 모델 추가**: 기존 OpenAI 모델에 더해 비용 효율적인 Anthropic의 Claude 모델을 새로운 옵션으로 추가합니다.
2.  **조회 API V2 도입**: 기존 조회 API의 성능 문제를 해결하기 위해, API Composition 패턴을 적용한 V2 API를 새로 구현합니다.

---

#### 주요 변경 사항 (Key Changes)

-   **Claude AI 연동**
    -   `ClaudeClientService` 및 Claude에 최적화된 `PromptBuilderV2`를 추가했습니다.
    -   기존 `POST /api/recipes` 엔드포인트에 `aiModel` 쿼리 파라미터를 추가하여, OpenAI(v1)와 Claude(v2)를 선택적으로 호출할 수 있도록 구현했습니다. (기본값: `openai`)

-   **레시피 조회 API V2 구현**
    -   `/api/v2` 경로에 새로운 `RecipeSearchControllerV2`를 추가했습니다.
    -   **정적 정보 API (`GET /api/v2/recipes`)**: 캐싱 가능한 레시피의 기본 정보만 빠르게 반환하여 클라이언트의 초기 로딩 속도를 개선합니다.
    -   **동적 정보 API (`POST /api/v2/recipes/status`)**: 클라이언트가 받은 ID 목록을 기반으로 좋아요, 평점 등 개인화된 동적 정보만 효율적으로 조회합니다.
    -   `RecipeSearchServiceV2`, `RecipeStatusService`를 추가하여 V2 API의 로직을 명확히 분리했습니다.

---

#### 기대 효과 (Impact)

-   **비용 절감 및 속도 향상**: 더 저렴하고 빠른 Claude AI 모델을 사용할 수 있는 옵션이 추가되었습니다.
-   **사용자 경험(UX) 개선**: V2 조회 API를 통해 레시피 목록의 로딩 속도가 극적으로 향상됩니다.
-   **안정성 및 확장성 확보**: 각 서비스의 역할이 명확히 분리되어 향후 기능 추가 및 유지보수가 용이해집니다.

---

#### 테스트 방법 (How to Test)

1.  **Claude AI 생성**: Postman으로 `POST /api/recipes?source=AI&aiModel=claude`를 호출하여 레시피가 정상적으로 생성되는지 확인합니다.
2.  **V2 API 조회**:
    -   `GET /api/v2/recipes`를 호출하여 정적 정보 목록을 받습니다.
    -   응답받은 `id` 목록을 사용하여 `POST /api/v2/recipes/status`를 호출하고, 동적 정보가 정상적으로 반환
