### PR TITLE
refactor: 전체 테스트 코드 BDD 스타일 통일

### DIFF
--- a/src/test/java/com/jdc/recipe_service/service/AdminRecipeServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/AdminRecipeServiceTest.java
@@ -22,8 +22,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AdminRecipeServiceTest {

--- a/src/test/java/com/jdc/recipe_service/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/CommentLikeServiceTest.java
@@ -18,8 +18,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CommentLikeServiceTest {
@@ -44,18 +45,21 @@ class CommentLikeServiceTest {
     @Test
     @DisplayName("toggleLike: 이미 좋아요가 있으면 삭제 후 false 반환")
     void toggleLike_alreadyExists() {
+        // Given
         CommentLike existing = CommentLike.builder()
                 .comment(comment)
                 .user(user)
                 .build();
         ReflectionTestUtils.setField(existing, "id", 200L);
 
-        when(commentLikeRepository.findByCommentIdAndUserId(100L, 10L))
-                .thenReturn(Optional.of(existing));
+        given(commentLikeRepository.findByCommentIdAndUserId(100L, 10L))
+                .willReturn(Optional.of(existing));
 
+        // When
         boolean result = commentLikeService.toggleLike(100L, 10L);
-        assertFalse(result);
 
+        // Then
+        assertThat(result).isFalse();
         verify(commentLikeRepository, times(1)).delete(existing);
         verifyNoMoreInteractions(recipeCommentRepository, userRepository);
     }
@@ -63,15 +67,16 @@ class CommentLikeServiceTest {
     @Test
     @DisplayName("toggleLike: 댓글이 없으면 COMMENT_NOT_FOUND 예외")
     void toggleLike_commentNotFound() {
-        when(commentLikeRepository.findByCommentIdAndUserId(999L, 10L))
-                .thenReturn(Optional.empty());
-        when(recipeCommentRepository.findById(999L))
-                .thenReturn(Optional.empty());
+        // Given
+        given(commentLikeRepository.findByCommentIdAndUserId(999L, 10L))
+                .willReturn(Optional.empty());
+        given(recipeCommentRepository.findById(999L))
+                .willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () ->
-                commentLikeService.toggleLike(999L, 10L)
-        );
-        assertEquals(ErrorCode.COMMENT_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> commentLikeService.toggleLike(999L, 10L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.COMMENT_NOT_FOUND));
 
         verify(commentLikeRepository, times(1))
                 .findByCommentIdAndUserId(999L, 10L);
@@ -82,17 +87,18 @@ class CommentLikeServiceTest {
     @Test
     @DisplayName("toggleLike: 사용자 없으면 USER_NOT_FOUND 예외")
     void toggleLike_userNotFound() {
-        when(commentLikeRepository.findByCommentIdAndUserId(100L, 10L))
-                .thenReturn(Optional.empty());
-        when(recipeCommentRepository.findById(100L))
-                .thenReturn(Optional.of(comment));
-        when(userRepository.findById(10L))
-                .thenReturn(Optional.empty());
+        // Given
+        given(commentLikeRepository.findByCommentIdAndUserId(100L, 10L))
+                .willReturn(Optional.empty());
+        given(recipeCommentRepository.findById(100L))
+                .willReturn(Optional.of(comment));
+        given(userRepository.findById(10L))
+                .willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () ->
-                commentLikeService.toggleLike(100L, 10L)
-        );
-        assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> commentLikeService.toggleLike(100L, 10L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
 
         verify(recipeCommentRepository, times(1)).findById(100L);
         verify(userRepository, times(1)).findById(10L);
@@ -101,38 +107,46 @@ class CommentLikeServiceTest {
     @Test
     @DisplayName("toggleLike: 정상 호출 시 새로운 좋아요 저장 후 true 반환")
     void toggleLike_success() {
-        when(commentLikeRepository.findByCommentIdAndUserId(100L, 10L))
-                .thenReturn(Optional.empty());
-        when(recipeCommentRepository.findById(100L))
-                .thenReturn(Optional.of(comment));
-        when(userRepository.findById(10L))
-                .thenReturn(Optional.of(user));
+        // Given
+        given(commentLikeRepository.findByCommentIdAndUserId(100L, 10L))
+                .willReturn(Optional.empty());
+        given(recipeCommentRepository.findById(100L))
+                .willReturn(Optional.of(comment));
+        given(userRepository.findById(10L))
+                .willReturn(Optional.of(user));
 
-        when(commentLikeRepository.save(any(CommentLike.class)))
-                .thenAnswer(invocation -> {
+        given(commentLikeRepository.save(any(CommentLike.class)))
+                .willAnswer(invocation -> {
                     CommentLike cl = invocation.getArgument(0);
                     ReflectionTestUtils.setField(cl, "id", 300L);
                     return cl;
                 });
 
+        // When
         boolean result = commentLikeService.toggleLike(100L, 10L);
-        assertTrue(result);
+
+        // Then
+        assertThat(result).isTrue();
 
         ArgumentCaptor<CommentLike> captor = ArgumentCaptor.forClass(CommentLike.class);
         verify(commentLikeRepository, times(1)).save(captor.capture());
 
         CommentLike saved = captor.getValue();
-        assertEquals(100L, ((RecipeComment) ReflectionTestUtils.getField(saved, "comment")).getId());
-        assertEquals(10L, ((User) ReflectionTestUtils.getField(saved, "user")).getId());
+        assertThat(((RecipeComment) ReflectionTestUtils.getField(saved, "comment")).getId()).isEqualTo(100L);
+        assertThat(((User) ReflectionTestUtils.getField(saved, "user")).getId()).isEqualTo(10L);
     }
 
     @Test
     @DisplayName("countLikes: 정상 호출 시 레포 countByCommentId 호출 결과 반환")
     void countLikes_success() {
-        when(commentLikeRepository.countByCommentId(100L)).thenReturn(7);
-        int cnt = commentLikeService.countLikes(100L);
-        assertEquals(7, cnt);
+        // Given
+        given(commentLikeRepository.countByCommentId(100L)).willReturn(7);
 
+        // When
+        int cnt = commentLikeService.countLikes(100L);
+
+        // Then
+        assertThat(cnt).isEqualTo(7);
         verify(commentLikeRepository, times(1)).countByCommentId(100L);
     }
 }

--- a/src/test/java/com/jdc/recipe_service/service/CommentServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/CommentServiceTest.java
@@ -28,8 +28,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDateTime;
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
@@ -81,22 +82,20 @@ class CommentServiceTest {
     @Test
     @DisplayName("getTop3CommentsWithLikes: 정상 조회 시 매핑된 DTO 리스트 반환")
     void getTop3CommentsWithLikes_success() {
-        // 1) 레포지토리에서 상위 3개 댓글 반환
+        // Given
         List<RecipeComment> topComments = List.of(comment1);
-        when(recipeCommentRepository.findTop3ByRecipeIdAndParentCommentIsNull(eq(20L), any(Pageable.class)))
-                .thenReturn(topComments);
+        given(recipeCommentRepository.findTop3ByRecipeIdAndParentCommentIsNull(eq(20L), any(Pageable.class)))
+                .willReturn(topComments);
 
-        // 2) 좋아요 집계 프로젝션 결과 세팅
         CommentLikeCountProjection proj = new CommentLikeCountProjection() {
             public Long getCommentId() { return 100L; }
             public int getLikeCount() { return 5; }
         };
-        when(commentLikeRepository.countLikesByCommentIds(List.of(100L)))
-                .thenReturn(List.of(proj));
+        given(commentLikeRepository.countLikesByCommentIds(List.of(100L)))
+                .willReturn(List.of(proj));
 
-        // 3) 현재 사용자가 좋아요 누른 댓글 목록 (empty)
-        when(commentLikeRepository.findLikedCommentIdsByUser(10L, List.of(100L)))
-                .thenReturn(Collections.emptyList());
+        given(commentLikeRepository.findLikedCommentIdsByUser(10L, List.of(100L)))
+                .willReturn(Collections.emptyList());
 
         CommentDto mappedDto = CommentDto.builder()
                 .id(100L)
@@ -111,14 +110,16 @@ class CommentServiceTest {
             mm.when(() -> CommentMapper.toDto(eq(comment1), eq(false), eq(5)))
                     .thenReturn(mappedDto);
 
+            // When
             List<CommentDto> result = commentService.getTop3CommentsWithLikes(20L, 10L);
 
-            assertEquals(1, result.size());
+            // Then
+            assertThat(result).hasSize(1);
             CommentDto dto = result.get(0);
-            assertEquals(100L, dto.getId());
-            assertEquals(5, dto.getLikeCount());
-            assertFalse(dto.isLikedByCurrentUser());
-            assertEquals(1, dto.getReplyCount());
+            assertThat(dto.getId()).isEqualTo(100L);
+            assertThat(dto.getLikeCount()).isEqualTo(5);
+            assertThat(dto.isLikedByCurrentUser()).isFalse();
+            assertThat(dto.getReplyCount()).isEqualTo(1);
         }
 
         verify(recipeCommentRepository, times(1))
@@ -133,11 +134,15 @@ class CommentServiceTest {
     @Test
     @DisplayName("getTop3CommentsWithLikes: 댓글이 없을 때 빈 리스트 반환하며, countLikesByCommentIds, findLikedCommentIdsByUser 는 빈 리스트로 호출됨")
     void getTop3CommentsWithLikes_empty() {
-        when(recipeCommentRepository.findTop3ByRecipeIdAndParentCommentIsNull(20L, Pageable.ofSize(3)))
-                .thenReturn(Collections.emptyList());
+        // Given
+        given(recipeCommentRepository.findTop3ByRecipeIdAndParentCommentIsNull(20L, Pageable.ofSize(3)))
+                .willReturn(Collections.emptyList());
 
+        // When
         List<CommentDto> result = commentService.getTop3CommentsWithLikes(20L, 10L);
-        assertTrue(result.isEmpty());
+
+        // Then
+        assertThat(result).isEmpty();
 
         // 댓글이 없더라도 countLikesByCommentIds(emptyList) 호출됨
         verify(commentLikeRepository, times(1))
@@ -149,13 +154,15 @@ class CommentServiceTest {
     @Test
     @DisplayName("createComment: 레시피 없으면 RECIPE_NOT_FOUND 예외")
     void createComment_recipeNotFound() {
-        when(recipeRepository.findById(20L)).thenReturn(Optional.empty());
+        // Given
+        given(recipeRepository.findById(20L)).willReturn(Optional.empty());
 
         CommentRequestDto dto = new CommentRequestDto("내용");
-        CustomException ex = assertThrows(CustomException.class, () ->
-                commentService.createComment(20L, dto, user)
-        );
-        assertEquals(ErrorCode.RECIPE_NOT_FOUND, ex.getErrorCode());
+
+        // When & Then
+        assertThatThrownBy(() -> commentService.createComment(20L, dto, user))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RECIPE_NOT_FOUND));
 
         verify(recipeRepository, times(1)).findById(20L);
         verifyNoInteractions(recipeCommentRepository);
@@ -164,9 +171,10 @@ class CommentServiceTest {
     @Test
     @DisplayName("createComment: 정상 호출 시 매핑된 CommentDto 반환")
     void createComment_success() {
-        when(recipeRepository.findById(20L)).thenReturn(Optional.of(recipe));
-        when(recipeCommentRepository.save(any(RecipeComment.class)))
-                .thenAnswer(invocation -> {
+        // Given
+        given(recipeRepository.findById(20L)).willReturn(Optional.of(recipe));
+        given(recipeCommentRepository.save(any(RecipeComment.class)))
+                .willAnswer(invocation -> {
                     RecipeComment saved = invocation.getArgument(0);
                     ReflectionTestUtils.setField(saved, "id", 200L);
                     return saved;
@@ -186,10 +194,13 @@ class CommentServiceTest {
                     .thenReturn(mappedDto);
 
             CommentRequestDto dto = new CommentRequestDto("내용");
+
+            // When
             CommentDto result = commentService.createComment(20L, dto, user);
 
-            assertEquals(200L, result.getId());
-            assertEquals("내용", result.getContent());
+            // Then
+            assertThat(result.getId()).isEqualTo(200L);
+            assertThat(result.getContent()).isEqualTo("내용");
         }
 
         verify(recipeRepository, times(1)).findById(20L);
@@ -199,12 +210,13 @@ class CommentServiceTest {
     @Test
     @DisplayName("createReply: 레시피 없으면 RECIPE_NOT_FOUND 예외")
     void createReply_recipeNotFound() {
-        when(recipeRepository.findById(20L)).thenReturn(Optional.empty());
+        // Given
+        given(recipeRepository.findById(20L)).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () ->
-                commentService.createReply(20L, 100L, new CommentRequestDto("답글"), user)
-        );
-        assertEquals(ErrorCode.RECIPE_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> commentService.createReply(20L, 100L, new CommentRequestDto("답글"), user))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RECIPE_NOT_FOUND));
 
         verify(recipeRepository, times(1)).findById(20L);
         verifyNoInteractions(userRepository, recipeCommentRepository);
@@ -215,13 +227,14 @@ class CommentServiceTest {
     @Test
     @DisplayName("createReply: 부모 댓글 없으면 COMMENT_NOT_FOUND 예외")
     void createReply_parentNotFound() {
-        when(recipeRepository.findById(20L)).thenReturn(Optional.of(recipe));
-        when(recipeCommentRepository.findByIdAndRecipeId(999L, 20L)).thenReturn(Optional.empty());
+        // Given
+        given(recipeRepository.findById(20L)).willReturn(Optional.of(recipe));
+        given(recipeCommentRepository.findByIdAndRecipeId(999L, 20L)).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () ->
-                commentService.createReply(20L, 999L, new CommentRequestDto("답글"), user)
-        );
-        assertEquals(ErrorCode.COMMENT_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> commentService.createReply(20L, 999L, new CommentRequestDto("답글"), user))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.COMMENT_NOT_FOUND));
 
         verify(recipeRepository, times(1)).findById(20L);
         verify(recipeCommentRepository, times(1))
@@ -231,12 +244,13 @@ class CommentServiceTest {
     @Test
     @DisplayName("createReply: 정상 호출 시 매핑된 ReplyDto 반환")
     void createReply_success() {
-        when(recipeRepository.findById(20L)).thenReturn(Optional.of(recipe));
-        when(recipeCommentRepository.findByIdAndRecipeId(100L, 20L))
-                .thenReturn(Optional.of(comment1));
+        // Given
+        given(recipeRepository.findById(20L)).willReturn(Optional.of(recipe));
+        given(recipeCommentRepository.findByIdAndRecipeId(100L, 20L))
+                .willReturn(Optional.of(comment1));
 
-        when(recipeCommentRepository.save(any(RecipeComment.class)))
-                .thenAnswer(invocation -> {
+        given(recipeCommentRepository.save(any(RecipeComment.class)))
+                .willAnswer(invocation -> {
                     RecipeComment saved = invocation.getArgument(0);
                     ReflectionTestUtils.setField(saved, "id", 300L);
                     return saved;
@@ -254,9 +268,12 @@ class CommentServiceTest {
             mm.when(() -> CommentMapper.toReplyDto(any(RecipeComment.class), eq(false), eq(0)))
                     .thenReturn(mappedReply);
 
+            // When
             ReplyDto result = commentService.createReply(20L, 100L, new CommentRequestDto("답글"), user);
-            assertEquals(300L, result.getId());
-            assertEquals("답글", result.getContent());
+
+            // Then
+            assertThat(result.getId()).isEqualTo(300L);
+            assertThat(result.getContent()).isEqualTo("답글");
         }
 
         verify(recipeCommentRepository, times(1)).save(any(RecipeComment.class));
@@ -265,13 +282,12 @@ class CommentServiceTest {
     @Test
     @DisplayName("getAllCommentsWithLikes: 페이지 정보에 따라 정렬된 CommentDto Page 반환")
     void getAllCommentsWithLikes_success() {
-        // 1) 최상위 댓글 1개에 대댓글 1개 세팅
+        // Given
         List<RecipeComment> comments = List.of(comment1);
         Pageable pageable = PageRequest.of(0, 10, Sort.unsorted());
-        when(recipeCommentRepository.findAllWithRepliesAndUsers(20L, pageable))
-                .thenReturn(comments);
+        given(recipeCommentRepository.findAllWithRepliesAndUsers(20L, pageable))
+                .willReturn(comments);
 
-        // 좋아요 집계
         CommentLikeCountProjection p1 = new CommentLikeCountProjection() {
             public Long getCommentId() { return 100L; }
             public int getLikeCount() { return 2; }
@@ -280,10 +296,10 @@ class CommentServiceTest {
             public Long getCommentId() { return 101L; }
             public int getLikeCount() { return 3; }
         };
-        when(commentLikeRepository.countLikesByCommentIds(List.of(100L, 101L)))
-                .thenReturn(List.of(p1, p2));
-        when(commentLikeRepository.findLikedCommentIdsByUser(10L, List.of(100L, 101L)))
-                .thenReturn(List.of(101L));
+        given(commentLikeRepository.countLikesByCommentIds(List.of(100L, 101L)))
+                .willReturn(List.of(p1, p2));
+        given(commentLikeRepository.findLikedCommentIdsByUser(10L, List.of(100L, 101L)))
+                .willReturn(List.of(101L));
 
         CommentDto topMapped = CommentDto.builder()
                 .id(100L).content("첫 번째 댓글")
@@ -302,13 +318,16 @@ class CommentServiceTest {
             mm.when(() -> CommentMapper.toReplyDto(eq(reply1), eq(true), eq(3)))
                     .thenReturn(replyMapped);
 
+            // When
             Page<CommentDto> page = commentService.getAllCommentsWithLikes(20L, 10L, pageable);
-            assertEquals(1, page.getTotalElements());
+
+            // Then
+            assertThat(page.getTotalElements()).isEqualTo(1);
             CommentDto dto = page.getContent().get(0);
-            assertEquals(100L, dto.getId());
-            assertEquals(2, dto.getLikeCount());
-            assertFalse(dto.isLikedByCurrentUser());
-            assertEquals(1, dto.getReplyCount());
+            assertThat(dto.getId()).isEqualTo(100L);
+            assertThat(dto.getLikeCount()).isEqualTo(2);
+            assertThat(dto.isLikedByCurrentUser()).isFalse();
+            assertThat(dto.getReplyCount()).isEqualTo(1);
         }
 
         verify(recipeCommentRepository, times(1))
@@ -322,13 +341,17 @@ class CommentServiceTest {
     @Test
     @DisplayName("getAllCommentsWithLikes: 댓글 없으면 빈 Page 반환")
     void getAllCommentsWithLikes_empty() {
+        // Given
         Pageable pageable = PageRequest.of(0, 5);
-        when(recipeCommentRepository.findAllWithRepliesAndUsers(20L, pageable))
-                .thenReturn(Collections.emptyList());
+        given(recipeCommentRepository.findAllWithRepliesAndUsers(20L, pageable))
+                .willReturn(Collections.emptyList());
 
+        // When
         Page<CommentDto> page = commentService.getAllCommentsWithLikes(20L, 10L, pageable);
-        assertEquals(0, page.getTotalElements());
-        assertTrue(page.getContent().isEmpty());
+
+        // Then
+        assertThat(page.getTotalElements()).isEqualTo(0);
+        assertThat(page.getContent()).isEmpty();
 
         verify(recipeCommentRepository, times(1))
                 .findAllWithRepliesAndUsers(20L, pageable);
@@ -338,13 +361,14 @@ class CommentServiceTest {
     @Test
     @DisplayName("findByIdAndRecipeId: 없는 댓글이면 COMMENT_NOT_FOUND 예외")
     void findByIdAndRecipeId_notFound() {
-        when(recipeCommentRepository.findByIdAndRecipeId(999L, 20L))
-                .thenReturn(Optional.empty());
+        // Given
+        given(recipeCommentRepository.findByIdAndRecipeId(999L, 20L))
+                .willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () ->
-                commentService.findByIdAndRecipeId(999L, 20L, 10L)
-        );
-        assertEquals(ErrorCode.COMMENT_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> commentService.findByIdAndRecipeId(999L, 20L, 10L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.COMMENT_NOT_FOUND));
 
         verify(recipeCommentRepository, times(1))
                 .findByIdAndRecipeId(999L, 20L);
@@ -353,11 +377,12 @@ class CommentServiceTest {
     @Test
     @DisplayName("findByIdAndRecipeId: 정상 호출 시 매핑된 CommentDto 반환")
     void findByIdAndRecipeId_success() {
-        when(recipeCommentRepository.findByIdAndRecipeId(100L, 20L))
-                .thenReturn(Optional.of(comment1));
+        // Given
+        given(recipeCommentRepository.findByIdAndRecipeId(100L, 20L))
+                .willReturn(Optional.of(comment1));
 
-        when(commentLikeRepository.countByCommentId(100L)).thenReturn(4);
-        when(commentLikeRepository.existsByCommentIdAndUserId(100L, 10L)).thenReturn(true);
+        given(commentLikeRepository.countByCommentId(100L)).willReturn(4);
+        given(commentLikeRepository.existsByCommentIdAndUserId(100L, 10L)).willReturn(true);
 
         CommentDto mapped = CommentDto.builder()
                 .id(100L).content("첫 번째 댓글")
@@ -369,11 +394,14 @@ class CommentServiceTest {
         try (MockedStatic<CommentMapper> mm = Mockito.mockStatic(CommentMapper.class)) {
             mm.when(() -> CommentMapper.toDto(comment1, true, 4)).thenReturn(mapped);
 
+            // When
             CommentDto result = commentService.findByIdAndRecipeId(100L, 20L, 10L);
-            assertEquals(100L, result.getId());
-            assertEquals(4, result.getLikeCount());
-            assertTrue(result.isLikedByCurrentUser());
-            assertEquals(1, result.getReplyCount());
+
+            // Then
+            assertThat(result.getId()).isEqualTo(100L);
+            assertThat(result.getLikeCount()).isEqualTo(4);
+            assertThat(result.isLikedByCurrentUser()).isTrue();
+            assertThat(result.getReplyCount()).isEqualTo(1);
         }
 
         verify(recipeCommentRepository, times(1))
@@ -387,12 +415,13 @@ class CommentServiceTest {
     @Test
     @DisplayName("deleteComment: 없는 댓글이면 COMMENT_NOT_FOUND 예외")
     void deleteComment_notFound() {
-        when(recipeCommentRepository.findById(500L)).thenReturn(Optional.empty());
+        // Given
+        given(recipeCommentRepository.findById(500L)).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () ->
-                commentService.deleteComment(500L, 10L)
-        );
-        assertEquals(ErrorCode.COMMENT_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> commentService.deleteComment(500L, 10L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.COMMENT_NOT_FOUND));
 
         verify(recipeCommentRepository, times(1)).findById(500L);
         verifyNoMoreInteractions(commentLikeRepository, recipeCommentRepository);
@@ -401,18 +430,19 @@ class CommentServiceTest {
     @Test
     @DisplayName("deleteComment: 작성자 != 요청자 이면 COMMENT_ACCESS_DENIED 예외")
     void deleteComment_notOwner() {
+        // Given
         User other = User.builder().id(99L).build();
         RecipeComment otherComment = RecipeComment.builder()
                 .user(other)
                 .build();
         ReflectionTestUtils.setField(otherComment, "id", 600L);
 
-        when(recipeCommentRepository.findById(600L)).thenReturn(Optional.of(otherComment));
+        given(recipeCommentRepository.findById(600L)).willReturn(Optional.of(otherComment));
 
-        CustomException ex = assertThrows(CustomException.class, () ->
-                commentService.deleteComment(600L, 10L)
-        );
-        assertEquals(ErrorCode.COMMENT_ACCESS_DENIED, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> commentService.deleteComment(600L, 10L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.COMMENT_ACCESS_DENIED));
 
         verify(recipeCommentRepository, times(1)).findById(600L);
         verifyNoMoreInteractions(commentLikeRepository, recipeCommentRepository);
@@ -421,10 +451,13 @@ class CommentServiceTest {
     @Test
     @DisplayName("deleteComment: 정상 호출 시 댓글과 좋아요 레포 삭제 호출")
     void deleteComment_success() {
-        when(recipeCommentRepository.findById(100L)).thenReturn(Optional.of(comment1));
+        // Given
+        given(recipeCommentRepository.findById(100L)).willReturn(Optional.of(comment1));
 
+        // When
         commentService.deleteComment(100L, 10L);
 
+        // Then
         // 100L(부모)과 101L(대댓글) → 두 개 모두 삭제
         verify(commentLikeRepository, times(1)).deleteByCommentIdIn(List.of(100L, 101L));
         verify(recipeCommentRepository, times(1)).delete(comment1);
@@ -433,10 +466,13 @@ class CommentServiceTest {
     @Test
     @DisplayName("deleteAllByRecipeId: 댓글이 없으면 댓글이 없더라도 deleteByRecipeId 호출")
     void deleteAllByRecipeId_empty() {
-        when(recipeCommentRepository.findByRecipeId(20L)).thenReturn(Collections.emptyList());
+        // Given
+        given(recipeCommentRepository.findByRecipeId(20L)).willReturn(Collections.emptyList());
 
+        // When
         commentService.deleteAllByRecipeId(20L);
 
+        // Then
         verify(recipeCommentRepository, times(1)).findByRecipeId(20L);
         // 댓글 목록이 빈 리스트여도, deleteByRecipeId(recipeId) 는 호출돼야 함
         verify(recipeCommentRepository, times(1)).deleteByRecipeId(20L);
@@ -446,11 +482,14 @@ class CommentServiceTest {
     @Test
     @DisplayName("deleteAllByRecipeId: 댓글이 있으면 좋아요부터 삭제 후 댓글 일괄 삭제")
     void deleteAllByRecipeId_success() {
+        // Given
         List<RecipeComment> all = List.of(comment1, reply1);
-        when(recipeCommentRepository.findByRecipeId(20L)).thenReturn(all);
+        given(recipeCommentRepository.findByRecipeId(20L)).willReturn(all);
 
+        // When
         commentService.deleteAllByRecipeId(20L);
 
+        // Then
         verify(commentLikeRepository, times(1)).deleteByCommentIdIn(List.of(100L, 101L));
         verify(recipeCommentRepository, times(1)).deleteByRecipeId(20L);
     }
@@ -458,22 +497,23 @@ class CommentServiceTest {
     @Test
     @DisplayName("getRepliesWithLikes: 정상 호출 시 정렬된 ReplyDto Page 반환")
     void getRepliesWithLikes_success() {
+        // Given
         Page<RecipeComment> pageEnt = new PageImpl<>(List.of(reply1), PageRequest.of(0, 5), 1);
         // 좋아요 기준 내림차순 정렬
         Pageable pageable = PageRequest.of(0, 5, Sort.by("likeCount").descending());
 
         // DB 조회 시에는 likeCount 정렬 제외
-        when(recipeCommentRepository.findByParentCommentId(100L, PageRequest.of(0,5, Sort.unsorted())))
-                .thenReturn(pageEnt);
+        given(recipeCommentRepository.findByParentCommentId(100L, PageRequest.of(0,5, Sort.unsorted())))
+                .willReturn(pageEnt);
 
         CommentLikeCountProjection p = new CommentLikeCountProjection() {
             public Long getCommentId() { return 101L; }
             public int getLikeCount() { return 4; }
         };
-        when(commentLikeRepository.countLikesByCommentIds(List.of(101L)))
-                .thenReturn(List.of(p));
-        when(commentLikeRepository.findLikedCommentIdsByUser(10L, List.of(101L)))
-                .thenReturn(List.of(101L));
+        given(commentLikeRepository.countLikesByCommentIds(List.of(101L)))
+                .willReturn(List.of(p));
+        given(commentLikeRepository.findLikedCommentIdsByUser(10L, List.of(101L)))
+                .willReturn(List.of(101L));
 
         ReplyDto mapped = ReplyDto.builder()
                 .id(101L)
@@ -487,12 +527,15 @@ class CommentServiceTest {
             mm.when(() -> CommentMapper.toReplyDto(reply1, true, 4))
                     .thenReturn(mapped);
 
+            // When
             Page<ReplyDto> page = commentService.getRepliesWithLikes(100L, 10L, pageable);
-            assertEquals(1, page.getTotalElements());
+
+            // Then
+            assertThat(page.getTotalElements()).isEqualTo(1);
             ReplyDto dto = page.getContent().get(0);
-            assertEquals(101L, dto.getId());
-            assertEquals(4, dto.getLikeCount());
-            assertTrue(dto.isLikedByCurrentUser());
+            assertThat(dto.getId()).isEqualTo(101L);
+            assertThat(dto.getLikeCount()).isEqualTo(4);
+            assertThat(dto.isLikedByCurrentUser()).isTrue();
         }
 
         verify(recipeCommentRepository, times(1))

--- a/src/test/java/com/jdc/recipe_service/service/DailyQuotaServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/DailyQuotaServiceTest.java
@@ -22,9 +22,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class DailyQuotaServiceTest {
@@ -53,17 +53,20 @@ class DailyQuotaServiceTest {
     @Test
     @DisplayName("시나리오 1: 일일 무료 한도가 남아있으면, 토큰을 확인하지 않고 성공한다 (결과: false)")
     void consume_success_with_daily_quota() {
+        // Given
         setAuth("ROLE_USER");
         Long userId = 1L;
         QuotaType type = QuotaType.AI_GENERATION;
         int limit = 2;
 
-        when(policyRepository.findByQuotaType(type)).thenReturn(Optional.empty());
-        when(props.getPerDay()).thenReturn(limit);
-        when(dao.tryConsume(eq(userId), eq(type), eq(limit))).thenReturn(true); // 무료 성공
+        given(policyRepository.findByQuotaType(type)).willReturn(Optional.empty());
+        given(props.getPerDay()).willReturn(limit);
+        given(dao.tryConsume(eq(userId), eq(type), eq(limit))).willReturn(true); // 무료 성공
 
+        // When
         boolean usedToken = svc.consumeForUserOrThrow(userId, type);
 
+        // Then
         assertThat(usedToken).isFalse();
         verify(userRepository, never()).findById(any());
     }
@@ -71,24 +74,27 @@ class DailyQuotaServiceTest {
     @Test
     @DisplayName("시나리오 2: 일일 한도가 소진되었으나, 보유 토큰이 있으면 성공한다 (결과: true)")
     void consume_success_with_token() {
+        // Given
         setAuth("ROLE_USER");
         Long userId = 1L;
         QuotaType type = QuotaType.AI_GENERATION;
         int limit = 2;
 
-        when(policyRepository.findByQuotaType(type)).thenReturn(Optional.empty());
-        when(props.getPerDay()).thenReturn(limit);
+        given(policyRepository.findByQuotaType(type)).willReturn(Optional.empty());
+        given(props.getPerDay()).willReturn(limit);
 
         // 1. 일일 한도 실패
-        when(dao.tryConsume(eq(userId), eq(type), eq(limit))).thenReturn(false);
+        given(dao.tryConsume(eq(userId), eq(type), eq(limit))).willReturn(false);
 
         // 2. 토큰 성공
         User mockUser = mock(User.class);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-        when(mockUser.tryUseAiToken()).thenReturn(true);
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(mockUser.tryUseAiToken()).willReturn(true);
 
+        // When
         boolean usedToken = svc.consumeForUserOrThrow(userId, type);
 
+        // Then
         assertThat(usedToken).isTrue();
         verify(mockUser).tryUseAiToken();
     }
@@ -96,44 +102,46 @@ class DailyQuotaServiceTest {
     @Test
     @DisplayName("시나리오 3: 일일 한도도 없고, 토큰도 없으면 예외가 발생한다")
     void consume_fail_no_quota_no_token() {
+        // Given
         setAuth("ROLE_USER");
         Long userId = 1L;
         QuotaType type = QuotaType.YOUTUBE_EXTRACTION;
         int limit = 3;
 
-        when(policyRepository.findByQuotaType(type)).thenReturn(Optional.empty());
-        when(props.getYoutubePerDay()).thenReturn(limit);
-        when(props.zoneId()).thenReturn(ZoneId.of("Asia/Seoul"));
+        given(policyRepository.findByQuotaType(type)).willReturn(Optional.empty());
+        given(props.getYoutubePerDay()).willReturn(limit);
+        given(props.zoneId()).willReturn(ZoneId.of("Asia/Seoul"));
 
         // 1. 일일 한도 실패
-        when(dao.tryConsume(eq(userId), eq(type), eq(limit))).thenReturn(false);
+        given(dao.tryConsume(eq(userId), eq(type), eq(limit))).willReturn(false);
 
         // 2. 토큰 실패
         User mockUser = mock(User.class);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-        when(mockUser.tryUseYoutubeToken()).thenReturn(false);
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(mockUser.tryUseYoutubeToken()).willReturn(false);
 
-        assertThrows(
-                DailyQuotaService.DailyQuotaExceededException.class,
-                () -> svc.consumeForUserOrThrow(userId, type)
-        );
+        // When & Then
+        assertThatThrownBy(() -> svc.consumeForUserOrThrow(userId, type))
+                .isInstanceOf(DailyQuotaService.DailyQuotaExceededException.class);
     }
 
     @Test
     @DisplayName("시나리오 4: 토큰을 사용하려는데 유저가 DB에 없으면 예외 발생 (방어 로직)")
     void consume_fail_user_not_found() {
+        // Given
         setAuth("ROLE_USER");
         Long userId = 999L;
         QuotaType type = QuotaType.AI_GENERATION;
 
-        when(policyRepository.findByQuotaType(type)).thenReturn(Optional.empty());
-        when(props.getPerDay()).thenReturn(1);
-        when(dao.tryConsume(any(), any(), anyInt())).thenReturn(false); // 일일 한도 끝남
+        given(policyRepository.findByQuotaType(type)).willReturn(Optional.empty());
+        given(props.getPerDay()).willReturn(1);
+        given(dao.tryConsume(any(), any(), anyInt())).willReturn(false); // 일일 한도 끝남
 
-        when(userRepository.findById(userId)).thenReturn(Optional.empty()); // 유저 없음
+        given(userRepository.findById(userId)).willReturn(Optional.empty()); // 유저 없음
 
-        assertThrows(IllegalArgumentException.class,
-                () -> svc.consumeForUserOrThrow(userId, type));
+        // When & Then
+        assertThatThrownBy(() -> svc.consumeForUserOrThrow(userId, type))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 
@@ -142,12 +150,15 @@ class DailyQuotaServiceTest {
     @Test
     @DisplayName("환불: usedToken=false면 Redis(Dao)를 복구한다")
     void refund_daily_quota() {
+        // Given
         setAuth("ROLE_USER");
         Long userId = 1L;
         QuotaType type = QuotaType.AI_GENERATION;
 
+        // When
         svc.refund(userId, type, false); // 무료 횟수 환불
 
+        // Then
         verify(dao).refundOnce(userId, type);
         verify(userRepository, never()).findById(any());
     }
@@ -155,15 +166,18 @@ class DailyQuotaServiceTest {
     @Test
     @DisplayName("환불: usedToken=true이고 유튜브 타입이면 유튜브 토큰을 복구한다")
     void refund_token_youtube() {
+        // Given
         setAuth("ROLE_USER");
         Long userId = 1L;
         QuotaType type = QuotaType.YOUTUBE_EXTRACTION;
 
         User mockUser = mock(User.class);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
 
+        // When
         svc.refund(userId, type, true); // 토큰 환불
 
+        // Then
         verify(dao, never()).refundOnce(any(), any());
         verify(mockUser).addYoutubeToken(1); // Youtube 토큰 증가 확인
     }
@@ -171,15 +185,18 @@ class DailyQuotaServiceTest {
     @Test
     @DisplayName("환불: usedToken=true이고 AI 타입이면 AI 토큰을 복구한다 [New]")
     void refund_token_ai() {
+        // Given
         setAuth("ROLE_USER");
         Long userId = 1L;
         QuotaType type = QuotaType.AI_GENERATION;
 
         User mockUser = mock(User.class);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
 
+        // When
         svc.refund(userId, type, true); // 토큰 환불
 
+        // Then
         verify(dao, never()).refundOnce(any(), any());
         verify(mockUser).addAiToken(1); // AI 토큰 증가 확인
     }
@@ -189,11 +206,14 @@ class DailyQuotaServiceTest {
     @Test
     @DisplayName("관리자는 무조건 통과 (false 반환)")
     void admin_bypasses_all_limits() {
+        // Given
         setAuth("ROLE_ADMIN");
         Long adminId = 99L;
 
+        // When
         boolean result = svc.consumeForUserOrThrow(adminId, QuotaType.AI_GENERATION);
 
+        // Then
         assertThat(result).isFalse();
         verifyNoInteractions(dao, policyRepository, userRepository);
     }
@@ -201,17 +221,20 @@ class DailyQuotaServiceTest {
     @Test
     @DisplayName("DB 정책 우선순위 확인")
     void db_policy_overrides_properties() {
+        // Given
         setAuth("ROLE_USER");
         Long userId = 3L;
         QuotaType type = QuotaType.AI_GENERATION;
         int dbLimit = 10;
 
         QuotaPolicy mockPolicy = QuotaPolicy.builder().limitCount(dbLimit).build();
-        when(policyRepository.findByQuotaType(type)).thenReturn(Optional.of(mockPolicy));
-        when(dao.tryConsume(eq(userId), eq(type), eq(dbLimit))).thenReturn(true);
+        given(policyRepository.findByQuotaType(type)).willReturn(Optional.of(mockPolicy));
+        given(dao.tryConsume(eq(userId), eq(type), eq(dbLimit))).willReturn(true);
 
+        // When
         svc.consumeForUserOrThrow(userId, type);
 
+        // Then
         verify(dao).tryConsume(eq(userId), eq(type), eq(dbLimit));
     }
 }

--- a/src/test/java/com/jdc/recipe_service/service/GeminiImageServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/GeminiImageServiceTest.java
@@ -22,8 +22,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class GeminiImageServiceTest {
@@ -51,12 +52,13 @@ class GeminiImageServiceTest {
     @Test
     @DisplayName("Failover 테스트: Global 429 에러 시 -> US-Central1으로 우회하여 성공해야 한다")
     void testFailoverLogic() {
-        when(restTemplate.postForEntity(contains("/locations/global/"), any(), eq(Map.class)))
-                .thenThrow(new HttpClientErrorException(HttpStatus.TOO_MANY_REQUESTS));
+        // Given
+        given(restTemplate.postForEntity(contains("/locations/global/"), any(), eq(Map.class)))
+                .willThrow(new HttpClientErrorException(HttpStatus.TOO_MANY_REQUESTS));
 
         Map<String, Object> successResponse = createMockResponse();
-        when(restTemplate.postForEntity(contains("/locations/us-central1/"), any(), eq(Map.class)))
-                .thenReturn(ResponseEntity.ok(successResponse));
+        given(restTemplate.postForEntity(contains("/locations/us-central1/"), any(), eq(Map.class)))
+                .willReturn(ResponseEntity.ok(successResponse));
 
         List<String> result = geminiImageService.generateImageUrls("test prompt", 1L, 100L);
 
@@ -74,12 +76,13 @@ class GeminiImageServiceTest {
     @Test
     @DisplayName("Failover 실패 테스트: 모든 리전이 실패하면 예외가 발생해야 한다 (Unit Test엔 AOP 없음)")
     void generateImageUrls_throwsException_whenAllFail() {
-        when(restTemplate.postForEntity(anyString(), any(), eq(Map.class)))
-                .thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+        // Given
+        given(restTemplate.postForEntity(anyString(), any(), eq(Map.class)))
+                .willThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
 
-        org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> {
-            geminiImageService.generateImageUrls("prompt", 1L, 1L);
-        });
+        // When & Then
+        assertThatThrownBy(() -> geminiImageService.generateImageUrls("prompt", 1L, 1L))
+                .isInstanceOf(Exception.class);
 
         verify(restTemplate, times(3)).postForEntity(anyString(), any(), eq(Map.class));
     }
@@ -99,13 +102,13 @@ class GeminiImageServiceTest {
     @Test
     @DisplayName("네트워크 오류(Timeout) 발생 시에도 다음 리전으로 넘어가야 한다")
     void testFailoverOnNetworkError() {
-
-        when(restTemplate.postForEntity(contains("/locations/global/"), any(), eq(Map.class)))
-                .thenThrow(new ResourceAccessException("Connection timed out"));
+        // Given
+        given(restTemplate.postForEntity(contains("/locations/global/"), any(), eq(Map.class)))
+                .willThrow(new ResourceAccessException("Connection timed out"));
 
         Map<String, Object> successResponse = createMockResponse();
-        when(restTemplate.postForEntity(contains("/locations/us-central1/"), any(), eq(Map.class)))
-                .thenReturn(ResponseEntity.ok(successResponse));
+        given(restTemplate.postForEntity(contains("/locations/us-central1/"), any(), eq(Map.class)))
+                .willReturn(ResponseEntity.ok(successResponse));
 
         geminiImageService.generateImageUrls("prompt", 1L, 1L);
 

--- a/src/test/java/com/jdc/recipe_service/service/OpenAiClientServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/OpenAiClientServiceTest.java
@@ -20,9 +20,10 @@
 //import java.util.Optional;
 //import java.util.concurrent.CompletionException;
 //
-//import static org.junit.jupiter.api.Assertions.*;
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.assertj.core.api.Assertions.assertThatThrownBy;
 //import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.*;
+//import static org.mockito.BDDMockito.*;
 //
 //class OpenAiClientServiceTest {
 //
@@ -42,96 +43,108 @@
 //
 //    @Test
 //    void generateRecipeJson_success() throws Exception {
+//        // Given
 //        String prompt = "테스트 프롬프트";
 //
 //        ChatCompletion completionMock = mock(ChatCompletion.class);
 //        ChatCompletion.Choice choiceMock = mock(ChatCompletion.Choice.class);
 //        ChatCompletionMessage messageMock = mock(ChatCompletionMessage.class);
 //
-//        when(openAIClient.chat()
+//        given(openAIClient.chat()
 //                .completions()
 //                .create(any(ChatCompletionCreateParams.class)))
-//                .thenReturn(completionMock);
+//                .willReturn(completionMock);
 //
-//        when(completionMock.choices()).thenReturn(List.of(choiceMock));
-//        when(choiceMock.message()).thenReturn(messageMock);
-//        when(messageMock.content()).thenReturn(Optional.of("{\"title\":\"dummy\"}"));
+//        given(completionMock.choices()).willReturn(List.of(choiceMock));
+//        given(choiceMock.message()).willReturn(messageMock);
+//        given(messageMock.content()).willReturn(Optional.of("{\"title\":\"dummy\"}"));
 //
 //        RecipeCreateRequestDto dtoMock = new RecipeCreateRequestDto();
-//        when(objectMapper.readValue("{\"title\":\"dummy\"}", RecipeCreateRequestDto.class))
-//                .thenReturn(dtoMock);
+//        given(objectMapper.readValue("{\"title\":\"dummy\"}", RecipeCreateRequestDto.class))
+//                .willReturn(dtoMock);
 //
+//        // When
 //        RecipeCreateRequestDto result = openAiClientService
 //                .generateRecipeJson(prompt)
 //                .join();
 //
-//        assertSame(dtoMock, result);
+//        // Then
+//        assertThat(result).isSameAs(dtoMock);
 //    }
 //
 //    @Test
 //    void generateRecipeJson_emptyChoices_throwsCustomException() {
+//        // Given
 //        ChatCompletion completionMock = mock(ChatCompletion.class);
 //
-//        when(openAIClient.chat()
+//        given(openAIClient.chat()
 //                .completions()
 //                .create(any(ChatCompletionCreateParams.class)))
-//                .thenReturn(completionMock);
+//                .willReturn(completionMock);
 //
-//        when(completionMock.choices()).thenReturn(List.of());
+//        given(completionMock.choices()).willReturn(List.of());
 //
-//        CompletionException ex = assertThrows(CompletionException.class, () ->
-//                openAiClientService.generateRecipeJson("p").join()
-//        );
-//        assertTrue(ex.getCause() instanceof CustomException);
-//        assertEquals(ErrorCode.AI_RECIPE_GENERATION_FAILED,
-//                ((CustomException) ex.getCause()).getErrorCode());
+//        // When & Then
+//        assertThatThrownBy(() -> openAiClientService.generateRecipeJson("p").join())
+//                .isInstanceOf(CompletionException.class)
+//                .satisfies(e -> {
+//                    assertThat(e.getCause()).isInstanceOf(CustomException.class);
+//                    assertThat(((CustomException) e.getCause()).getErrorCode())
+//                            .isEqualTo(ErrorCode.AI_RECIPE_GENERATION_FAILED);
+//                });
 //    }
 //
 //    @Test
 //    void generateRecipeJson_noContent_throwsCustomException() {
+//        // Given
 //        ChatCompletion completionMock = mock(ChatCompletion.class);
 //        ChatCompletion.Choice choiceMock = mock(ChatCompletion.Choice.class);
 //        ChatCompletionMessage messageMock = mock(ChatCompletionMessage.class);
 //
-//        when(openAIClient.chat()
+//        given(openAIClient.chat()
 //                .completions()
 //                .create(any(ChatCompletionCreateParams.class)))
-//                .thenReturn(completionMock);
+//                .willReturn(completionMock);
 //
-//        when(completionMock.choices()).thenReturn(List.of(choiceMock));
-//        when(choiceMock.message()).thenReturn(messageMock);
-//        when(messageMock.content()).thenReturn(Optional.empty());
+//        given(completionMock.choices()).willReturn(List.of(choiceMock));
+//        given(choiceMock.message()).willReturn(messageMock);
+//        given(messageMock.content()).willReturn(Optional.empty());
 //
-//        CompletionException ex = assertThrows(CompletionException.class, () ->
-//                openAiClientService.generateRecipeJson("p").join()
-//        );
-//        assertTrue(ex.getCause() instanceof CustomException);
-//        assertEquals(ErrorCode.AI_RECIPE_GENERATION_FAILED,
-//                ((CustomException) ex.getCause()).getErrorCode());
+//        // When & Then
+//        assertThatThrownBy(() -> openAiClientService.generateRecipeJson("p").join())
+//                .isInstanceOf(CompletionException.class)
+//                .satisfies(e -> {
+//                    assertThat(e.getCause()).isInstanceOf(CustomException.class);
+//                    assertThat(((CustomException) e.getCause()).getErrorCode())
+//                            .isEqualTo(ErrorCode.AI_RECIPE_GENERATION_FAILED);
+//                });
 //    }
 //
 //    @Test
 //    void generateRecipeJson_invalidJson_throwsCustomException() throws Exception {
+//        // Given
 //        ChatCompletion completionMock = mock(ChatCompletion.class);
 //        ChatCompletion.Choice choiceMock = mock(ChatCompletion.Choice.class);
 //        ChatCompletionMessage messageMock = mock(ChatCompletionMessage.class);
 //
-//        when(openAIClient.chat()
+//        given(openAIClient.chat()
 //                .completions()
 //                .create(any(ChatCompletionCreateParams.class)))
-//                .thenReturn(completionMock);
+//                .willReturn(completionMock);
 //
-//        when(completionMock.choices()).thenReturn(List.of(choiceMock));
-//        when(choiceMock.message()).thenReturn(messageMock);
-//        when(messageMock.content()).thenReturn(Optional.of("잘못된 JSON"));
-//        when(objectMapper.readValue("잘못된 JSON", RecipeCreateRequestDto.class))
-//                .thenThrow(new RuntimeException("파싱 에러"));
+//        given(completionMock.choices()).willReturn(List.of(choiceMock));
+//        given(choiceMock.message()).willReturn(messageMock);
+//        given(messageMock.content()).willReturn(Optional.of("잘못된 JSON"));
+//        given(objectMapper.readValue("잘못된 JSON", RecipeCreateRequestDto.class))
+//                .willThrow(new RuntimeException("파싱 에러"));
 //
-//        CompletionException ex = assertThrows(CompletionException.class, () ->
-//                openAiClientService.generateRecipeJson("p").join()
-//        );
-//        assertTrue(ex.getCause() instanceof CustomException);
-//        assertEquals(ErrorCode.INTERNAL_SERVER_ERROR,
-//                ((CustomException) ex.getCause()).getErrorCode());
+//        // When & Then
+//        assertThatThrownBy(() -> openAiClientService.generateRecipeJson("p").join())
+//                .isInstanceOf(CompletionException.class)
+//                .satisfies(e -> {
+//                    assertThat(e.getCause()).isInstanceOf(CustomException.class);
+//                    assertThat(((CustomException) e.getCause()).getErrorCode())
+//                            .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+//                });
 //    }
 //}

--- a/src/test/java/com/jdc/recipe_service/service/RecipeExtractionServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeExtractionServiceTest.java
@@ -29,13 +29,15 @@ import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.*;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -74,7 +76,7 @@ class RecipeExtractionServiceTest {
         );
 
         // TransactionTemplate Mocking
-        lenient().when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+        lenient().given(transactionTemplate.execute(any())).willAnswer(invocation -> {
             TransactionCallback<Object> callback = invocation.getArgument(0);
             return callback.doInTransaction(null);
         });
@@ -86,11 +88,11 @@ class RecipeExtractionServiceTest {
             return null;
         }).when(transactionTemplate).executeWithoutResult(any());
 
-        // [핵심] Gemini 기본 Mocking (NPE 방지) - 이게 없어서 터졌음
+        // [핵심] Gemini 기본 Mocking (NPE 방지)
         RecipeCreateRequestDto defaultGeminiResponse = new RecipeCreateRequestDto();
         defaultGeminiResponse.setIsRecipe(true);
-        lenient().when(geminiMultimodalService.generateRecipeFromYoutubeUrl(any(), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(defaultGeminiResponse));
+        lenient().given(geminiMultimodalService.generateRecipeFromYoutubeUrl(any(), any(), any()))
+                .willReturn(CompletableFuture.completedFuture(defaultGeminiResponse));
     }
 
     @Test
@@ -104,13 +106,13 @@ class RecipeExtractionServiceTest {
         RecipeGenerationJob jobA = spy(RecipeGenerationJob.builder().id(1L).userId(userA).status(JobStatus.PENDING).build());
         RecipeGenerationJob jobB = spy(RecipeGenerationJob.builder().id(2L).userId(userB).status(JobStatus.PENDING).build());
 
-        when(jobRepository.findById(1L)).thenReturn(Optional.of(jobA));
-        when(jobRepository.findById(2L)).thenReturn(Optional.of(jobB));
+        // Given
+        given(jobRepository.findById(1L)).willReturn(Optional.of(jobA));
+        given(jobRepository.findById(2L)).willReturn(Optional.of(jobB));
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        // yt-dlp Delay Mock
-        when(ytDlpService.getVideoDataFull(anyString())).thenAnswer(inv -> {
+        given(ytDlpService.getVideoDataFull(anyString())).willAnswer(inv -> {
             System.out.println("🐌 [Test] AI 처리 중... (Delay)");
             latch.await(1, TimeUnit.SECONDS);
             return new YtDlpService.YoutubeFullDataDto("busvideo1", videoUrl, "Title", SUFFICIENT_TEXT, "Comments", "Sub", SUFFICIENT_TEXT, "Ch", "Id", "Thumb", "Prof", 100L, 100L, 60L);
@@ -145,26 +147,25 @@ class RecipeExtractionServiceTest {
         String videoUrl = "https://www.youtube.com/watch?v=mukbang";
         RecipeGenerationJob job = spy(RecipeGenerationJob.builder().id(jobId).status(JobStatus.PENDING).build());
 
-        when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
-
-        when(ytDlpService.getVideoDataFull(anyString())).thenReturn(
+        // Given
+        given(jobRepository.findById(jobId)).willReturn(Optional.of(job));
+        given(ytDlpService.getVideoDataFull(anyString())).willReturn(
                 new YtDlpService.YoutubeFullDataDto("mukbang", videoUrl, "Mukbang", SUFFICIENT_TEXT, "Eat", "", SUFFICIENT_TEXT, "Ch", "Id", "", "", 0L, 0L, 100L)
         );
 
-        // Grok 결과: 레시피 아님
         RecipeCreateRequestDto fakeResult = new RecipeCreateRequestDto();
         fakeResult.setIsRecipe(false);
         fakeResult.setNonRecipeReason("그냥 먹방임");
-        when(grokClientService.generateRecipeStep1(any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(fakeResult));
+        given(grokClientService.generateRecipeStep1(any(), any()))
+                .willReturn(CompletableFuture.completedFuture(fakeResult));
 
+        // When
         service.processYoutubeExtractionAsyncV2(jobId, videoUrl, 100L, "User");
 
+        // Then
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(job).setErrorMessage(captor.capture());
-
-        // 901 에러 확인
-        assertTrue(captor.getValue().startsWith("901::"));
+        assertThat(captor.getValue()).startsWith("901::");
         // 환불 호출 X 확인
         verify(dailyQuotaService, never()).refund(anyLong(), any(), anyBoolean());
     }
@@ -176,14 +177,11 @@ class RecipeExtractionServiceTest {
         String videoUrl = "https://www.youtube.com/watch?v=error";
         RecipeGenerationJob job = spy(RecipeGenerationJob.builder().id(jobId).status(JobStatus.PENDING).build());
 
-        when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
-
-        // 1. yt-dlp 실패 (의도적 예외)
-        when(ytDlpService.getVideoDataFull(anyString())).thenThrow(new RuntimeException("Connection Error"));
-
-        // 2. Fallback Gemini도 실패하도록 설정 (Mock 재설정)
-        when(geminiMultimodalService.generateRecipeFromYoutubeUrl(any(), any(), any()))
-                .thenThrow(new RuntimeException("Gemini Also Failed"));
+        // Given
+        given(jobRepository.findById(jobId)).willReturn(Optional.of(job));
+        given(ytDlpService.getVideoDataFull(anyString())).willThrow(new RuntimeException("Connection Error"));
+        given(geminiMultimodalService.generateRecipeFromYoutubeUrl(any(), any(), any()))
+                .willThrow(new RuntimeException("Gemini Also Failed"));
 
         service.processYoutubeExtractionAsyncV2(jobId, videoUrl, 100L, "User");
 
@@ -204,9 +202,9 @@ class RecipeExtractionServiceTest {
         String shortsUrl = "https://www.youtube.com/shorts/shorts123?feature=share";
         RecipeGenerationJob job = spy(RecipeGenerationJob.builder().id(jobId).status(JobStatus.PENDING).build());
 
-        when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
-
-        when(ytDlpService.getVideoDataFull(anyString())).thenAnswer(inv -> {
+        // Given
+        given(jobRepository.findById(jobId)).willReturn(Optional.of(job));
+        given(ytDlpService.getVideoDataFull(anyString())).willAnswer(inv -> {
             String url = inv.getArgument(0);
             if(url.contains("shorts123")) {
                 return new YtDlpService.YoutubeFullDataDto("shorts123", url, "Shorts", SUFFICIENT_TEXT, "", "", SUFFICIENT_TEXT, "Ch", "Id", "", "", 0L, 0L, 50L);
@@ -233,13 +231,16 @@ class RecipeExtractionServiceTest {
                 .progress(0)
                 .build();
 
-        when(jobRepository.findById(jobId)).thenReturn(Optional.of(failedJob));
+        // Given
+        given(jobRepository.findById(jobId)).willReturn(Optional.of(failedJob));
 
+        // When
         JobStatusDto statusDto = service.getJobStatus(jobId);
 
-        assertEquals("901", statusDto.getCode());
-        assertEquals("레시피 영상이 아닙니다.", statusDto.getMessage());
-        assertEquals(JobStatus.FAILED, statusDto.getStatus());
+        // Then
+        assertThat(statusDto.getCode()).isEqualTo("901");
+        assertThat(statusDto.getMessage()).isEqualTo("레시피 영상이 아닙니다.");
+        assertThat(statusDto.getStatus()).isEqualTo(JobStatus.FAILED);
     }
 
     private void mockSuccessFlow(Long recipeId) {
@@ -247,18 +248,16 @@ class RecipeExtractionServiceTest {
         mockDto.setIsRecipe(true);
         mockDto.setIngredients(new ArrayList<>());
 
-        lenient().when(grokClientService.generateRecipeStep1(any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(mockDto));
-
-        lenient().when(grokClientService.refineIngredientsOnly(any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(new ArrayList<>()));
-
-        lenient().when(asyncImageService.generateImageFromDto(any(), anyLong()))
-                .thenReturn(CompletableFuture.completedFuture("http://img.com/a.jpg"));
+        lenient().given(grokClientService.generateRecipeStep1(any(), any()))
+                .willReturn(CompletableFuture.completedFuture(mockDto));
+        lenient().given(grokClientService.refineIngredientsOnly(any(), any()))
+                .willReturn(CompletableFuture.completedFuture(new ArrayList<>()));
+        lenient().given(asyncImageService.generateImageFromDto(any(), anyLong()))
+                .willReturn(CompletableFuture.completedFuture("http://img.com/a.jpg"));
 
         PresignedUrlResponse response = PresignedUrlResponse.builder().recipeId(recipeId).build();
-        lenient().when(recipeService.createRecipeAndGenerateUrls(any(), anyLong(), any(), any()))
-                .thenReturn(response);
+        lenient().given(recipeService.createRecipeAndGenerateUrls(any(), anyLong(), any(), any()))
+                .willReturn(response);
     }
 
     @Test
@@ -276,7 +275,8 @@ class RecipeExtractionServiceTest {
                 .status(JobStatus.IN_PROGRESS)
                 .build();
 
-        when(jobRepository.findById(jobId)).thenReturn(Optional.of(mockJob));
+        // Given
+        given(jobRepository.findById(jobId)).willReturn(Optional.of(mockJob));
 
         PresignedUrlResponse mockResponse = PresignedUrlResponse.builder().recipeId(recipeId).build();
         doAnswer(invocation -> {
@@ -299,5 +299,132 @@ class RecipeExtractionServiceTest {
         }
 
         verify(recipeFavoriteService, times(3)).addFavoriteIfNotExists(userId, recipeId);
+    }
+
+    // ─── parseIngredientBlock / buildIngredientHighlightSection ────────────────
+
+    @Test
+    @DisplayName("parseIngredientBlock: '재료' 섹션 키워드 이후 라인이 결과 목록에 수집되는 테스트")
+    void parseIngredientBlock_collectsLinesAfterSectionKeyword() {
+        // Given
+        String text = """
+                재료
+                계란 2개
+                소금 약간
+
+                만드는 법
+                1. 끓인다
+                """;
+        List<String> result = new ArrayList<>();
+
+        // When
+        ReflectionTestUtils.invokeMethod(service, "parseIngredientBlock", text, result);
+
+        // Then
+        assertThat(result).contains("계란 2개", "소금 약간");
+        assertThat(result).doesNotContain("만드는 법", "1. 끓인다");
+    }
+
+    @Test
+    @DisplayName("parseIngredientBlock: 섹션 키워드 없이도 단위 패턴 매칭 라인이 수집되는 테스트")
+    void parseIngredientBlock_collectsLinesMatchingUnitPattern() {
+        // Given
+        String text = """
+                오늘의 요리 소개합니다
+                간장 3T
+                설탕 2큰술
+                물 200ml
+                아무 텍스트
+                """;
+        List<String> result = new ArrayList<>();
+
+        // When
+        ReflectionTestUtils.invokeMethod(service, "parseIngredientBlock", text, result);
+
+        // Then
+        assertThat(result).contains("간장 3T", "설탕 2큰술", "물 200ml");
+    }
+
+    @Test
+    @DisplayName("parseIngredientBlock: 콤마로 구분된 재료는 개별 항목으로 분리되는 테스트")
+    void parseIngredientBlock_splitsCommaSeparatedIngredients() {
+        // Given — 섹션 키워드 형식으로 재료가 나열된 경우
+        String text = """
+                재료
+                소스 : 간장 4T, 맛술 2T, 참기름 1T
+                """;
+        List<String> result = new ArrayList<>();
+
+        // When
+        ReflectionTestUtils.invokeMethod(service, "parseIngredientBlock", text, result);
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder("간장 4T", "맛술 2T", "참기름 1T");
+    }
+
+    @Test
+    @DisplayName("buildIngredientHighlightSection: 설명글에 재료 없으면 빈 문자열을 반환하는 테스트")
+    void buildIngredientHighlightSection_returnsEmptyStringWhenNoIngredients() {
+        // Given
+        String description = "안녕하세요 오늘은 맛있는 요리를 소개합니다";
+        String comments = "구독 좋아요 눌러주세요~";
+
+        // When
+        String result = ReflectionTestUtils.invokeMethod(service, "buildIngredientHighlightSection", description, comments);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("buildIngredientHighlightSection: 재료 있으면 🔴 강조 헤더가 붙은 문자열을 반환하는 테스트")
+    void buildIngredientHighlightSection_returnsHighlightedSectionWhenIngredientsFound() {
+        // Given
+        String description = """
+                재료
+                두부 1모
+                간장 2T
+                """;
+        String comments = "";
+
+        // When
+        String result = ReflectionTestUtils.invokeMethod(service, "buildIngredientHighlightSection", description, comments);
+
+        // Then
+        assertThat(result).startsWith("🔴 [최우선 재료 목록");
+        assertThat(result).contains("두부 1모", "간장 2T");
+    }
+
+    @Test
+    @DisplayName("buildIngredientHighlightSection: 댓글에서도 재료를 추출하는 테스트")
+    void buildIngredientHighlightSection_extractsIngredientsFromComments() {
+        // Given — 설명글엔 재료 없고 댓글에 재료 있는 경우
+        String description = "오늘도 좋은 하루 되세요!";
+        String comments = """
+                재료
+                닭가슴살 200g
+                올리브오일 1T
+                """;
+
+        // When
+        String result = ReflectionTestUtils.invokeMethod(service, "buildIngredientHighlightSection", description, comments);
+
+        // Then
+        assertThat(result).contains("닭가슴살 200g", "올리브오일 1T");
+    }
+
+    @Test
+    @DisplayName("parseIngredientBlock: null 또는 빈 문자열 입력 시 예외 없이 빈 결과를 반환하는 테스트")
+    void parseIngredientBlock_handlesNullAndEmptyInputGracefully() {
+        // Given
+        List<String> result1 = new ArrayList<>();
+        List<String> result2 = new ArrayList<>();
+
+        // When & Then — 예외 없이 처리
+        ReflectionTestUtils.invokeMethod(service, "parseIngredientBlock", (Object) null, result1);
+        ReflectionTestUtils.invokeMethod(service, "parseIngredientBlock", "   ", result2);
+
+        assertThat(result1).isEmpty();
+        assertThat(result2).isEmpty();
     }
 }

--- a/src/test/java/com/jdc/recipe_service/service/RecipeExtractionServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeExtractionServiceTest.java
@@ -76,12 +76,12 @@ class RecipeExtractionServiceTest {
         );
 
         // TransactionTemplate Mocking
-        lenient().given(transactionTemplate.execute(any())).willAnswer(invocation -> {
+        given(transactionTemplate.execute(any())).willAnswer(invocation -> {
             TransactionCallback<Object> callback = invocation.getArgument(0);
             return callback.doInTransaction(null);
         });
 
-        lenient().doAnswer(invocation -> {
+        doAnswer(invocation -> {
             java.util.function.Consumer<org.springframework.transaction.TransactionStatus> consumer =
                     invocation.getArgument(0);
             consumer.accept(null);
@@ -91,7 +91,7 @@ class RecipeExtractionServiceTest {
         // [핵심] Gemini 기본 Mocking (NPE 방지)
         RecipeCreateRequestDto defaultGeminiResponse = new RecipeCreateRequestDto();
         defaultGeminiResponse.setIsRecipe(true);
-        lenient().given(geminiMultimodalService.generateRecipeFromYoutubeUrl(any(), any(), any()))
+        given(geminiMultimodalService.generateRecipeFromYoutubeUrl(any(), any(), any()))
                 .willReturn(CompletableFuture.completedFuture(defaultGeminiResponse));
     }
 
@@ -248,15 +248,15 @@ class RecipeExtractionServiceTest {
         mockDto.setIsRecipe(true);
         mockDto.setIngredients(new ArrayList<>());
 
-        lenient().given(grokClientService.generateRecipeStep1(any(), any()))
+        given(grokClientService.generateRecipeStep1(any(), any()))
                 .willReturn(CompletableFuture.completedFuture(mockDto));
-        lenient().given(grokClientService.refineIngredientsOnly(any(), any()))
+        given(grokClientService.refineIngredientsOnly(any(), any()))
                 .willReturn(CompletableFuture.completedFuture(new ArrayList<>()));
-        lenient().given(asyncImageService.generateImageFromDto(any(), anyLong()))
+        given(asyncImageService.generateImageFromDto(any(), anyLong()))
                 .willReturn(CompletableFuture.completedFuture("http://img.com/a.jpg"));
 
         PresignedUrlResponse response = PresignedUrlResponse.builder().recipeId(recipeId).build();
-        lenient().given(recipeService.createRecipeAndGenerateUrls(any(), anyLong(), any(), any()))
+        given(recipeService.createRecipeAndGenerateUrls(any(), anyLong(), any(), any()))
                 .willReturn(response);
     }
 

--- a/src/test/java/com/jdc/recipe_service/service/RecipeFavoriteServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeFavoriteServiceTest.java
@@ -17,8 +17,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class RecipeFavoriteServiceTest {
@@ -45,21 +46,24 @@ class RecipeFavoriteServiceTest {
     @Test
     @DisplayName("toggleFavorite: 이미 즐겨찾기 되어 있으면 삭제 후 false 반환")
     void toggleFavorite_existingFavorite_returnsFalse() {
+        // Given
         // 1) favoriteRepository.findByUserIdAndRecipeId(...) 가 Optional.of(...) 리턴
         RecipeFavorite existing = RecipeFavorite.builder()
                 .id(100L)
                 .user(user)
                 .recipe(recipe)
                 .build();
-        when(favoriteRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
-                .thenReturn(Optional.of(existing));
+        given(favoriteRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
+                .willReturn(Optional.of(existing));
 
         // 2) delete(...) 호출 시 아무 일 없음
-        doNothing().when(favoriteRepository).delete(existing);
+        willDoNothing().given(favoriteRepository).delete(existing);
 
+        // When
         boolean result = favoriteService.toggleFavorite(user.getId(), recipe.getId());
 
-        assertFalse(result);
+        // Then
+        assertThat(result).isFalse();
         verify(favoriteRepository, times(1)).findByUserIdAndRecipeId(user.getId(), recipe.getId());
         verify(favoriteRepository, times(1)).delete(existing);
         // 유저/레시피 조회는 호출되지 않아야 함
@@ -69,44 +73,48 @@ class RecipeFavoriteServiceTest {
     @Test
     @DisplayName("toggleFavorite: 즐겨찾기 기록이 없으면 새로 저장 후 true 반환")
     void toggleFavorite_noFavorite_savesAndReturnsTrue() {
+        // Given
         // 1) findByUserIdAndRecipeId -> Optional.empty()
-        when(favoriteRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
-                .thenReturn(Optional.empty());
+        given(favoriteRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
+                .willReturn(Optional.empty());
 
         // 2) userRepository.findById -> user
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         // 3) recipeRepository.findById -> recipe
-        when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
+        given(recipeRepository.findById(recipe.getId())).willReturn(Optional.of(recipe));
 
         // 4) save(...) 호출 시 그대로 RecipeFavorite 객체 리턴
         ArgumentCaptor<RecipeFavorite> captor = ArgumentCaptor.forClass(RecipeFavorite.class);
-        when(favoriteRepository.save(captor.capture()))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        given(favoriteRepository.save(captor.capture()))
+                .willAnswer(invocation -> invocation.getArgument(0));
 
+        // When
         boolean result = favoriteService.toggleFavorite(user.getId(), recipe.getId());
 
-        assertTrue(result);
+        // Then
+        assertThat(result).isTrue();
         verify(favoriteRepository, times(1)).findByUserIdAndRecipeId(user.getId(), recipe.getId());
         verify(userRepository, times(1)).findById(user.getId());
         verify(recipeRepository, times(1)).findById(recipe.getId());
         verify(favoriteRepository, times(1)).save(any(RecipeFavorite.class));
 
         RecipeFavorite saved = captor.getValue();
-        assertEquals(user.getId(), saved.getUser().getId());
-        assertEquals(recipe.getId(), saved.getRecipe().getId());
+        assertThat(saved.getUser().getId()).isEqualTo(user.getId());
+        assertThat(saved.getRecipe().getId()).isEqualTo(recipe.getId());
     }
 
     @Test
     @DisplayName("toggleFavorite: 존재하지 않는 유저면 USER_NOT_FOUND 예외")
     void toggleFavorite_userNotFound_throwsException() {
-        when(favoriteRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
-                .thenReturn(Optional.empty());
-        when(userRepository.findById(user.getId())).thenReturn(Optional.empty());
+        // Given
+        given(favoriteRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
+                .willReturn(Optional.empty());
+        given(userRepository.findById(user.getId())).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            favoriteService.toggleFavorite(user.getId(), recipe.getId());
-        });
-        assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> favoriteService.toggleFavorite(user.getId(), recipe.getId()))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
 
         verify(favoriteRepository, times(1)).findByUserIdAndRecipeId(user.getId(), recipe.getId());
         verify(userRepository, times(1)).findById(user.getId());
@@ -116,15 +124,16 @@ class RecipeFavoriteServiceTest {
     @Test
     @DisplayName("toggleFavorite: 존재하지 않는 레시피면 RECIPE_NOT_FOUND 예외")
     void toggleFavorite_recipeNotFound_throwsException() {
-        when(favoriteRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
-                .thenReturn(Optional.empty());
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.empty());
+        // Given
+        given(favoriteRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
+                .willReturn(Optional.empty());
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(recipeRepository.findById(recipe.getId())).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            favoriteService.toggleFavorite(user.getId(), recipe.getId());
-        });
-        assertEquals(ErrorCode.RECIPE_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> favoriteService.toggleFavorite(user.getId(), recipe.getId()))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RECIPE_NOT_FOUND));
 
         verify(favoriteRepository, times(1)).findByUserIdAndRecipeId(user.getId(), recipe.getId());
         verify(userRepository, times(1)).findById(user.getId());
@@ -135,10 +144,13 @@ class RecipeFavoriteServiceTest {
     @Test
     @DisplayName("deleteByRecipeId: favoriteRepository.deleteByRecipeId 호출")
     void deleteByRecipeId_invokesRepository() {
-        doNothing().when(favoriteRepository).deleteByRecipeId(recipe.getId());
+        // Given
+        willDoNothing().given(favoriteRepository).deleteByRecipeId(recipe.getId());
 
+        // When
         favoriteService.deleteByRecipeId(recipe.getId());
 
+        // Then
         verify(favoriteRepository, times(1)).deleteByRecipeId(recipe.getId());
     }
 }

--- a/src/test/java/com/jdc/recipe_service/service/RecipeIngredientServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeIngredientServiceTest.java
@@ -20,8 +20,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.math.BigDecimal;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class RecipeIngredientServiceTest {
@@ -58,7 +59,7 @@ class RecipeIngredientServiceTest {
                 .unit("g")
                 .price(500)
                 .build();
-        when(ingredientRepository.findAll()).thenReturn(List.of(master));
+        given(ingredientRepository.findAll()).willReturn(List.of(master));
 
         RecipeIngredientRequestDto dto = RecipeIngredientRequestDto.builder()
                 .name("소금")
@@ -73,16 +74,17 @@ class RecipeIngredientServiceTest {
                 RecipeSourceType.USER
         );
 
-        assertEquals(0, totalCost, "총 가격은 0이어야 합니다.");
+        // Then
+        assertThat(totalCost).isEqualTo(0);
 
         ArgumentCaptor<RecipeIngredient> captor = ArgumentCaptor.forClass(RecipeIngredient.class);
         verify(recipeIngredientRepository, times(1)).save(captor.capture());
 
         RecipeIngredient savedEntity = captor.getValue();
-        assertEquals("약간", savedEntity.getQuantity(), "DB에는 원본 수량 문자열이 저장되어야 합니다.");
-        assertEquals(0, savedEntity.getPrice().intValue(), "계산된 가격은 0이어야 합니다.");
-        assertNotNull(savedEntity.getIngredient());
-        assertEquals(master.getId(), savedEntity.getIngredient().getId());
+        assertThat(savedEntity.getQuantity()).isEqualTo("약간");
+        assertThat(savedEntity.getPrice().intValue()).isEqualTo(0);
+        assertThat(savedEntity.getIngredient()).isNotNull();
+        assertThat(savedEntity.getIngredient().getId()).isEqualTo(master.getId());
     }
 
     @Test
@@ -95,7 +97,7 @@ class RecipeIngredientServiceTest {
                 .price(1000)
                 .build();
 
-        when(ingredientRepository.findAll()).thenReturn(List.of(master));
+        given(ingredientRepository.findAll()).willReturn(List.of(master));
 
         RecipeIngredientRequestDto dto = RecipeIngredientRequestDto.builder()
                 .name("감자")
@@ -110,21 +112,22 @@ class RecipeIngredientServiceTest {
                 RecipeSourceType.USER
         );
 
-        assertEquals(2000, totalCost);
+        // Then
+        assertThat(totalCost).isEqualTo(2000);
 
         ArgumentCaptor<RecipeIngredient> captor = ArgumentCaptor.forClass(RecipeIngredient.class);
         verify(recipeIngredientRepository, times(1)).save(captor.capture());
 
         RecipeIngredient savedEntity = captor.getValue();
-        assertEquals(dummyRecipe.getId(), savedEntity.getRecipe().getId());
-        assertNotNull(savedEntity.getIngredient());
-        assertEquals(master.getId(), savedEntity.getIngredient().getId());
-        assertEquals("2", savedEntity.getQuantity());
-        assertEquals("g", savedEntity.getUnit());
-        assertEquals(2000, savedEntity.getPrice().intValue());
-        assertNull(savedEntity.getCustomName());
-        assertNull(savedEntity.getCustomPrice());
-        assertNull(savedEntity.getCustomUnit());
+        assertThat(savedEntity.getRecipe().getId()).isEqualTo(dummyRecipe.getId());
+        assertThat(savedEntity.getIngredient()).isNotNull();
+        assertThat(savedEntity.getIngredient().getId()).isEqualTo(master.getId());
+        assertThat(savedEntity.getQuantity()).isEqualTo("2");
+        assertThat(savedEntity.getUnit()).isEqualTo("g");
+        assertThat(savedEntity.getPrice().intValue()).isEqualTo(2000);
+        assertThat(savedEntity.getCustomName()).isNull();
+        assertThat(savedEntity.getCustomPrice()).isEqualTo(0); // 마스터 재료 사용 시 customPrice는 0으로 초기화
+        assertThat(savedEntity.getCustomUnit()).isNull();
     }
 
     @Test
@@ -136,7 +139,7 @@ class RecipeIngredientServiceTest {
                 .unit("kg")
                 .price(2000)
                 .build();
-        when(ingredientRepository.findAll()).thenReturn(List.of(master));
+        given(ingredientRepository.findAll()).willReturn(List.of(master));
 
         RecipeIngredientRequestDto dto = RecipeIngredientRequestDto.builder()
                 .name("밀가루")
@@ -151,20 +154,21 @@ class RecipeIngredientServiceTest {
                 RecipeSourceType.USER
         );
 
-        assertEquals(1000, totalCost);
+        // Then
+        assertThat(totalCost).isEqualTo(1000);
 
         ArgumentCaptor<RecipeIngredient> captor = ArgumentCaptor.forClass(RecipeIngredient.class);
         verify(recipeIngredientRepository, times(1)).save(captor.capture());
         RecipeIngredient savedEntity = captor.getValue();
-        assertEquals("1/2", savedEntity.getQuantity());
-        assertEquals("kg", savedEntity.getUnit());
-        assertEquals(1000, savedEntity.getPrice().intValue());
+        assertThat(savedEntity.getQuantity()).isEqualTo("1/2");
+        assertThat(savedEntity.getUnit()).isEqualTo("kg");
+        assertThat(savedEntity.getPrice().intValue()).isEqualTo(1000);
     }
 
     @Test
     @DisplayName("saveAll: 마스터 재료가 없고, USER 모드에서 customPrice 혹은 customUnit이 없으면 예외 발생")
     void saveAll_masterIngredientMissing_userMode_throwException() {
-        when(ingredientRepository.findAll()).thenReturn(List.of());
+        given(ingredientRepository.findAll()).willReturn(List.of());
 
         RecipeIngredientRequestDto dto = RecipeIngredientRequestDto.builder()
                 .name("새로운재료")
@@ -173,21 +177,16 @@ class RecipeIngredientServiceTest {
                 .customPrice(null)
                 .build();
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            recipeIngredientService.saveAll(
-                    dummyRecipe,
-                    List.of(dto),
-                    RecipeSourceType.USER
-            );
-        });
-
-        assertEquals(ErrorCode.CUSTOM_INGREDIENT_INFO_MISSING, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> recipeIngredientService.saveAll(dummyRecipe, List.of(dto), RecipeSourceType.USER))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.CUSTOM_INGREDIENT_INFO_MISSING));
     }
 
     @Test
-    @DisplayName("saveAll: quantity가 잘못된 형식일 때, INVALID_INGREDIENT_QUANTITY 예외 발생")
-    void saveAll_invalidQuantity_throwException() {
-        when(ingredientRepository.findAll()).thenReturn(List.of());
+    @DisplayName("saveAll: quantity가 숫자로 변환 불가한 형식일 때, '약간'으로 자동 보정되어 저장된다")
+    void saveAll_invalidQuantity_correctedToSpecialWord() {
+        given(ingredientRepository.findAll()).willReturn(List.of());
 
         RecipeIngredientRequestDto dto = RecipeIngredientRequestDto.builder()
                 .name("감자")
@@ -196,15 +195,12 @@ class RecipeIngredientServiceTest {
                 .customPrice(BigDecimal.valueOf(1000))
                 .build();
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            recipeIngredientService.saveAll(
-                    dummyRecipe,
-                    List.of(dto),
-                    RecipeSourceType.USER
-            );
-        });
+        // 서비스는 예외를 던지지 않고 수량을 "약간"으로 보정 후 저장
+        recipeIngredientService.saveAll(dummyRecipe, List.of(dto), RecipeSourceType.USER);
 
-        assertEquals(ErrorCode.INVALID_INGREDIENT_QUANTITY, ex.getErrorCode());
+        ArgumentCaptor<RecipeIngredient> captor = ArgumentCaptor.forClass(RecipeIngredient.class);
+        verify(recipeIngredientRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getQuantity()).isEqualTo("약간");
     }
 
     @Test
@@ -217,21 +213,16 @@ class RecipeIngredientServiceTest {
                 .customPrice(BigDecimal.valueOf(1000))
                 .build();
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            recipeIngredientService.saveAll(
-                    dummyRecipe,
-                    List.of(dto),
-                    RecipeSourceType.USER
-            );
-        });
-
-        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> recipeIngredientService.saveAll(dummyRecipe, List.of(dto), RecipeSourceType.USER))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT_VALUE));
     }
 
     @Test
     @DisplayName("saveAll: AI 모드에서 마스터 재료가 없고 customUnit만 있을 경우, price=0으로 계산")
     void saveAll_masterMissingAiMode_priceZero() {
-        when(ingredientRepository.findAll()).thenReturn(List.of());
+        given(ingredientRepository.findAll()).willReturn(List.of());
 
         RecipeIngredientRequestDto dto = RecipeIngredientRequestDto.builder()
                 .name("AI재료")
@@ -245,15 +236,158 @@ class RecipeIngredientServiceTest {
                 List.of(dto),
                 RecipeSourceType.AI
         );
-        assertEquals(0, totalCost);
+        // Then
+        assertThat(totalCost).isEqualTo(0);
 
         ArgumentCaptor<RecipeIngredient> captor = ArgumentCaptor.forClass(RecipeIngredient.class);
         verify(recipeIngredientRepository, times(1)).save(captor.capture());
         RecipeIngredient savedEntity = captor.getValue();
 
-        assertNull(savedEntity.getIngredient());
-        assertEquals("3", savedEntity.getQuantity());
-        assertEquals("개", savedEntity.getUnit());
-        assertEquals(0, savedEntity.getPrice().intValue());
+        assertThat(savedEntity.getIngredient()).isNull();
+        assertThat(savedEntity.getQuantity()).isEqualTo("3");
+        assertThat(savedEntity.getUnit()).isEqualTo("개");
+        assertThat(savedEntity.getPrice().intValue()).isEqualTo(0);
+    }
+
+    // ─── updateIngredients: 커스텀 재료 영양성분 보존 ──────────────────────────
+
+    @Test
+    @DisplayName("updateIngredients: 커스텀 재료 수정 시 DTO에 없는 영양성분이 기존 값으로 채워지는 테스트")
+    void updateIngredients_preservesNutritionFromExistingCustomIngredient() {
+        // Given
+        RecipeIngredient existingCustom = RecipeIngredient.builder()
+                .id(10L)
+                .recipe(dummyRecipe)
+                .customName("간장")
+                .customCalorie(BigDecimal.valueOf(60))
+                .customCarbohydrate(BigDecimal.valueOf(10))
+                .customProtein(BigDecimal.valueOf(5))
+                .customFat(BigDecimal.valueOf(0.5))
+                .customSugar(BigDecimal.valueOf(2))
+                .customSodium(BigDecimal.valueOf(800))
+                .customPrice(500)
+                .build();
+
+        given(recipeIngredientRepository.findByRecipeId(dummyRecipe.getId()))
+                .willReturn(List.of(existingCustom));
+        given(ingredientRepository.findAll()).willReturn(List.of());
+
+        RecipeIngredientRequestDto dto = RecipeIngredientRequestDto.builder()
+                .name("간장")
+                .quantity("2")
+                .customUnit("ml")
+                // 영양성분 미전송 (null)
+                .build();
+
+        // When
+        recipeIngredientService.updateIngredients(dummyRecipe, List.of(dto), RecipeSourceType.USER);
+
+        // Then — 기존 영양성분이 DTO에 채워졌는지 확인
+        assertThat(dto.getCustomCalories()).isEqualByComparingTo(BigDecimal.valueOf(60));
+        assertThat(dto.getCustomCarbohydrate()).isEqualByComparingTo(BigDecimal.valueOf(10));
+        assertThat(dto.getCustomProtein()).isEqualByComparingTo(BigDecimal.valueOf(5));
+        assertThat(dto.getCustomFat()).isEqualByComparingTo(BigDecimal.valueOf(0.5));
+        assertThat(dto.getCustomSugar()).isEqualByComparingTo(BigDecimal.valueOf(2));
+        assertThat(dto.getCustomSodium()).isEqualByComparingTo(BigDecimal.valueOf(800));
+        assertThat(dto.getCustomPrice()).isEqualByComparingTo(BigDecimal.valueOf(500));
+    }
+
+    @Test
+    @DisplayName("updateIngredients: DTO에 이미 영양성분 값이 있으면 기존 값으로 덮어쓰지 않는 테스트")
+    void updateIngredients_doesNotOverwriteDtoNutritionIfAlreadyPresent() {
+        // Given
+        RecipeIngredient existingCustom = RecipeIngredient.builder()
+                .id(11L)
+                .recipe(dummyRecipe)
+                .customName("소금")
+                .customCalorie(BigDecimal.ZERO)
+                .customSodium(BigDecimal.valueOf(38000))
+                .build();
+
+        given(recipeIngredientRepository.findByRecipeId(dummyRecipe.getId()))
+                .willReturn(List.of(existingCustom));
+        given(ingredientRepository.findAll()).willReturn(List.of());
+
+        RecipeIngredientRequestDto dto = RecipeIngredientRequestDto.builder()
+                .name("소금")
+                .quantity("약간")
+                .customUnit("꼬집")
+                .customCalories(BigDecimal.valueOf(99))  // 이미 입력된 값
+                .build();
+
+        // When
+        recipeIngredientService.updateIngredients(dummyRecipe, List.of(dto), RecipeSourceType.USER);
+
+        // Then — DTO에 미리 있던 값(99)이 유지되어야 함
+        assertThat(dto.getCustomCalories()).isEqualByComparingTo(BigDecimal.valueOf(99));
+    }
+
+    @Test
+    @DisplayName("updateIngredients: 마스터 재료로 전환 시 커스텀 영양성분 보존 로직이 적용되지 않는 테스트")
+    void updateIngredients_doesNotPreserveNutrition_whenIngredientBecomeMaster() {
+        // Given — 기존에 커스텀으로 저장된 재료
+        RecipeIngredient existingCustom = RecipeIngredient.builder()
+                .id(12L)
+                .recipe(dummyRecipe)
+                .customName("계란")
+                .customCalorie(BigDecimal.valueOf(155))
+                .build();
+
+        // 이번에는 마스터 재료가 DB에 존재함
+        Ingredient masterEgg = Ingredient.builder()
+                .id(1L)
+                .name("계란")
+                .unit("개")
+                .price(300)
+                .build();
+
+        given(recipeIngredientRepository.findByRecipeId(dummyRecipe.getId()))
+                .willReturn(List.of(existingCustom));
+        given(ingredientRepository.findAll()).willReturn(List.of(masterEgg));
+
+        RecipeIngredientRequestDto dto = RecipeIngredientRequestDto.builder()
+                .name("계란")
+                .quantity("2")
+                .build();
+
+        ArgumentCaptor<RecipeIngredient> captor = ArgumentCaptor.forClass(RecipeIngredient.class);
+
+        // When
+        recipeIngredientService.updateIngredients(dummyRecipe, List.of(dto), RecipeSourceType.USER);
+
+        // Then — 마스터 재료로 매핑되어 ingredient != null, customName == null
+        verify(recipeIngredientRepository).save(captor.capture());
+        assertThat(captor.getValue().getIngredient()).isNotNull();
+        assertThat(captor.getValue().getCustomName()).isNull();
+    }
+
+    @Test
+    @DisplayName("updateIngredients: 기존 커스텀 재료의 step 재료도 함께 삭제되는 테스트")
+    void updateIngredients_deletesStepIngredientsBeforeResave() {
+        // Given
+        RecipeIngredient existing = RecipeIngredient.builder()
+                .id(20L)
+                .recipe(dummyRecipe)
+                .customName("참기름")
+                .customCalorie(BigDecimal.valueOf(884))
+                .build();
+
+        given(recipeIngredientRepository.findByRecipeId(dummyRecipe.getId()))
+                .willReturn(List.of(existing));
+        given(ingredientRepository.findAll()).willReturn(List.of());
+
+        RecipeIngredientRequestDto dto = RecipeIngredientRequestDto.builder()
+                .name("참기름")
+                .quantity("약간")
+                .customUnit("ml")
+                .build();
+
+        // When
+        recipeIngredientService.updateIngredients(dummyRecipe, List.of(dto), RecipeSourceType.USER);
+
+        // Then — step 재료 삭제 확인
+        verify(recipeStepIngredientRepository).deleteByRecipeIngredientId(20L);
+        verify(recipeIngredientRepository).deleteByRecipeId(dummyRecipe.getId());
+        verify(recipeIngredientRepository).flush();
     }
 }

--- a/src/test/java/com/jdc/recipe_service/service/RecipeLikeServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeLikeServiceTest.java
@@ -18,8 +18,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class RecipeLikeServiceTest {
@@ -47,18 +48,21 @@ class RecipeLikeServiceTest {
     @Test
     @DisplayName("toggleLike: 이미 좋아요 되어 있으면 삭제 후 false 반환")
     void toggleLike_existingLike_returnsFalse() {
+        // Given
         RecipeLike existing = RecipeLike.builder()
                 .id(200L)
                 .user(user)
                 .recipe(recipe)
                 .build();
-        when(likeRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
-                .thenReturn(Optional.of(existing));
-        doNothing().when(likeRepository).delete(existing);
+        given(likeRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
+                .willReturn(Optional.of(existing));
+        willDoNothing().given(likeRepository).delete(existing);
 
+        // When
         boolean result = likeService.toggleLike(user.getId(), recipe.getId());
 
-        assertFalse(result);
+        // Then
+        assertThat(result).isFalse();
         verify(likeRepository, times(1)).findByUserIdAndRecipeId(user.getId(), recipe.getId());
         verify(likeRepository, times(1)).delete(existing);
         verifyNoInteractions(userRepository, recipeRepository);
@@ -67,38 +71,42 @@ class RecipeLikeServiceTest {
     @Test
     @DisplayName("toggleLike: 좋아요 기록이 없으면 새로 저장 후 true 반환")
     void toggleLike_noLike_savesAndReturnsTrue() {
-        when(likeRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
-                .thenReturn(Optional.empty());
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
+        // Given
+        given(likeRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
+                .willReturn(Optional.empty());
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(recipeRepository.findById(recipe.getId())).willReturn(Optional.of(recipe));
 
         ArgumentCaptor<RecipeLike> captor = ArgumentCaptor.forClass(RecipeLike.class);
-        when(likeRepository.save(captor.capture())).thenAnswer(invocation -> invocation.getArgument(0));
+        given(likeRepository.save(captor.capture())).willAnswer(invocation -> invocation.getArgument(0));
 
+        // When
         boolean result = likeService.toggleLike(user.getId(), recipe.getId());
 
-        assertTrue(result);
+        // Then
+        assertThat(result).isTrue();
         verify(likeRepository, times(1)).findByUserIdAndRecipeId(user.getId(), recipe.getId());
         verify(userRepository, times(1)).findById(user.getId());
         verify(recipeRepository, times(1)).findById(recipe.getId());
         verify(likeRepository, times(1)).save(any(RecipeLike.class));
 
         RecipeLike saved = captor.getValue();
-        assertEquals(user.getId(), saved.getUser().getId());
-        assertEquals(recipe.getId(), saved.getRecipe().getId());
+        assertThat(saved.getUser().getId()).isEqualTo(user.getId());
+        assertThat(saved.getRecipe().getId()).isEqualTo(recipe.getId());
     }
 
     @Test
     @DisplayName("toggleLike: 존재하지 않는 유저면 USER_NOT_FOUND 예외")
     void toggleLike_userNotFound_throwsException() {
-        when(likeRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
-                .thenReturn(Optional.empty());
-        when(userRepository.findById(user.getId())).thenReturn(Optional.empty());
+        // Given
+        given(likeRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
+                .willReturn(Optional.empty());
+        given(userRepository.findById(user.getId())).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            likeService.toggleLike(user.getId(), recipe.getId());
-        });
-        assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> likeService.toggleLike(user.getId(), recipe.getId()))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
 
         verify(likeRepository, times(1)).findByUserIdAndRecipeId(user.getId(), recipe.getId());
         verify(userRepository, times(1)).findById(user.getId());
@@ -108,15 +116,16 @@ class RecipeLikeServiceTest {
     @Test
     @DisplayName("toggleLike: 존재하지 않는 레시피면 RECIPE_NOT_FOUND 예외")
     void toggleLike_recipeNotFound_throwsException() {
-        when(likeRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
-                .thenReturn(Optional.empty());
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.empty());
+        // Given
+        given(likeRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
+                .willReturn(Optional.empty());
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(recipeRepository.findById(recipe.getId())).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            likeService.toggleLike(user.getId(), recipe.getId());
-        });
-        assertEquals(ErrorCode.RECIPE_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> likeService.toggleLike(user.getId(), recipe.getId()))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RECIPE_NOT_FOUND));
 
         verify(likeRepository, times(1)).findByUserIdAndRecipeId(user.getId(), recipe.getId());
         verify(userRepository, times(1)).findById(user.getId());
@@ -127,10 +136,13 @@ class RecipeLikeServiceTest {
     @Test
     @DisplayName("deleteByRecipeId: likeRepository.deleteByRecipeId 호출")
     void deleteByRecipeId_invokesRepository() {
-        doNothing().when(likeRepository).deleteByRecipeId(recipe.getId());
+        // Given
+        willDoNothing().given(likeRepository).deleteByRecipeId(recipe.getId());
 
+        // When
         likeService.deleteByRecipeId(recipe.getId());
 
+        // Then
         verify(likeRepository, times(1)).deleteByRecipeId(recipe.getId());
     }
 }

--- a/src/test/java/com/jdc/recipe_service/service/RecipeRatingServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeRatingServiceTest.java
@@ -18,8 +18,9 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class RecipeRatingServiceTest {
@@ -56,36 +57,34 @@ class RecipeRatingServiceTest {
     }
 
     @Test
-    @DisplayName("rateRecipe: 새 평가 저장 후 반환")
+    @DisplayName("rateRecipe: 새 평가 저장 후 반환하는 테스트")
     void rateRecipe_newRating_savesAndReturns() {
+        // Given
         RecipeRatingRequestDto dto = new RecipeRatingRequestDto(4.5, null);
 
-        // 레시피/유저 조회 정상
-        when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        given(recipeRepository.findById(recipe.getId())).willReturn(Optional.of(recipe));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(ratingRepository.findByUserAndRecipe(user, recipe)).willReturn(Optional.empty());
 
-        // ratingRepository.findByUserAndRecipe -> Optional.empty()
-        when(ratingRepository.findByUserAndRecipe(user, recipe)).thenReturn(Optional.empty());
-
-        // save(...) 호출 시 인자로 들어온 객체를 반환
         ArgumentCaptor<RecipeRating> captor = ArgumentCaptor.forClass(RecipeRating.class);
-        when(ratingRepository.save(captor.capture()))
-                .thenAnswer(invocation -> {
+        given(ratingRepository.save(captor.capture()))
+                .willAnswer(invocation -> {
                     RecipeRating r = invocation.getArgument(0);
                     // 저장 후 ID 세팅
                     ReflectionTestUtils.setField(r, "id", 200L);
                     return r;
                 });
 
-        // 평균 계산용 stub (예시: 단건만 있어서 avg=4.5, count=1)
-        when(ratingRepository.calculateAverageByRecipeId(recipe.getId())).thenReturn(4.5);
-        when(ratingRepository.countByRecipeId(recipe.getId())).thenReturn(1L);
+        given(ratingRepository.calculateAverageByRecipeId(recipe.getId())).willReturn(4.5);
+        given(ratingRepository.countByRecipeId(recipe.getId())).willReturn(1L);
 
+        // When
         RecipeRatingResponseDto response = ratingService.rateRecipe(recipe.getId(), user.getId(), dto);
 
-        assertNotNull(response);
-        assertEquals(200L, response.getId());
-        assertEquals(4.5, response.getStars());
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(200L);
+        assertThat(response.getStars()).isEqualTo(4.5);
 
         // Repository 호출 검증
         verify(recipeRepository, times(1)).findById(recipe.getId());
@@ -94,8 +93,8 @@ class RecipeRatingServiceTest {
         verify(ratingRepository, times(1)).save(any(RecipeRating.class));
 
         // 평균 평점 갱신 검증
-        assertEquals(BigDecimal.valueOf(4.5).setScale(2, RoundingMode.HALF_UP), recipe.getAvgRating());
-        assertEquals(1L, recipe.getRatingCount());
+        assertThat(recipe.getAvgRating()).isEqualTo(BigDecimal.valueOf(4.5).setScale(2, RoundingMode.HALF_UP));
+        assertThat(recipe.getRatingCount()).isEqualTo(1L);
 
         // 댓글 저장은 넘어간 상태 (dto.getComment()가 null)
         verify(commentRepository, never()).save(any(RecipeComment.class));
@@ -103,72 +102,77 @@ class RecipeRatingServiceTest {
     }
 
     @Test
-    @DisplayName("rateRecipe: 기존 평가가 있으면 평점만 업데이트")
+    @DisplayName("rateRecipe: 기존 평가가 있으면 평점만 업데이트하는 테스트")
     void rateRecipe_existingRating_updatesAndReturns() {
+        // Given
         RecipeRatingRequestDto dto = new RecipeRatingRequestDto(2.0, "맛있어요");
 
-        when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        given(recipeRepository.findById(recipe.getId())).willReturn(Optional.of(recipe));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         // 기존 평가 있음
-        when(ratingRepository.findByUserAndRecipe(user, recipe)).thenReturn(Optional.of(existingRating));
+        given(ratingRepository.findByUserAndRecipe(user, recipe)).willReturn(Optional.of(existingRating));
 
         // save(...) 시 그대로 existingRating 반환
-        when(ratingRepository.save(existingRating)).thenReturn(existingRating);
+        given(ratingRepository.save(existingRating)).willReturn(existingRating);
 
         // 평균 및 카운트 계산: 예: (3 + 2) / 2 = 2.5
-        when(ratingRepository.calculateAverageByRecipeId(recipe.getId())).thenReturn(2.5);
-        when(ratingRepository.countByRecipeId(recipe.getId())).thenReturn(2L);
+        given(ratingRepository.calculateAverageByRecipeId(recipe.getId())).willReturn(2.5);
+        given(ratingRepository.countByRecipeId(recipe.getId())).willReturn(2L);
 
+        // When
         RecipeRatingResponseDto response = ratingService.rateRecipe(recipe.getId(), user.getId(), dto);
 
-        assertNotNull(response);
-        assertEquals(existingRating.getId(), response.getId());
-        assertEquals(2.0, response.getStars());
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(existingRating.getId());
+        assertThat(response.getStars()).isEqualTo(2.0);
 
         // 기존 객체의 rating 필드가 변경됐는지
-        assertEquals(2.0, existingRating.getRating());
+        assertThat(existingRating.getRating()).isEqualTo(2.0);
 
         // 댓글 저장 검증 (dto.getComment()가 비어 있지 않으므로 저장)
         ArgumentCaptor<RecipeComment> commentCaptor = ArgumentCaptor.forClass(RecipeComment.class);
         verify(commentRepository, times(1)).save(commentCaptor.capture());
 
         RecipeComment savedComment = commentCaptor.getValue();
-        assertEquals(user.getId(), savedComment.getUser().getId());
-        assertEquals(recipe.getId(), savedComment.getRecipe().getId());
-        assertEquals("맛있어요", savedComment.getComment());
+        assertThat(savedComment.getUser().getId()).isEqualTo(user.getId());
+        assertThat(savedComment.getRecipe().getId()).isEqualTo(recipe.getId());
+        assertThat(savedComment.getComment()).isEqualTo("맛있어요");
 
         // 평균/카운트 갱신 검증
-        assertEquals(BigDecimal.valueOf(2.5).setScale(2, RoundingMode.HALF_UP), recipe.getAvgRating());
-        assertEquals(2L, recipe.getRatingCount());
+        assertThat(recipe.getAvgRating()).isEqualTo(BigDecimal.valueOf(2.5).setScale(2, RoundingMode.HALF_UP));
+        assertThat(recipe.getRatingCount()).isEqualTo(2L);
 
     }
 
     @Test
-    @DisplayName("rateRecipe: 존재하지 않는 레시피면 RECIPE_NOT_FOUND 예외")
+    @DisplayName("rateRecipe: 존재하지 않는 레시피면 RECIPE_NOT_FOUND 예외 발생하는 테스트")
     void rateRecipe_recipeNotFound_throwsException() {
+        // Given
         RecipeRatingRequestDto dto = new RecipeRatingRequestDto(5.0, null);
-        when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.empty());
+        given(recipeRepository.findById(recipe.getId())).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            ratingService.rateRecipe(recipe.getId(), user.getId(), dto);
-        });
-        assertEquals(ErrorCode.RECIPE_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> ratingService.rateRecipe(recipe.getId(), user.getId(), dto))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RECIPE_NOT_FOUND));
 
         verify(recipeRepository, times(1)).findById(recipe.getId());
         verifyNoMoreInteractions(userRepository, ratingRepository, commentRepository, cookingRecordService);
     }
 
     @Test
-    @DisplayName("rateRecipe: 존재하지 않는 유저면 USER_NOT_FOUND 예외")
+    @DisplayName("rateRecipe: 존재하지 않는 유저면 USER_NOT_FOUND 예외 발생하는 테스트")
     void rateRecipe_userNotFound_throwsException() {
+        // Given
         RecipeRatingRequestDto dto = new RecipeRatingRequestDto(5.0, null);
-        when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
-        when(userRepository.findById(user.getId())).thenReturn(Optional.empty());
+        given(recipeRepository.findById(recipe.getId())).willReturn(Optional.of(recipe));
+        given(userRepository.findById(user.getId())).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            ratingService.rateRecipe(recipe.getId(), user.getId(), dto);
-        });
-        assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> ratingService.rateRecipe(recipe.getId(), user.getId(), dto))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
 
         verify(recipeRepository, times(1)).findById(recipe.getId());
         verify(userRepository, times(1)).findById(user.getId());
@@ -176,43 +180,47 @@ class RecipeRatingServiceTest {
     }
 
     @Test
-    @DisplayName("deleteRating: 정상 삭제 후 ID 반환")
+    @DisplayName("deleteRating: 정상 삭제 후 ID 반환하는 테스트")
     void deleteRating_existingRating_deletesAndReturnsId() {
-        when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(ratingRepository.findByUserAndRecipe(user, recipe)).thenReturn(Optional.of(existingRating));
+        // Given
+        given(recipeRepository.findById(recipe.getId())).willReturn(Optional.of(recipe));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(ratingRepository.findByUserAndRecipe(user, recipe)).willReturn(Optional.of(existingRating));
 
         // delete(...) 시 아무 일 없음
-        doNothing().when(ratingRepository).delete(existingRating);
+        willDoNothing().given(ratingRepository).delete(existingRating);
 
         // 평균/카운트 갱신: 삭제 후 평가가 없어서 avg=0, count=0
-        when(ratingRepository.calculateAverageByRecipeId(recipe.getId())).thenReturn(0.0);
-        when(ratingRepository.countByRecipeId(recipe.getId())).thenReturn(0L);
+        given(ratingRepository.calculateAverageByRecipeId(recipe.getId())).willReturn(0.0);
+        given(ratingRepository.countByRecipeId(recipe.getId())).willReturn(0L);
 
+        // When
         Long deletedId = ratingService.deleteRating(recipe.getId(), user.getId());
 
-        assertEquals(existingRating.getId(), deletedId);
+        // Then
+        assertThat(deletedId).isEqualTo(existingRating.getId());
         verify(recipeRepository, times(1)).findById(recipe.getId());
         verify(userRepository, times(1)).findById(user.getId());
         verify(ratingRepository, times(1)).findByUserAndRecipe(user, recipe);
         verify(ratingRepository, times(1)).delete(existingRating);
 
         // 평균/카운트 재갱신 검증
-        assertEquals(BigDecimal.valueOf(0.0).setScale(2, RoundingMode.HALF_UP), recipe.getAvgRating());
-        assertEquals(0L, recipe.getRatingCount());
+        assertThat(recipe.getAvgRating()).isEqualTo(BigDecimal.valueOf(0.0).setScale(2, RoundingMode.HALF_UP));
+        assertThat(recipe.getRatingCount()).isEqualTo(0L);
     }
 
     @Test
-    @DisplayName("deleteRating: 평점 레코드가 없으면 RATING_NOT_FOUND 예외")
+    @DisplayName("deleteRating: 평점 레코드가 없으면 RATING_NOT_FOUND 예외 발생하는 테스트")
     void deleteRating_ratingNotFound_throwsException() {
-        when(recipeRepository.findById(recipe.getId())).thenReturn(Optional.of(recipe));
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(ratingRepository.findByUserAndRecipe(user, recipe)).thenReturn(Optional.empty());
+        // Given
+        given(recipeRepository.findById(recipe.getId())).willReturn(Optional.of(recipe));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(ratingRepository.findByUserAndRecipe(user, recipe)).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            ratingService.deleteRating(recipe.getId(), user.getId());
-        });
-        assertEquals(ErrorCode.RATING_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> ratingService.deleteRating(recipe.getId(), user.getId()))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RATING_NOT_FOUND));
 
         verify(recipeRepository, times(1)).findById(recipe.getId());
         verify(userRepository, times(1)).findById(user.getId());
@@ -221,33 +229,46 @@ class RecipeRatingServiceTest {
     }
 
     @Test
-    @DisplayName("getMyRating: 유저 평점 있으면 해당 평점 반환")
+    @DisplayName("getMyRating: 유저 평점 있으면 해당 평점 반환하는 테스트")
     void getMyRating_existingRating_returnsValue() {
-        when(ratingRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
-                .thenReturn(Optional.of(RecipeRating.builder().rating(3.7).build()));
+        // Given
+        given(ratingRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
+                .willReturn(Optional.of(RecipeRating.builder().rating(3.7).build()));
 
+        // When
         double result = ratingService.getMyRating(recipe.getId(), user.getId());
-        assertEquals(3.7, result);
+
+        // Then
+        assertThat(result).isEqualTo(3.7);
         verify(ratingRepository, times(1)).findByUserIdAndRecipeId(user.getId(), recipe.getId());
     }
 
     @Test
-    @DisplayName("getMyRating: 평점이 없으면 0.0 반환")
+    @DisplayName("getMyRating: 평점이 없으면 0.0 반환하는 테스트")
     void getMyRating_noRating_returnsZero() {
-        when(ratingRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
-                .thenReturn(Optional.empty());
+        // Given
+        given(ratingRepository.findByUserIdAndRecipeId(user.getId(), recipe.getId()))
+                .willReturn(Optional.empty());
 
+        // When
         double result = ratingService.getMyRating(recipe.getId(), user.getId());
-        assertEquals(0.0, result);
+
+        // Then
+        assertThat(result).isEqualTo(0.0);
         verify(ratingRepository, times(1)).findByUserIdAndRecipeId(user.getId(), recipe.getId());
     }
 
     @Test
-    @DisplayName("getRatingCount: 레시피별 평점 개수 반환")
+    @DisplayName("getRatingCount: 레시피별 평점 개수 반환하는 테스트")
     void getRatingCount_returnsCount() {
-        when(ratingRepository.countByRecipeId(recipe.getId())).thenReturn(5L);
+        // Given
+        given(ratingRepository.countByRecipeId(recipe.getId())).willReturn(5L);
+
+        // When
         long count = ratingService.getRatingCount(recipe.getId());
-        assertEquals(5L, count);
+
+        // Then
+        assertThat(count).isEqualTo(5L);
         verify(ratingRepository, times(1)).countByRecipeId(recipe.getId());
     }
 }

--- a/src/test/java/com/jdc/recipe_service/service/RecipeSearchServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeSearchServiceTest.java
@@ -36,8 +36,9 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class RecipeSearchServiceTest {
@@ -114,189 +115,110 @@ class RecipeSearchServiceTest {
     @Test
     @DisplayName("getRecipeDetail: 존재하는 레시피 ID인 경우, 올바른 DTO 반환")
     void getRecipeDetail_Success() {
+        // Given
         ReflectionTestUtils.setField(sampleRecipe, "likeCount", 10L);
+        given(recipeRepository.findWithUserById(existingId)).willReturn(Optional.of(sampleRecipe));
+        given(recipeLikeRepository.existsByRecipeIdAndUserId(existingId, userId)).willReturn(true);
+        given(recipeFavoriteRepository.existsByRecipeIdAndUserId(existingId, userId)).willReturn(false);
+        given(recipeRatingService.getMyRating(existingId, userId)).willReturn(5.0);
+        given(recipeRatingService.getRatingCount(existingId)).willReturn(20L);
 
-        // 1) recipeRepository.findWithUserById(existingId) 모킹
-        when(recipeRepository.findWithUserById(existingId))
-                .thenReturn(Optional.of(sampleRecipe));
-
-        // 2) 좋아요·즐겨찾기 정보 모킹
-        when(recipeLikeRepository.existsByRecipeIdAndUserId(existingId, userId)).thenReturn(true);
-        when(recipeFavoriteRepository.existsByRecipeIdAndUserId(existingId, userId)).thenReturn(false);
-
-        // 3) RatingService 모킹
-        when(recipeRatingService.getMyRating(existingId, userId)).thenReturn(5.0);
-        when(recipeRatingService.getRatingCount(existingId)).thenReturn(20L);
-
-        // 4) 태그 목록 모킹
         RecipeTag tagEntity = RecipeTag.builder()
-                .id(1L)
-                .recipe(sampleRecipe)
-                .tag(TagType.QUICK)
-                .build();
-        when(recipeTagRepository.findByRecipeId(existingId))
-                .thenReturn(List.of(tagEntity));
+                .id(1L).recipe(sampleRecipe).tag(TagType.QUICK).build();
+        given(recipeTagRepository.findByRecipeId(existingId)).willReturn(List.of(tagEntity));
 
-        // 5) 재료 목록 모킹
         RecipeIngredient ingrEntity = RecipeIngredient.builder()
-                .id(1L)
-                .recipe(sampleRecipe)
-                .ingredient(null)
-                .quantity("2")
-                .unit("개")
-                .price(2000)
-                .customName("감자")
-                .customPrice(1000)
-                .customUnit("개")
-                .build();
-        when(recipeIngredientRepository.findByRecipeId(existingId))
-                .thenReturn(List.of(ingrEntity));
+                .id(1L).recipe(sampleRecipe).ingredient(null)
+                .quantity("2").unit("개").price(2000)
+                .customName("감자").customPrice(1000).customUnit("개").build();
+        given(recipeIngredientRepository.findByRecipeId(existingId)).willReturn(List.of(ingrEntity));
 
-        RecipeIngredientDto ingrDto = new RecipeIngredientDto(
-                1L, "감자", "2", "개", 2000,1.0, null
-        );
+        RecipeIngredientDto ingrDto = new RecipeIngredientDto(1L, "감자", "2", "개", 2000, 1.0, null);
+
         try (MockedStatic<RecipeIngredientMapper> ingrMapper = Mockito.mockStatic(RecipeIngredientMapper.class)) {
-            ingrMapper.when(() ->
-                    RecipeIngredientMapper.toDtoList(List.of(ingrEntity))
-            ).thenReturn(List.of(ingrDto));
+            ingrMapper.when(() -> RecipeIngredientMapper.toDtoList(List.of(ingrEntity))).thenReturn(List.of(ingrDto));
 
-            // 6) 단계 목록 모킹
             RecipeStep stepEntity = RecipeStep.builder()
-                    .id(1L)
-                    .recipe(sampleRecipe)
-                    .stepNumber(1)
-                    .instruction("손질")
-                    .imageKey("step-img-key")
-                    .action(null)
-                    .build();
+                    .id(1L).recipe(sampleRecipe).stepNumber(1)
+                    .instruction("손질").imageKey("step-img-key").action(null).build();
             stepEntity.getStepIngredients().clear();
-            when(recipeStepRepository.findByRecipeIdOrderByStepNumber(existingId))
-                    .thenReturn(List.of(stepEntity));
+            given(recipeStepRepository.findByRecipeIdOrderByStepNumber(existingId)).willReturn(List.of(stepEntity));
 
-            // generateImageUrl(...) 오버라이드: "step-img-key" 요청 시 stepImageUrl 리턴
             String stepImageUrl = "https://bucket.region.amazonaws.com/step-img-key";
             doReturn(stepImageUrl).when(spyService).generateImageUrl("step-img-key");
 
-            RecipeStepIngredientDto usedIngrDto = new RecipeStepIngredientDto(
-                    1L, "감자", "2", "개"
-            );
+            RecipeStepIngredientDto usedIngrDto = new RecipeStepIngredientDto(1L, "감자", "2", "개");
             try (MockedStatic<StepIngredientMapper> stepIngrMapper = Mockito.mockStatic(StepIngredientMapper.class)) {
-                stepIngrMapper.when(() ->
-                        StepIngredientMapper.toDtoList(stepEntity.getStepIngredients())
-                ).thenReturn(List.of(usedIngrDto));
+                stepIngrMapper.when(() -> StepIngredientMapper.toDtoList(stepEntity.getStepIngredients()))
+                        .thenReturn(List.of(usedIngrDto));
 
-                RecipeStepDto stepDto = new RecipeStepDto(
-                        1,
-                        "손질",
-                        stepImageUrl,
-                        "step-img-key",
-                        null,
-                        null,
-                        List.of(usedIngrDto)
-                );
+                RecipeStepDto stepDto = new RecipeStepDto(1, "손질", stepImageUrl, "step-img-key", null, null, List.of(usedIngrDto));
                 try (MockedStatic<RecipeStepMapper> stepMapper = Mockito.mockStatic(RecipeStepMapper.class)) {
-                    stepMapper.when(() ->
-                            RecipeStepMapper.toDto(stepEntity, List.of(usedIngrDto), stepImageUrl, "step-img-key")
-                    ).thenReturn(stepDto);
-
-                    // 7) CommentService 모킹
-                    CommentUserDto authorDtoComment = CommentUserDto.builder()
-                            .id(2L)
-                            .nickname("commenter")
-                            .profileImage("http://profile.commenter")
-                            .build();
+                    stepMapper.when(() -> RecipeStepMapper.toDto(stepEntity, List.of(usedIngrDto), stepImageUrl, "step-img-key"))
+                            .thenReturn(stepDto);
 
                     CommentDto commentDto = CommentDto.builder()
-                            .id(1L)
-                            .content("댓글 내용")
-                            .createdAt(LocalDateTime.of(2025, 6, 2, 0, 0))
-                            .author(authorDtoComment)
-                            .likeCount(0)
-                            .likedByCurrentUser(false)
-                            .replyCount(0)
-                            .build();
+                            .id(1L).content("댓글 내용").createdAt(LocalDateTime.of(2025, 6, 2, 0, 0))
+                            .author(CommentUserDto.builder().id(2L).nickname("commenter").profileImage("http://profile.commenter").build())
+                            .likeCount(0).likedByCurrentUser(false).replyCount(0).build();
+                    given(commentService.getTop3CommentsWithLikes(existingId, userId)).willReturn(List.of(commentDto));
+                    given(recipeCommentRepository.countByRecipeId(existingId)).willReturn(1L);
 
-                    when(commentService.getTop3CommentsWithLikes(existingId, userId))
-                            .thenReturn(List.of(commentDto));
-                    when(recipeCommentRepository.countByRecipeId(existingId)).thenReturn(1L);
-
-                    // 8) UserMapper 모킹
                     UserDto authorDto = UserDto.builder()
-                            .id(sampleRecipe.getUser().getId())
-                            .nickname("author")
-                            .profileImage("http://profile.test")
-                            .build();
+                            .id(sampleRecipe.getUser().getId()).nickname("author").profileImage("http://profile.test").build();
                     try (MockedStatic<UserMapper> userMapper = Mockito.mockStatic(UserMapper.class)) {
-                        userMapper.when(() ->
-                                UserMapper.toSimpleDto(sampleRecipe.getUser())
-                        ).thenReturn(authorDto);
+                        userMapper.when(() -> UserMapper.toSimpleDto(sampleRecipe.getUser())).thenReturn(authorDto);
 
-                        // --- 실제 서비스 호출 (스파이 사용) ---
+                        // When
                         RecipeDetailDto actual = spyService.getRecipeDetail(existingId, userId);
 
-                        // DTO 기본 필드 검증
-                        assertNotNull(actual);
-                        assertEquals(existingId, actual.getId());
-                        assertEquals("테스트 레시피", actual.getTitle());
-                        assertEquals("레시피 설명", actual.getDescription());
+                        // Then
+                        assertThat(actual).isNotNull();
+                        assertThat(actual.getId()).isEqualTo(existingId);
+                        assertThat(actual.getTitle()).isEqualTo("테스트 레시피");
+                        assertThat(actual.getDescription()).isEqualTo("레시피 설명");
+                        assertThat(actual.isPrivate()).isFalse();
+                        assertThat(actual.isAiGenerated()).isFalse();
+                        assertThat(actual.getLikeCount()).isEqualTo(10L);
+                        assertThat(actual.isLikedByCurrentUser()).isTrue();
+                        assertThat(actual.isFavoriteByCurrentUser()).isFalse();
 
-                        // private=false → 접근 가능
-                        assertFalse(actual.isPrivate());
-                        assertFalse(actual.isAiGenerated());
-
-                        // 좋아요·즐겨찾기 정보
-                        assertEquals(10L, actual.getLikeCount());
-                        assertTrue(actual.isLikedByCurrentUser());
-                        assertFalse(actual.isFavoriteByCurrentUser());
-
-                        // RatingInfo 검증
                         RecipeRatingInfoDto ratingInfo = actual.getRatingInfo();
-                        assertNotNull(ratingInfo);
-                        assertEquals(BigDecimal.valueOf(4.5), ratingInfo.getAvgRating());
-                        assertEquals(5L, ratingInfo.getMyRating());
-                        assertEquals(20L, ratingInfo.getRatingCount());
+                        assertThat(ratingInfo).isNotNull();
+                        assertThat(ratingInfo.getAvgRating()).isEqualTo(BigDecimal.valueOf(4.5));
+                        assertThat(ratingInfo.getMyRating()).isEqualTo(5L);
+                        assertThat(ratingInfo.getRatingCount()).isEqualTo(20L);
 
-                        // author 검증
-                        assertNotNull(actual.getAuthor());
-                        assertEquals("author", actual.getAuthor().getNickname());
+                        assertThat(actual.getAuthor()).isNotNull();
+                        assertThat(actual.getAuthor().getNickname()).isEqualTo("author");
+                        assertThat(actual.getTags()).hasSize(1);
+                        assertThat(actual.getTags().get(0)).isEqualTo(TagType.QUICK.getDisplayName());
 
-                        // tags: TagType.QUICK → displayName
-                        assertEquals(1, actual.getTags().size());
-                        assertEquals(TagType.QUICK.getDisplayName(), actual.getTags().get(0));
-
-                        // ingredients
-                        assertEquals(1, actual.getIngredients().size());
+                        assertThat(actual.getIngredients()).hasSize(1);
                         RecipeIngredientDto actIngr = actual.getIngredients().get(0);
-                        assertEquals(1L, actIngr.getId());
-                        assertEquals("감자", actIngr.getName());
-                        assertEquals("2", actIngr.getQuantity());
-                        assertEquals("개", actIngr.getUnit());
-                        assertEquals(2000, actIngr.getPrice());
+                        assertThat(actIngr.getId()).isEqualTo(1L);
+                        assertThat(actIngr.getName()).isEqualTo("감자");
+                        assertThat(actIngr.getQuantity()).isEqualTo("2");
+                        assertThat(actIngr.getUnit()).isEqualTo("개");
+                        assertThat(actIngr.getPrice()).isEqualTo(2000);
 
-                        // steps
-                        assertEquals(1, actual.getSteps().size());
+                        assertThat(actual.getSteps()).hasSize(1);
                         RecipeStepDto actStep = actual.getSteps().get(0);
-                        assertEquals(1, actStep.getStepNumber());
-                        assertEquals("손질", actStep.getInstruction());
-                        assertEquals(stepImageUrl, actStep.getStepImageUrl());
-                        assertEquals(1, actStep.getIngredients().size());
-                        assertEquals("감자", actStep.getIngredients().get(0).getName());
+                        assertThat(actStep.getStepNumber()).isEqualTo(1);
+                        assertThat(actStep.getInstruction()).isEqualTo("손질");
+                        assertThat(actStep.getStepImageUrl()).isEqualTo(stepImageUrl);
+                        assertThat(actStep.getIngredients()).hasSize(1);
+                        assertThat(actStep.getIngredients().get(0).getName()).isEqualTo("감자");
 
-                        // comments
-                        assertEquals(1, actual.getComments().size());
-                        assertEquals("댓글 내용", actual.getComments().get(0).getContent());
-                        assertEquals(1L, actual.getCommentCount());
+                        assertThat(actual.getComments()).hasSize(1);
+                        assertThat(actual.getComments().get(0).getContent()).isEqualTo("댓글 내용");
+                        assertThat(actual.getCommentCount()).isEqualTo(1L);
+                        assertThat(actual.getTotalIngredientCost()).isEqualTo(2000);
+                        assertThat(actual.getMarketPrice()).isEqualTo(5000);
+                        assertThat(actual.getSavings()).isEqualTo(3000);
+                        assertThat(actual.getCreatedAt()).isNotNull();
+                        assertThat(actual.getUpdatedAt()).isNotNull();
 
-                        // cost·price·savings
-                        assertEquals(2000, actual.getTotalIngredientCost());
-                        assertEquals(5000, actual.getMarketPrice());
-                        assertEquals(3000, actual.getSavings());
-
-                        // createdAt·updatedAt: 널이 아니어야 함
-                        assertNotNull(actual.getCreatedAt());
-                        assertNotNull(actual.getUpdatedAt());
-
-                        // 내부 호출 verify
                         verify(recipeRepository, times(1)).findWithUserById(existingId);
                         verify(recipeLikeRepository, times(1)).existsByRecipeIdAndUserId(existingId, userId);
                         verify(recipeFavoriteRepository, times(1)).existsByRecipeIdAndUserId(existingId, userId);
@@ -304,8 +226,7 @@ class RecipeSearchServiceTest {
                         verify(recipeRatingService, times(1)).getRatingCount(existingId);
                         verify(recipeTagRepository, times(1)).findByRecipeId(existingId);
                         verify(recipeIngredientRepository, times(1)).findByRecipeId(existingId);
-                        verify(recipeStepRepository, times(1))
-                                .findByRecipeIdOrderByStepNumber(existingId);
+                        verify(recipeStepRepository, times(1)).findByRecipeIdOrderByStepNumber(existingId);
                         verify(spyService, times(1)).generateImageUrl("step-img-key");
                         verify(commentService, times(1)).getTop3CommentsWithLikes(existingId, userId);
                         verify(recipeCommentRepository, times(1)).countByRecipeId(existingId);
@@ -318,13 +239,13 @@ class RecipeSearchServiceTest {
     @Test
     @DisplayName("getRecipeDetail: 없는 ID 조회 시, RECIPE_NOT_FOUND 예외 발생")
     void getRecipeDetail_NotFound() {
-        when(recipeRepository.findWithUserById(missingId))
-                .thenReturn(Optional.empty());
+        // Given
+        given(recipeRepository.findWithUserById(missingId)).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            spyService.getRecipeDetail(missingId, userId);
-        });
-        assertEquals(ErrorCode.RECIPE_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> spyService.getRecipeDetail(missingId, userId))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RECIPE_NOT_FOUND));
 
         verify(recipeRepository, times(1)).findWithUserById(missingId);
         verifyNoMoreInteractions(
@@ -341,17 +262,14 @@ class RecipeSearchServiceTest {
     @Test
     @DisplayName("getRecipeDetail: PRIVATE 상태의 레시피를 다른 사용자가 조회 시, RECIPE_PRIVATE_ACCESS_DENIED 예외 발생")
     void getRecipeDetail_PrivateRecipe_OtherUser_throwException() {
-        // sampleRecipe의 isPrivate를 true로 변경
+        // Given
         sampleRecipe.updateIsPrivate(true);
+        given(recipeRepository.findWithUserById(existingId)).willReturn(Optional.of(sampleRecipe));
 
-        when(recipeRepository.findWithUserById(existingId))
-                .thenReturn(Optional.of(sampleRecipe));
-
-        // 작성자(user.id=2L)와 조회자(userId=100L)가 다르므로 예외 발생
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            spyService.getRecipeDetail(existingId, userId);
-        });
-        assertEquals(ErrorCode.RECIPE_PRIVATE_ACCESS_DENIED, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> spyService.getRecipeDetail(existingId, userId))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RECIPE_PRIVATE_ACCESS_DENIED));
 
         verify(recipeRepository, times(1)).findWithUserById(existingId);
         verifyNoMoreInteractions(
@@ -372,9 +290,11 @@ class RecipeSearchServiceTest {
         Pageable pageable = Pageable.unpaged();
         Long currentUserId = 1L;
 
+        // Given
         Page<RecipeSimpleDto> mockPage = new PageImpl<>(List.of());
-        when(recipeRepository.findPopularRecipesSince(any(), any())).thenReturn(mockPage);
+        given(recipeRepository.findPopularRecipesSince(any(), any())).willReturn(mockPage);
 
+        // When
         spyService.getPopularRecipes(period, pageable, currentUserId);
 
         verify(recipeRepository, times(1)).findPopularRecipesSince(any(LocalDateTime.class), eq(pageable));
@@ -389,13 +309,12 @@ class RecipeSearchServiceTest {
         Pageable pageable = Pageable.unpaged();
         Long currentUserId = 1L;
 
+        // Given
         Page<RecipeSimpleDto> mockPage = new PageImpl<>(List.of());
-        when(recipeRepository.findBudgetRecipes(any(), any())).thenReturn(mockPage);
+        given(recipeRepository.findBudgetRecipes(any(), any())).willReturn(mockPage);
+        doReturn(mockPage).when(spyService).addLikeInfoToPage(any(), eq(currentUserId));
 
-        doReturn(mockPage)
-                .when(spyService)
-                .addLikeInfoToPage(any(), eq(currentUserId));
-
+        // When
         spyService.getBudgetRecipes(maxCost, pageable, currentUserId);
 
         verify(recipeRepository, times(1)).findBudgetRecipes(eq(maxCost), eq(pageable));
@@ -405,7 +324,8 @@ class RecipeSearchServiceTest {
     @Test
     @DisplayName("searchRecipes: Querydsl 사용 시, RecipeSearchCondition 객체가 Repository로 올바르게 전달되는지 확인")
     void searchRecipes_Querydsl_WithMaxCostAndSorting() {
-        when(searchProperties.getEngine()).thenReturn("querydsl");
+        // Given
+        given(searchProperties.getEngine()).willReturn("querydsl");
 
         String q = "파스타";
         Integer maxCost = 20000;
@@ -417,17 +337,13 @@ class RecipeSearchServiceTest {
         cond.setMaxCost(maxCost);
 
         Page<RecipeSimpleDto> mockPage = new PageImpl<>(List.of());
-        when(recipeRepository.search(any(RecipeSearchCondition.class), eq(pageable), eq(userId)))
-                .thenReturn(mockPage);
+        given(recipeRepository.search(any(RecipeSearchCondition.class), eq(pageable), eq(userId))).willReturn(mockPage);
 
+        // When
         recipeSearchService.searchRecipes(cond, pageable, userId);
 
-        verify(recipeRepository, times(1)).search(
-                eq(cond),
-                eq(pageable),
-                eq(userId)
-        );
-
-        assertEquals("파스타", cond.getTitle());
+        // Then
+        verify(recipeRepository, times(1)).search(eq(cond), eq(pageable), eq(userId));
+        assertThat(cond.getTitle()).isEqualTo("파스타");
     }
 }

--- a/src/test/java/com/jdc/recipe_service/service/RecipeServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeServiceTest.java
@@ -39,9 +39,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class RecipeServiceTest {
@@ -128,48 +129,51 @@ class RecipeServiceTest {
     @Test
     @DisplayName("createRecipeAndGenerateUrls: 정상 입력 시 PresignedUrlResponse 반환")
     void createRecipe_success() throws Exception {
-        when(userRepository.findById(author.getId()))
-                .thenReturn(Optional.of(author));
+        // Given
+        given(userRepository.findById(author.getId()))
+                .willReturn(Optional.of(author));
 
-        doAnswer(invocation -> {
+        willAnswer(invocation -> {
             Recipe toSave = invocation.getArgument(0);
             Field idField = Recipe.class.getDeclaredField("id");
             idField.setAccessible(true);
             idField.set(toSave, 555L);
             return toSave;
-        }).when(recipeRepository).save(any(Recipe.class));
+        }).given(recipeRepository).save(any(Recipe.class));
 
-        when(recipeIngredientService.saveAll(any(Recipe.class), anyList(), eq(RecipeSourceType.USER)))
-                .thenReturn(0);
+        given(recipeIngredientService.saveAll(any(Recipe.class), anyList(), eq(RecipeSourceType.USER)))
+                .willReturn(0);
 
-        when(recipeIngredientRepository.findByRecipeId(anyLong()))
-                .thenReturn(Collections.emptyList());
+        given(recipeIngredientRepository.findByRecipeId(anyLong()))
+                .willReturn(Collections.emptyList());
 
-        doNothing().when(recipeStepService).saveAll(any(Recipe.class), anyList());
-        doNothing().when(recipeTagService).saveAll(any(Recipe.class), anyList());
+        willDoNothing().given(recipeStepService).saveAll(any(Recipe.class), anyList());
+        willDoNothing().given(recipeTagService).saveAll(any(Recipe.class), anyList());
 
-        when(recipeImageService.generateAndSavePresignedUrls(any(Recipe.class), anyList()))
-                .thenReturn(Collections.emptyList());
+        given(recipeImageService.generateAndSavePresignedUrls(any(Recipe.class), anyList()))
+                .willReturn(Collections.emptyList());
 
         Recipe fullRecipe = Recipe.builder()
                 .id(555L)
                 .user(author)
                 .title("신규 레시피")
                 .build();
-        when(recipeRepository.findWithAllRelationsById(555L))
-                .thenReturn(Optional.of(fullRecipe));
+        given(recipeRepository.findWithAllRelationsById(555L))
+                .willReturn(Optional.of(fullRecipe));
 
         RecipeWithImageUploadRequest requestWithFile = RecipeWithImageUploadRequest.builder()
                 .recipe(createDto)
                 .files(nonEmptyFiles)
                 .build();
 
+        // When
         PresignedUrlResponse response = recipeService.createRecipeAndGenerateUrls(
                 requestWithFile, author.getId(), RecipeSourceType.USER, null);
 
-        assertNotNull(response);
-        assertEquals(555L, response.getRecipeId());
-        assertTrue(response.getUploads().isEmpty());
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getRecipeId()).isEqualTo(555L);
+        assertThat(response.getUploads()).isEmpty();
 
         verify(userRepository, times(1)).findById(author.getId());
         verify(recipeRepository, times(1)).save(any(Recipe.class));
@@ -187,8 +191,9 @@ class RecipeServiceTest {
     @Test
     @DisplayName("createRecipeAndGenerateUrls: main 타입 파일 없이 요청 시 USER_RECIPE_IMAGE_REQUIRED 예외")
     void createRecipe_noMainFile_throwsImageRequired() {
-        when(userRepository.findById(author.getId()))
-                .thenReturn(Optional.of(author));
+        // Given
+        given(userRepository.findById(author.getId()))
+                .willReturn(Optional.of(author));
 
         createDto.setIsPrivate(null);
 
@@ -197,10 +202,10 @@ class RecipeServiceTest {
                 .files(emptyFiles)
                 .build();
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            recipeService.createRecipeAndGenerateUrls(requestWithoutFile, author.getId(), RecipeSourceType.USER, null);
-        });
-        assertEquals(ErrorCode.USER_RECIPE_IMAGE_REQUIRED, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> recipeService.createRecipeAndGenerateUrls(requestWithoutFile, author.getId(), RecipeSourceType.USER, null))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.USER_RECIPE_IMAGE_REQUIRED));
 
         verify(userRepository, times(1)).findById(author.getId());
         verifyNoInteractions(recipeRepository);
@@ -209,17 +214,18 @@ class RecipeServiceTest {
     @Test
     @DisplayName("createRecipeAndGenerateUrls: 사용자 없는 경우 USER_NOT_FOUND 예외")
     void createRecipe_userNotFound_throwsException() {
-        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+        // Given
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
 
         RecipeWithImageUploadRequest request = RecipeWithImageUploadRequest.builder()
                 .recipe(createDto)
                 .files(emptyFiles)
                 .build();
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            recipeService.createRecipeAndGenerateUrls(request, 999L, RecipeSourceType.USER, null);
-        });
-        assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> recipeService.createRecipeAndGenerateUrls(request, 999L, RecipeSourceType.USER, null))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
 
         verify(userRepository, times(1)).findById(999L);
         verifyNoMoreInteractions(recipeRepository);
@@ -228,14 +234,15 @@ class RecipeServiceTest {
     @Test
     @DisplayName("updateUserRecipe: 정상 수정 시 PresignedUrlResponse 반환")
     void updateRecipe_success() {
+        // Given
         Recipe existing = Recipe.builder()
                 .id(100L)
                 .user(author)
                 .title("기존 레시피")
                 .build();
-        when(recipeRepository.findWithUserById(100L)).thenReturn(Optional.of(existing));
-        when(recipeRepository.findWithAllRelationsById(100L))
-                .thenReturn(Optional.of(existing));
+        given(recipeRepository.findWithUserById(100L)).willReturn(Optional.of(existing));
+        given(recipeRepository.findWithAllRelationsById(100L))
+                .willReturn(Optional.of(existing));
 
         RecipeUpdateRequestDto updateDto = RecipeUpdateRequestDto.builder()
                 .title("수정된 레시피")
@@ -252,27 +259,29 @@ class RecipeServiceTest {
                 .files(nonEmptyFiles)
                 .build();
 
-        when(recipeIngredientService.updateIngredientsFromUser(eq(existing), anyList()))
-                .thenReturn(0);
+        given(recipeIngredientService.updateIngredientsFromUser(eq(existing), anyList()))
+                .willReturn(0);
 
-        when(recipeIngredientRepository.findByRecipeId(anyLong()))
-                .thenReturn(Collections.emptyList());
+        given(recipeIngredientRepository.findByRecipeId(anyLong()))
+                .willReturn(Collections.emptyList());
 
-        doNothing().when(recipeStepService).updateStepsFromUser(eq(existing), anyList());
-        doNothing().when(recipeTagService).updateTags(eq(existing), anyList());
+        willDoNothing().given(recipeStepService).updateStepsFromUser(eq(existing), anyList());
+        willDoNothing().given(recipeTagService).updateTags(eq(existing), anyList());
 
-        doNothing().when(recipeAnalysisService).analyzeRecipeAsync(anyLong());
-        doNothing().when(recipeIndexingService).indexRecipeSafelyWithRetry(100L);
+        willDoNothing().given(recipeAnalysisService).analyzeRecipeAsync(anyLong());
+        willDoNothing().given(recipeIndexingService).indexRecipeSafelyWithRetry(100L);
 
-        when(recipeImageService.generateAndSavePresignedUrls(any(Recipe.class), anyList()))
-                .thenReturn(Collections.emptyList());
+        given(recipeImageService.generateAndSavePresignedUrls(any(Recipe.class), anyList()))
+                .willReturn(Collections.emptyList());
 
+        // When
         PresignedUrlResponse response = recipeService.updateUserRecipe(
                 100L, author.getId(), updateRequest);
 
-        assertNotNull(response);
-        assertEquals(100L, response.getRecipeId());
-        assertTrue(response.getUploads().isEmpty());
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getRecipeId()).isEqualTo(100L);
+        assertThat(response.getUploads()).isEmpty();
 
         verify(recipeRepository, times(1)).findWithUserById(100L);
         verify(recipeIngredientService, times(1))
@@ -289,17 +298,18 @@ class RecipeServiceTest {
     @Test
     @DisplayName("updateUserRecipe: 존재하지 않는 레시피 수정 시 RECIPE_NOT_FOUND 예외")
     void updateRecipe_notFound_throwsException() {
-        when(recipeRepository.findWithUserById(2000L)).thenReturn(Optional.empty());
+        // Given
+        given(recipeRepository.findWithUserById(2000L)).willReturn(Optional.empty());
 
         RecipeUpdateWithImageRequest dummyRequest = RecipeUpdateWithImageRequest.builder()
                 .recipe(RecipeUpdateRequestDto.builder().build())
                 .files(emptyFiles)
                 .build();
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            recipeService.updateUserRecipe(2000L, author.getId(), dummyRequest);
-        });
-        assertEquals(ErrorCode.RECIPE_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> recipeService.updateUserRecipe(2000L, author.getId(), dummyRequest))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RECIPE_NOT_FOUND));
 
         verify(recipeRepository, times(1)).findWithUserById(2000L);
         verifyNoMoreInteractions(recipeIngredientService, recipeStepService, recipeTagService);
@@ -308,24 +318,25 @@ class RecipeServiceTest {
     @Test
     @DisplayName("updateUserRecipe: 소유자가 아닌 사용자가 수정 시 RECIPE_ACCESS_DENIED 예외")
     void updateRecipe_notOwner_throwsException() {
+        // Given
         User otherUser = User.builder().id(99L).build();
         Recipe existing = Recipe.builder()
                 .id(300L)
                 .user(otherUser)
                 .title("남의 레시피")
                 .build();
-        when(recipeRepository.findWithUserById(300L))
-                .thenReturn(Optional.of(existing));
+        given(recipeRepository.findWithUserById(300L))
+                .willReturn(Optional.of(existing));
 
         RecipeUpdateWithImageRequest dummyRequest = RecipeUpdateWithImageRequest.builder()
                 .recipe(RecipeUpdateRequestDto.builder().build()) // 빈 UpdateDto
                 .files(emptyFiles)
                 .build();
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            recipeService.updateUserRecipe(300L, author.getId(), dummyRequest);
-        });
-        assertEquals(ErrorCode.RECIPE_ACCESS_DENIED, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> recipeService.updateUserRecipe(300L, author.getId(), dummyRequest))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RECIPE_ACCESS_DENIED));
 
         verify(recipeRepository, times(1)).findWithUserById(300L);
         verifyNoMoreInteractions(recipeIngredientService, recipeStepService, recipeTagService);
@@ -334,25 +345,29 @@ class RecipeServiceTest {
     @Test
     @DisplayName("deleteRecipe: 정상 삭제 시 recipeId 반환")
     void deleteRecipe_success() {
+        // Given
         Recipe existing = Recipe.builder()
                 .id(400L)
                 .user(author)
                 .title("삭제할 레시피")
                 .build();
-        when(recipeRepository.findWithUserById(400L)).thenReturn(Optional.of(existing));
+        given(recipeRepository.findWithUserById(400L)).willReturn(Optional.of(existing));
 
-        doNothing().when(recipeImageService).deleteImagesByRecipeId(400L);
-        doNothing().when(recipeLikeService).deleteByRecipeId(400L);
-        doNothing().when(recipeFavoriteService).deleteByRecipeId(400L);
-        doNothing().when(commentService).deleteAllByRecipeId(400L);
-        doNothing().when(recipeStepService).deleteAllByRecipeId(400L);
-        doNothing().when(recipeIngredientService).deleteAllByRecipeId(400L);
-        doNothing().when(recipeTagService).deleteAllByRecipeId(400L);
-        doNothing().when(recipeIndexingService).deleteRecipeSafelyWithRetry(400L);
-        doNothing().when(recipeRatingRepository).deleteByRecipeId(400L);
+        willDoNothing().given(recipeImageService).deleteImagesByRecipeId(400L);
+        willDoNothing().given(recipeLikeService).deleteByRecipeId(400L);
+        willDoNothing().given(recipeFavoriteService).deleteByRecipeId(400L);
+        willDoNothing().given(commentService).deleteAllByRecipeId(400L);
+        willDoNothing().given(recipeStepService).deleteAllByRecipeId(400L);
+        willDoNothing().given(recipeIngredientService).deleteAllByRecipeId(400L);
+        willDoNothing().given(recipeTagService).deleteAllByRecipeId(400L);
+        willDoNothing().given(recipeIndexingService).deleteRecipeSafelyWithRetry(400L);
+        willDoNothing().given(recipeRatingRepository).deleteByRecipeId(400L);
 
+        // When
         Long result = recipeService.deleteRecipe(400L, author.getId());
-        assertEquals(400L, result);
+
+        // Then
+        assertThat(result).isEqualTo(400L);
 
         verify(recipeRepository, times(1)).findWithUserById(400L);
         verify(recipeImageService, times(1)).deleteImagesByRecipeId(400L);
@@ -370,12 +385,13 @@ class RecipeServiceTest {
     @Test
     @DisplayName("deleteRecipe: 존재하지 않는 레시피 삭제 시 RECIPE_NOT_FOUND 예외")
     void deleteRecipe_notFound_throwsException() {
-        when(recipeRepository.findWithUserById(500L)).thenReturn(Optional.empty());
+        // Given
+        given(recipeRepository.findWithUserById(500L)).willReturn(Optional.empty());
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            recipeService.deleteRecipe(500L, author.getId());
-        });
-        assertEquals(ErrorCode.RECIPE_NOT_FOUND, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> recipeService.deleteRecipe(500L, author.getId()))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RECIPE_NOT_FOUND));
 
         verify(recipeRepository, times(1)).findWithUserById(500L);
         verifyNoMoreInteractions(recipeImageService, recipeLikeService, recipeFavoriteService,
@@ -385,19 +401,20 @@ class RecipeServiceTest {
     @Test
     @DisplayName("deleteRecipe: 소유자가 아닌 사용자가 삭제 시 RECIPE_ACCESS_DENIED 예외")
     void deleteRecipe_notOwner_throwsException() {
+        // Given
         User otherUser = User.builder().id(77L).build();
         Recipe existing = Recipe.builder()
                 .id(600L)
                 .user(otherUser)
                 .title("남의 레시피")
                 .build();
-        when(recipeRepository.findWithUserById(600L))
-                .thenReturn(Optional.of(existing));
+        given(recipeRepository.findWithUserById(600L))
+                .willReturn(Optional.of(existing));
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            recipeService.deleteRecipe(600L, author.getId());
-        });
-        assertEquals(ErrorCode.RECIPE_ACCESS_DENIED, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> recipeService.deleteRecipe(600L, author.getId()))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.RECIPE_ACCESS_DENIED));
 
         verify(recipeRepository, times(1)).findWithUserById(600L);
         verifyNoMoreInteractions(recipeImageService, recipeLikeService, recipeFavoriteService,
@@ -407,6 +424,7 @@ class RecipeServiceTest {
     @Test
     @DisplayName("togglePrivacy: 일반 사용자 레시피 공개/비공개 전환 성공")
     void togglePrivacy_success() {
+        // Given
         Recipe recipe = Recipe.builder()
                 .id(123L)
                 .user(author)
@@ -415,10 +433,13 @@ class RecipeServiceTest {
                 .imageKey("image.jpg")
                 .build();
 
-        when(recipeRepository.findWithUserById(123L)).thenReturn(Optional.of(recipe));
+        given(recipeRepository.findWithUserById(123L)).willReturn(Optional.of(recipe));
 
+        // When
         boolean result = recipeService.togglePrivacy(123L, author.getId());
-        assertFalse(result);
+
+        // Then
+        assertThat(result).isFalse();
 
         verify(recipeRepository).findWithUserById(123L);
     }
@@ -426,6 +447,7 @@ class RecipeServiceTest {
     @Test
     @DisplayName("togglePrivacy: AI 레시피가 이미지 없이 공개되려 할 때 예외")
     void togglePrivacy_aiRecipeWithoutImage_throws() {
+        // Given
         Recipe recipe = Recipe.builder()
                 .id(124L)
                 .user(author)
@@ -434,45 +456,45 @@ class RecipeServiceTest {
                 .imageKey(null)
                 .build();
 
-        when(recipeRepository.findWithUserById(124L)).thenReturn(Optional.of(recipe));
+        given(recipeRepository.findWithUserById(124L)).willReturn(Optional.of(recipe));
 
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            recipeService.togglePrivacy(124L, author.getId());
-        });
-
-        assertEquals(ErrorCode.CANNOT_MAKE_PUBLIC_WITHOUT_IMAGE, ex.getErrorCode());
+        // When & Then
+        assertThatThrownBy(() -> recipeService.togglePrivacy(124L, author.getId()))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.CANNOT_MAKE_PUBLIC_WITHOUT_IMAGE));
     }
 
     @Test
     @DisplayName("createRecipeAndGenerateUrls: AI 레시피 생성 시 로그가 정상적으로 저장되는지 검증")
     void createAiRecipe_logsActivity() {
+        // Given
         Long userId = author.getId();
         String nickname = author.getNickname();
         AiRecipeConcept concept = AiRecipeConcept.FINE_DINING;
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(author));
+        given(userRepository.findById(userId)).willReturn(Optional.of(author));
 
-        doAnswer(inv -> {
+        willAnswer(inv -> {
             Recipe r = inv.getArgument(0);
             Field id = Recipe.class.getDeclaredField("id");
             id.setAccessible(true);
             id.set(r, 777L);
             return r;
-        }).when(recipeRepository).save(any(Recipe.class));
+        }).given(recipeRepository).save(any(Recipe.class));
 
-        when(recipeIngredientService.saveAll(any(), any(), eq(RecipeSourceType.AI))).thenReturn(10000);
-        when(recipeIngredientRepository.findByRecipeId(any())).thenReturn(Collections.emptyList());
-        when(recipeRepository.findWithAllRelationsById(any())).thenReturn(Optional.of(Recipe.builder().user(author).id(777L).build()));
+        given(recipeIngredientService.saveAll(any(), any(), eq(RecipeSourceType.AI))).willReturn(10000);
+        given(recipeIngredientRepository.findByRecipeId(any())).willReturn(Collections.emptyList());
+        given(recipeRepository.findWithAllRelationsById(any())).willReturn(Optional.of(Recipe.builder().user(author).id(777L).build()));
 
         RecipeWithImageUploadRequest request = RecipeWithImageUploadRequest.builder()
                 .recipe(createDto)
                 .files(nonEmptyFiles)
                 .build();
 
-
+        // When
         recipeService.createRecipeAndGenerateUrls(request, userId, RecipeSourceType.AI, concept);
 
-
+        // Then
         verify(recipeActivityService, times(1)).saveLog(
                 eq(userId),
                 eq(nickname),
@@ -483,28 +505,31 @@ class RecipeServiceTest {
     @Test
     @DisplayName("createRecipeAndGenerateUrls: 유저 직접 생성 시에는 로그가 저장되지 않아야 함")
     void createUserRecipe_doesNotLog() {
+        // Given
         Long userId = author.getId();
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(author));
-        doAnswer(inv -> {
+        given(userRepository.findById(userId)).willReturn(Optional.of(author));
+        willAnswer(inv -> {
             Recipe r = inv.getArgument(0);
             Field id = Recipe.class.getDeclaredField("id");
             id.setAccessible(true);
             id.set(r, 888L);
             return r;
-        }).when(recipeRepository).save(any(Recipe.class));
+        }).given(recipeRepository).save(any(Recipe.class));
 
-        when(recipeIngredientService.saveAll(any(), any(), eq(RecipeSourceType.USER))).thenReturn(5000);
-        when(recipeIngredientRepository.findByRecipeId(any())).thenReturn(Collections.emptyList());
-        when(recipeRepository.findWithAllRelationsById(any())).thenReturn(Optional.of(Recipe.builder().user(author).id(888L).build()));
+        given(recipeIngredientService.saveAll(any(), any(), eq(RecipeSourceType.USER))).willReturn(5000);
+        given(recipeIngredientRepository.findByRecipeId(any())).willReturn(Collections.emptyList());
+        given(recipeRepository.findWithAllRelationsById(any())).willReturn(Optional.of(Recipe.builder().user(author).id(888L).build()));
 
         RecipeWithImageUploadRequest request = RecipeWithImageUploadRequest.builder()
                 .recipe(createDto)
                 .files(nonEmptyFiles)
                 .build();
 
+        // When
         recipeService.createRecipeAndGenerateUrls(request, userId, RecipeSourceType.USER, null);
 
+        // Then
         verify(recipeActivityService, never()).saveLog(any(), any(), any());
     }
 

--- a/src/test/java/com/jdc/recipe_service/service/RecipeStepServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeStepServiceTest.java
@@ -21,8 +21,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class RecipeStepServiceTest {
@@ -71,9 +72,9 @@ class RecipeStepServiceTest {
     }
 
     @Test
-    @DisplayName("getStepsByRecipeId: 레포에서 가져온 리스트를 그대로 반환")
+    @DisplayName("getStepsByRecipeId: 레포에서 가져온 리스트를 그대로 반환하는 테스트")
     void getStepsByRecipeId_success() {
-        // given
+        // Given
         RecipeStep step1 = RecipeStep.builder()
                 .id(1L)
                 .stepNumber(1)
@@ -87,25 +88,25 @@ class RecipeStepServiceTest {
                 .recipe(recipe)
                 .build();
 
-        when(recipeStepRepository.findByRecipeIdOrderByStepNumber(10L))
-                .thenReturn(List.of(step1, step2));
+        given(recipeStepRepository.findByRecipeIdOrderByStepNumber(10L))
+                .willReturn(List.of(step1, step2));
 
-        // when
+        // When
         var actual = service.getStepsByRecipeId(10L);
 
-        // then
-        assertEquals(2, actual.size());
-        assertEquals(step1, actual.get(0));
-        assertEquals(step2, actual.get(1));
+        // Then
+        assertThat(actual).hasSize(2);
+        assertThat(actual.get(0)).isEqualTo(step1);
+        assertThat(actual.get(1)).isEqualTo(step2);
         verify(recipeStepRepository, times(1)).findByRecipeIdOrderByStepNumber(10L);
     }
 
     @Test
-    @DisplayName("saveAll: 새로운 단계와 단계별 재료를 모두 저장한다")
+    @DisplayName("saveAll: 새로운 단계와 단계별 재료를 모두 저장하는 테스트")
     void saveAll_success() {
-        // given
-        when(recipeIngredientRepository.findByRecipeId(10L))
-                .thenReturn(List.of(ingr1, ingr2));
+        // Given
+        given(recipeIngredientRepository.findByRecipeId(10L))
+                .willReturn(List.of(ingr1, ingr2));
 
         // DTO: stepNumber, instruction, imageKey, action, ingredients 리스트
         RecipeStepIngredientRequestDto siDto1 = new RecipeStepIngredientRequestDto();
@@ -120,19 +121,19 @@ class RecipeStepServiceTest {
         dto1.setAction("씻기");
         dto1.setIngredients(List.of(siDto1));
 
-        // when
+        // When
         service.saveAll(recipe, List.of(dto1));
 
-        // then
+        // Then
         // 1) RecipeStep 저장 검증
         ArgumentCaptor<RecipeStep> stepCaptor = ArgumentCaptor.forClass(RecipeStep.class);
         verify(recipeStepRepository, times(1)).save(stepCaptor.capture());
         RecipeStep savedStep = stepCaptor.getValue();
-        assertEquals(1, savedStep.getStepNumber());
-        assertEquals("감자 씻기", savedStep.getInstruction());
-        assertEquals("key1", savedStep.getImageKey());
-        assertEquals("씻기", savedStep.getAction());
-        assertEquals(recipe, savedStep.getRecipe());
+        assertThat(savedStep.getStepNumber()).isEqualTo(1);
+        assertThat(savedStep.getInstruction()).isEqualTo("감자 씻기");
+        assertThat(savedStep.getImageKey()).isEqualTo("key1");
+        assertThat(savedStep.getAction()).isEqualTo("씻기");
+        assertThat(savedStep.getRecipe()).isEqualTo(recipe);
 
         // 2) 단계별 재료 저장 검증
         ArgumentCaptor<RecipeStepIngredient> stepIngrCaptor = ArgumentCaptor.forClass(RecipeStepIngredient.class);
@@ -140,19 +141,19 @@ class RecipeStepServiceTest {
         RecipeStepIngredient savedStepIngr = stepIngrCaptor.getValue();
 
         // 이제 ingredient 필드가 null이므로, 대신 customName("감자")이 설정되었는지 확인한다.
-        assertNull(savedStepIngr.getIngredient());
-        assertEquals("감자", savedStepIngr.getCustomName());
-        assertEquals("2", savedStepIngr.getQuantity());
-        assertEquals("개", savedStepIngr.getUnit());
-        assertEquals(savedStep, savedStepIngr.getStep());
+        assertThat(savedStepIngr.getIngredient()).isNull();
+        assertThat(savedStepIngr.getCustomName()).isEqualTo("감자");
+        assertThat(savedStepIngr.getQuantity()).isEqualTo("2");
+        assertThat(savedStepIngr.getUnit()).isEqualTo("개");
+        assertThat(savedStepIngr.getStep()).isEqualTo(savedStep);
     }
 
     @Test
-    @DisplayName("saveAll: 존재하지 않는 재료명을 넘기면 INGREDIENT_NOT_FOUND 예외 (단계 저장 후 재료 저장 전 예외)")
+    @DisplayName("saveAll: 존재하지 않는 재료명을 넘기면 INGREDIENT_NOT_FOUND 예외 발생하는 테스트 (단계 저장 후 재료 저장 전 예외)")
     void saveAll_missingIngredient_throw() {
-        // given
-        when(recipeIngredientRepository.findByRecipeId(10L))
-                .thenReturn(List.of(ingr1)); // "양파"는 맵에 없음
+        // Given
+        given(recipeIngredientRepository.findByRecipeId(10L))
+                .willReturn(List.of(ingr1)); // "양파"는 맵에 없음
 
         RecipeStepIngredientRequestDto siDto = new RecipeStepIngredientRequestDto();
         siDto.setName("양파");
@@ -166,12 +167,13 @@ class RecipeStepServiceTest {
         dto.setAction("씻기");
         dto.setIngredients(List.of(siDto));
 
-        // when & then
-        CustomException ex = assertThrows(CustomException.class, () -> {
-            service.saveAll(recipe, List.of(dto));
-        });
-        assertEquals(ErrorCode.INGREDIENT_NOT_FOUND, ex.getErrorCode());
-        assertTrue(ex.getMessage().contains("양파"));
+        // When & Then
+        assertThatThrownBy(() -> service.saveAll(recipe, List.of(dto)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.INGREDIENT_NOT_FOUND);
+                    assertThat(e.getMessage()).contains("양파");
+                });
 
         // RecipeStep은 1회 저장되지만, RecipeStepIngredient는 저장되지 않아야 한다
         verify(recipeStepRepository, times(1)).save(any());
@@ -179,11 +181,11 @@ class RecipeStepServiceTest {
     }
 
     @Test
-    @DisplayName("updateSteps: 없어진 step은 삭제, 기존 step은 업데이트, 새 step은 추가한다")
+    @DisplayName("updateSteps: 없어진 step은 삭제, 기존 step은 업데이트, 새 step은 추가하는 테스트")
     void updateSteps_success() {
-        // given
-        when(recipeIngredientRepository.findByRecipeId(10L))
-                .thenReturn(List.of(ingr1, ingr2));
+        // Given
+        given(recipeIngredientRepository.findByRecipeId(10L))
+                .willReturn(List.of(ingr1, ingr2));
 
         // 기존에 DB에 저장된 단계 1,2 준비
         RecipeStep existing1 = RecipeStep.builder()
@@ -213,8 +215,8 @@ class RecipeStepServiceTest {
                 .build();
         existing2.getStepIngredients().add(existingStepIngr);
 
-        when(recipeStepRepository.findByRecipeIdOrderByStepNumber(10L))
-                .thenReturn(List.of(existing1, existing2));
+        given(recipeStepRepository.findByRecipeIdOrderByStepNumber(10L))
+                .willReturn(List.of(existing1, existing2));
 
         // --- 1번 단계 수정 DTO 준비 ---
         RecipeStepIngredientRequestDto newSi1 = new RecipeStepIngredientRequestDto();
@@ -242,17 +244,17 @@ class RecipeStepServiceTest {
         dto3.setAction("끓이기");
         dto3.setIngredients(List.of(si3));
 
-        // when
+        // When
         service.updateSteps(recipe, List.of(dto1, dto3));
 
-        // then
+        // Then
         // 1) 2번 단계는 삭제되어야 한다
         verify(recipeStepRepository, times(1)).delete(existing2);
 
         // 2) 1번 단계 필드가 업데이트되었는지 확인
-        assertEquals("수정된1", existing1.getInstruction());
-        assertEquals("newKey1", existing1.getImageKey());
-        assertEquals("섞기", existing1.getAction());
+        assertThat(existing1.getInstruction()).isEqualTo("수정된1");
+        assertThat(existing1.getImageKey()).isEqualTo("newKey1");
+        assertThat(existing1.getAction()).isEqualTo("섞기");
 
         // 3) existing1 단계에 재료(감자)가 새로 추가되었는지 확인
         ArgumentCaptor<RecipeStepIngredient> capExist1 = ArgumentCaptor.forClass(RecipeStepIngredient.class);
@@ -263,17 +265,17 @@ class RecipeStepServiceTest {
                         rsi.getStep().equals(existing1)
                                 && Objects.equals(rsi.getCustomName(), "감자")
                 );
-        assertTrue(foundForExist1, "1번 단계에 customName = '감자'이 추가되어야 한다");
+        assertThat(foundForExist1).as("1번 단계에 customName = '감자'이 추가되어야 한다").isTrue();
 
         // 4) 3번 단계가 새로 생성되고 save()가 호출되었는지 확인
         ArgumentCaptor<RecipeStep> newStepCap = ArgumentCaptor.forClass(RecipeStep.class);
         verify(recipeStepRepository, times(1)).save(newStepCap.capture());
         RecipeStep savedStep3 = newStepCap.getValue();
-        assertEquals(3, savedStep3.getStepNumber());
-        assertEquals("새로운3", savedStep3.getInstruction());
-        assertEquals("key3", savedStep3.getImageKey());
-        assertEquals("끓이기", savedStep3.getAction());
-        assertEquals(recipe, savedStep3.getRecipe());
+        assertThat(savedStep3.getStepNumber()).isEqualTo(3);
+        assertThat(savedStep3.getInstruction()).isEqualTo("새로운3");
+        assertThat(savedStep3.getImageKey()).isEqualTo("key3");
+        assertThat(savedStep3.getAction()).isEqualTo("끓이기");
+        assertThat(savedStep3.getRecipe()).isEqualTo(recipe);
 
         // 5) 3번 단계의 재료도 save()가 최소 1회 호출되었는지 확인 (customName="감자")
         boolean foundForStep3 = savedList.stream()
@@ -281,17 +283,18 @@ class RecipeStepServiceTest {
                         Objects.equals(rsi.getStep(), savedStep3)
                                 && Objects.equals(rsi.getCustomName(), "감자")
                 );
-        assertTrue(foundForStep3, "3번 단계에 customName = '감자'이 추가되어야 한다");
+        assertThat(foundForStep3).as("3번 단계에 customName = '감자'이 추가되어야 한다").isTrue();
 
         // 전체적으로 RecipeStepIngredientRepository.save()는 최소 2회 호출
         verify(recipeStepIngredientRepository, atLeast(2)).save(any());
     }
 
     @Test
-    @DisplayName("updateSteps: 잘못된 재료가 DTO에 있으면 INGREDIENT_NOT_FOUND 예외")
+    @DisplayName("updateSteps: 잘못된 재료가 DTO에 있으면 INGREDIENT_NOT_FOUND 예외 발생하는 테스트")
     void updateSteps_missingIngredient_throw() {
-        when(recipeIngredientRepository.findByRecipeId(10L))
-                .thenReturn(List.of(ingr1));
+        // Given
+        given(recipeIngredientRepository.findByRecipeId(10L))
+                .willReturn(List.of(ingr1));
 
         // 기존 단계 하나, id=1
         RecipeStep existing = RecipeStep.builder()
@@ -299,8 +302,8 @@ class RecipeStepServiceTest {
                 .stepNumber(1)
                 .recipe(recipe)
                 .build();
-        when(recipeStepRepository.findByRecipeIdOrderByStepNumber(10L))
-                .thenReturn(List.of(existing));
+        given(recipeStepRepository.findByRecipeIdOrderByStepNumber(10L))
+                .willReturn(List.of(existing));
 
         // DTO에 존재하지 않는 "고추장"을 참조
         RecipeStepIngredientRequestDto wrongSi = new RecipeStepIngredientRequestDto();
@@ -315,20 +318,25 @@ class RecipeStepServiceTest {
         dto.setAction("넣기");
         dto.setIngredients(List.of(wrongSi));
 
-        CustomException ex = assertThrows(CustomException.class, () ->
-                service.updateSteps(recipe, List.of(dto))
-        );
-        assertEquals(ErrorCode.INGREDIENT_NOT_FOUND, ex.getErrorCode());
-        assertTrue(ex.getMessage().contains("고추장"));
+        // When & Then
+        assertThatThrownBy(() -> service.updateSteps(recipe, List.of(dto)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> {
+                    assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.INGREDIENT_NOT_FOUND);
+                    assertThat(e.getMessage()).contains("고추장");
+                });
     }
 
     @Test
-    @DisplayName("deleteAllByRecipeId: 모든 단계와 연관된 단계별 재료를 벌크 삭제한다")
+    @DisplayName("deleteAllByRecipeId: 모든 단계와 연관된 단계별 재료를 벌크 삭제하는 테스트")
     void deleteAllByRecipeId_success() {
+        // Given
         Long recipeId = 10L;
 
+        // When
         service.deleteAllByRecipeId(recipeId);
 
+        // Then
         verify(recipeStepIngredientRepository, times(1)).deleteAllByRecipeId(recipeId);
 
         verify(recipeStepRepository, times(1)).deleteByRecipeId(recipeId);
@@ -337,10 +345,11 @@ class RecipeStepServiceTest {
     }
 
     @Test
-    @DisplayName("updateStepsFromUser: action 없이 instruction, imageKey만 업데이트")
+    @DisplayName("updateStepsFromUser: action 없이 instruction, imageKey만 업데이트하는 테스트")
     void updateStepsFromUser_success() {
-        when(recipeIngredientRepository.findByRecipeId(10L))
-                .thenReturn(List.of(ingr1));
+        // Given
+        given(recipeIngredientRepository.findByRecipeId(10L))
+                .willReturn(List.of(ingr1));
 
         RecipeStep existing = RecipeStep.builder()
                 .id(1L)
@@ -350,8 +359,8 @@ class RecipeStepServiceTest {
                 .recipe(recipe)
                 .build();
 
-        when(recipeStepRepository.findByRecipeIdOrderByStepNumber(10L))
-                .thenReturn(List.of(existing));
+        given(recipeStepRepository.findByRecipeIdOrderByStepNumber(10L))
+                .willReturn(List.of(existing));
 
         // DTO: action 없이 instruction과 imageKey만 반영
         RecipeStepIngredientRequestDto siDto = new RecipeStepIngredientRequestDto();
@@ -365,11 +374,13 @@ class RecipeStepServiceTest {
         dto.setImageKey("newKey");
         dto.setIngredients(List.of(siDto));
 
+        // When
         service.updateStepsFromUser(recipe, List.of(dto));
 
+        // Then
         // 기존 단계 instruction, imageKey만 바뀌고 action은 그대로 null
-        assertEquals("새로운", existing.getInstruction());
-        assertEquals("newKey", existing.getImageKey());
-        assertNull(existing.getAction());
+        assertThat(existing.getInstruction()).isEqualTo("새로운");
+        assertThat(existing.getImageKey()).isEqualTo("newKey");
+        assertThat(existing.getAction()).isNull();
     }
 }

--- a/src/test/java/com/jdc/recipe_service/service/RecipeTagServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeTagServiceTest.java
@@ -13,9 +13,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class RecipeTagServiceTest {
@@ -39,13 +39,16 @@ class RecipeTagServiceTest {
     @Test
     @DisplayName("saveAll: 중복 태그가 있어도 한 번만 저장된다")
     void saveAll_distinctTags() {
+        // Given
         var inputTags = List.of("🍽️ 혼밥", "🍽️ 혼밥", "⚡ 초스피드 / 간단 요리");
 
-        when(recipeTagRepository.saveAll(anyList()))
-                .thenReturn(Collections.emptyList());
+        given(recipeTagRepository.saveAll(anyList()))
+                .willReturn(Collections.emptyList());
 
+        // When
         recipeTagService.saveAll(dummyRecipe, inputTags);
 
+        // Then
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<RecipeTag>> captor = ArgumentCaptor.forClass(List.class);
         verify(recipeTagRepository, times(1)).saveAll(captor.capture());
@@ -53,21 +56,24 @@ class RecipeTagServiceTest {
         List<RecipeTag> savedList = captor.getValue();
         Set<TagType> savedTypes = new HashSet<>();
         for (var rt : savedList) {
-            assertEquals(dummyRecipe.getId(), rt.getRecipe().getId());
+            assertThat(rt.getRecipe().getId()).isEqualTo(dummyRecipe.getId());
             savedTypes.add(rt.getTag());
         }
-        assertTrue(savedTypes.contains(TagType.SOLO));
-        assertTrue(savedTypes.contains(TagType.QUICK));
-        assertEquals(2, savedTypes.size());
+        assertThat(savedTypes).contains(TagType.SOLO);
+        assertThat(savedTypes).contains(TagType.QUICK);
+        assertThat(savedTypes).hasSize(2);
     }
 
     @Test
     @DisplayName("saveAll: 빈 리스트 입력 시 저장을 하지 않는다")
     void saveAll_emptyInput_noSave() {
+        // Given
         var inputTags = Collections.<String>emptyList();
 
+        // When
         recipeTagService.saveAll(dummyRecipe, inputTags);
 
+        // Then
         // 빈 리스트인 경우 saveAll 호출이 없어야 한다
         verify(recipeTagRepository, never()).saveAll(anyList());
     }
@@ -75,6 +81,7 @@ class RecipeTagServiceTest {
     @Test
     @DisplayName("updateTags: 기존 태그가 있고, 새로운 태그 목록으로 업데이트된다")
     void updateTags_addAndRemoveTags() {
+        // Given
         // 기존 태그: SOLO, PICNIC
         var existingSolo = RecipeTag.builder()
                 .id(100L)
@@ -91,38 +98,43 @@ class RecipeTagServiceTest {
         // 새 입력: SOLO(유지), HEALTHY(추가)
         var newTagDisplay = List.of("🍽️ 혼밥", "🥗 다이어트 / 건강식");
 
-        when(recipeTagRepository.findByRecipeId(dummyRecipe.getId()))
-                .thenReturn(existingList);
-        doNothing().when(recipeTagRepository).deleteAll(anyList());
-        when(recipeTagRepository.saveAll(anyList()))
-                .thenReturn(Collections.emptyList());
+        given(recipeTagRepository.findByRecipeId(dummyRecipe.getId()))
+                .willReturn(existingList);
+        willDoNothing().given(recipeTagRepository).deleteAll(anyList());
+        given(recipeTagRepository.saveAll(anyList()))
+                .willReturn(Collections.emptyList());
 
+        // When
         recipeTagService.updateTags(dummyRecipe, newTagDisplay);
 
+        // Then
         // 1) PICNIC 은 삭제 대상
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<RecipeTag>> removeCaptor = ArgumentCaptor.forClass(List.class);
         verify(recipeTagRepository, times(1)).deleteAll(removeCaptor.capture());
         var toRemove = removeCaptor.getValue();
-        assertEquals(1, toRemove.size());
-        assertEquals(TagType.PICNIC, toRemove.get(0).getTag());
+        assertThat(toRemove).hasSize(1);
+        assertThat(toRemove.get(0).getTag()).isEqualTo(TagType.PICNIC);
 
         // 2) HEALTHY 는 saveAll 로 한 번만 추가
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<RecipeTag>> addAllCaptor = ArgumentCaptor.forClass(List.class);
         verify(recipeTagRepository, times(1)).saveAll(addAllCaptor.capture());
         var toAdd = addAllCaptor.getValue();
-        assertEquals(1, toAdd.size());
-        assertEquals(TagType.HEALTHY, toAdd.get(0).getTag());
+        assertThat(toAdd).hasSize(1);
+        assertThat(toAdd.get(0).getTag()).isEqualTo(TagType.HEALTHY);
     }
 
     @Test
     @DisplayName("deleteAllByRecipeId: repository.deleteByRecipeId 메서드가 호출된다")
     void deleteAllByRecipeId_callsRepository() {
-        doNothing().when(recipeTagRepository).deleteByRecipeId(dummyRecipe.getId());
+        // Given
+        willDoNothing().given(recipeTagRepository).deleteByRecipeId(dummyRecipe.getId());
 
+        // When
         recipeTagService.deleteAllByRecipeId(dummyRecipe.getId());
 
+        // Then
         verify(recipeTagRepository, times(1)).deleteByRecipeId(dummyRecipe.getId());
     }
 }

--- a/src/test/java/com/jdc/recipe_service/service/UserServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/UserServiceTest.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.verify;
+import static org.mockito.BDDMockito.verify;
 
 @SpringBootTest
 @Transactional
@@ -34,6 +34,7 @@ class UserServiceDeleteTest {
     @Test
     @DisplayName("유저 하드 삭제 시 연관된 레시피, 댓글, 좋아요가 DB Cascade에 의해 모두 삭제되어야 한다")
     void deleteUser_Cascade_Test() {
+        // Given
         User targetUser = userRepository.save(User.builder()
                 .nickname("삭제될유저")
                 .provider("google")
@@ -74,8 +75,10 @@ class UserServiceDeleteTest {
         em.flush();
         em.clear();
 
+        // When
         userService.deleteUser(targetUser.getId());
 
+        // Then
         assertThat(userRepository.findById(targetUser.getId())).isEmpty();
         assertThat(recipeRepository.findById(myRecipe.getId())).isEmpty();
         assertThat(recipeCommentRepository.findById(commentOnMyRecipe.getId())).isEmpty();

--- a/src/test/java/com/jdc/recipe_service/service/credit/UserCreditServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/credit/UserCreditServiceTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserCreditServiceTest {
@@ -47,14 +47,14 @@ class UserCreditServiceTest {
     @Test
     @DisplayName("성공: 구독(기간제) 크레딧이 유료 크레딧보다 먼저 차감되어야 한다.")
     void useCredit_Priority_Success() {
-        // given
+        // Given
         Long userId = 1L;
         User user = User.builder().id(userId).build();
 
         // [New] 유저 조회 Mocking 필요
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         // [New] 중복 거래 아님 설정
-        when(creditHistoryRepository.existsByTransactionId(any())).thenReturn(false);
+        given(creditHistoryRepository.existsByTransactionId(any())).willReturn(false);
 
         // 상황: 구독 크레딧 3개, 유료 크레딧 5개 보유 중
         UserCredit subCredit = UserCredit.builder()
@@ -66,15 +66,15 @@ class UserCreditServiceTest {
                 .expiresAt(LocalDateTime.now().plusYears(1)).build();
 
         // Repository는 정렬된 순서대로 반환한다고 가정
-        when(userCreditRepository.findUseableCredits(eq(userId), any(PageRequest.class)))
-                .thenReturn(List.of(subCredit, paidCredit));
+        given(userCreditRepository.findUseableCredits(eq(userId), any(PageRequest.class)))
+                .willReturn(List.of(subCredit, paidCredit));
 
-        when(userCreditRepository.calculateTotalBalance(userId)).thenReturn(4); // 사용 후 잔액 가정
+        given(userCreditRepository.calculateTotalBalance(userId)).willReturn(4); // 사용 후 잔액 가정
 
-        // when: 4개를 사용함 (파라미터 추가됨)
+        // When: 4개를 사용함 (파라미터 추가됨)
         userCreditService.useCredit(userId, 4, "TEST_REF", 100L, "TX_12345");
 
-        // then
+        // Then
         // 1. 구독 크레딧(3개)은 다 써서 0이 되어야 함
         assertThat(subCredit.getAmount()).isEqualTo(0);
 
@@ -88,20 +88,20 @@ class UserCreditServiceTest {
     @Test
     @DisplayName("실패: 잔액이 부족하면 예외가 발생해야 한다.")
     void useCredit_Insufficient_Balance() {
-        // given
+        // Given
         Long userId = 1L;
         User user = User.builder().id(userId).build();
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(creditHistoryRepository.existsByTransactionId(any())).thenReturn(false);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(creditHistoryRepository.existsByTransactionId(any())).willReturn(false);
 
         UserCredit bonusCredit = UserCredit.builder()
                 .user(user).creditType(CreditType.BONUS).amount(2).build();
 
-        when(userCreditRepository.findUseableCredits(eq(userId), any(PageRequest.class)))
-                .thenReturn(List.of(bonusCredit));
+        given(userCreditRepository.findUseableCredits(eq(userId), any(PageRequest.class)))
+                .willReturn(List.of(bonusCredit));
 
-        // when & then: 5개를 쓰려고 하면 에러 발생
+        // When & Then: 5개를 쓰려고 하면 에러 발생
         assertThatThrownBy(() -> userCreditService.useCredit(userId, 5, "TEST", 1L, "TX_FAIL"))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PAYMENT_REQUIRED);
@@ -110,15 +110,17 @@ class UserCreditServiceTest {
     @Test
     @DisplayName("실패: 가진 크레딧이 아예 없으면 예외 발생")
     void useCredit_No_Credit() {
+        // Given
         Long userId = 1L;
         User user = User.builder().id(userId).build();
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(creditHistoryRepository.existsByTransactionId(any())).thenReturn(false);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(creditHistoryRepository.existsByTransactionId(any())).willReturn(false);
 
-        when(userCreditRepository.findUseableCredits(eq(userId), any(PageRequest.class)))
-                .thenReturn(Collections.emptyList());
+        given(userCreditRepository.findUseableCredits(eq(userId), any(PageRequest.class)))
+                .willReturn(Collections.emptyList());
 
+        // When & Then
         assertThatThrownBy(() -> userCreditService.useCredit(userId, 1, "TEST", 1L, "TX_EMPTY"))
                 .isInstanceOf(CustomException.class);
     }
@@ -126,17 +128,17 @@ class UserCreditServiceTest {
     @Test
     @DisplayName("성공: 이미 처리된 트랜잭션ID라면 아무것도 하지 않고 종료해야 한다(Idempotency).")
     void useCredit_Duplicate_Transaction_Ignored() {
-        // given
+        // Given
         Long userId = 1L;
         String duplicateTxId = "TX_DUP_123";
 
         // 이미 존재하는 트랜잭션이라고 설정
-        when(creditHistoryRepository.existsByTransactionId(duplicateTxId)).thenReturn(true);
+        given(creditHistoryRepository.existsByTransactionId(duplicateTxId)).willReturn(true);
 
-        // when
+        // When
         userCreditService.useCredit(userId, 1, "TEST", 1L, duplicateTxId);
 
-        // then
+        // Then
         // 1. 유저 조회나 크레딧 조회 로직이 실행되지 않아야 함
         verify(userRepository, never()).findById(any());
         verify(userCreditRepository, never()).findUseableCredits(any(), any());

--- a/src/test/java/com/jdc/recipe_service/service/image/RecipeImageMatchingTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/image/RecipeImageMatchingTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
 @SpringBootTest
 class RecipeImageMatchingTest {
@@ -37,13 +37,12 @@ class RecipeImageMatchingTest {
         DishType dishType = DishType.SOUP_STEW;
 
         // 1. 가짜 DB 설정: 해당 키워드의 레시피가 5개 있다고 가정
-        when(recipeRepository.countCandidateRecipes(eq("김치찌개"), eq(dishType)))
-                .thenReturn(5L);
+        given(recipeRepository.countCandidateRecipes(eq("김치찌개"), eq(dishType)))
+                .willReturn(5L);
 
-        // 2. 가짜 DB 설정: 페이징으로 조회했을 때 가짜 레시피를 반환하도록 세팅
         Recipe mockRecipe = Recipe.builder().imageKey("s3/path/real_kimchi.jpg").build();
-        when(recipeRepository.findCandidateRecipesByKeywordAndDishType(eq("김치찌개"), eq(dishType), any(PageRequest.class)))
-                .thenReturn(new PageImpl<>(List.of(mockRecipe)));
+        given(recipeRepository.findCandidateRecipesByKeywordAndDishType(eq("김치찌개"), eq(dishType), any(PageRequest.class)))
+                .willReturn(new PageImpl<>(List.of(mockRecipe)));
 
         // When (진짜 로직 실행!)
         String resultImageKey = imageMatchingService.findMatchingImageKey(keywords, dishType);
@@ -63,8 +62,8 @@ class RecipeImageMatchingTest {
         DishType dishType = DishType.FRIED_PAN;
 
         // 가짜 DB 설정: 해당 키워드의 레시피가 0개라고 가정
-        when(recipeRepository.countCandidateRecipes(anyString(), any(DishType.class)))
-                .thenReturn(0L);
+        given(recipeRepository.countCandidateRecipes(anyString(), any(DishType.class)))
+                .willReturn(0L);
 
         // When
         String resultImageKey = imageMatchingService.findMatchingImageKey(keywords, dishType);

--- a/src/test/java/com/jdc/recipe_service/service/media/RecipeAccuracyTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/media/RecipeAccuracyTest.java
@@ -1,0 +1,254 @@
+package com.jdc.recipe_service.service.media;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jdc.recipe_service.domain.dto.recipe.RecipeCreateRequestDto;
+import com.jdc.recipe_service.domain.dto.recipe.ingredient.RecipeIngredientRequestDto;
+import com.jdc.recipe_service.service.ai.GrokClientService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@SpringBootTest
+class RecipeAccuracyTest {
+
+    @Autowired
+    private YtDlpService ytDlpService;
+
+    @Autowired
+    private GrokClientService grokClientService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final Pattern UNIT_PATTERN = Pattern.compile("(?i)(큰술|작은술|밥숟가락|티스푼|종이컵|국자|주걱|꼬집|약간|적당량|spoon|tbs|tbsp|tsp|cup|oz|lb|kg|ml|l|cc|liter|개|마리|모|단|통|알|쪽|줌|봉|봉지|팩|장|copy|ea|\\b[0-9]+/[0-9]+\\b|\\b[0-9.]+\\s?(g|kg|ml|l|cc)\\b)");
+    private static final Pattern INGREDIENT_KEYWORD_PATTERN = Pattern.compile("(?i)(재료|ingredient|준비물|필요|양념|소스|드레싱|시즈닝|seasoning|sauce|dressing|materials|shopping list)");
+    private static final Pattern NUMBER_UNIT_IN_LINE = Pattern.compile("\\d+\\s*[./]?\\s*\\d*\\s*(큰술|작은술|스푼|티스푼|종이컵|국자|개|마리|g|kg|ml|봉지|줌|쪽|알|장|컵|꼬집|약간|적당량|tbsp|tsp|cup|oz)\\b|\\b(약간|적당량|조금)");
+
+    // ✅ 테스트할 URL 목록 - 여기에 추가
+    private static final List<String> TEST_URLS = List.of(
+            "https://www.youtube.com/watch?v=miuQsqrnewc"
+            // 추가 URL을 아래에 넣어주세요:
+            // "https://www.youtube.com/watch?v=xxxx",
+            // "https://www.youtube.com/watch?v=yyyy"
+    );
+
+    private static final String SEPARATOR = "\n" + "=".repeat(70) + "\n";
+    private static final String THIN_SEPARATOR = "-".repeat(50);
+
+    @Test
+    void testPipelineAccuracy() throws Exception {
+        int total = TEST_URLS.size();
+        System.out.println(SEPARATOR);
+        System.out.printf("🎯 레시피 추출 정확도 테스트 시작 (총 %d개 영상)%n", total);
+        System.out.println(SEPARATOR);
+
+        for (int i = 0; i < TEST_URLS.size(); i++) {
+            String url = TEST_URLS.get(i);
+            System.out.printf("%n[%d/%d] 처리 시작: %s%n", i + 1, total, url);
+            System.out.println(THIN_SEPARATOR);
+
+            try {
+                runSingleTest(url, i + 1);
+            } catch (Exception e) {
+                System.out.printf("❌ 오류 발생: %s%n", e.getMessage());
+            }
+
+            System.out.println(SEPARATOR);
+        }
+
+        System.out.println("✅ 전체 테스트 완료");
+    }
+
+    private void runSingleTest(String url, int index) throws Exception {
+        long startTime = System.currentTimeMillis();
+
+        // ─── 1. 메타데이터 수집 ───────────────────────────────────────
+        System.out.println("📥 [1] 유튜브 데이터 추출 중...");
+        YtDlpService.YoutubeFullDataDto videoData = ytDlpService.getVideoDataFull(url);
+
+        System.out.printf("📌 제목: %s%n", videoData.title());
+
+        // ─── 2. 소스 데이터 출력 (원본 기준) ─────────────────────────
+        System.out.println("\n📄 [소스 데이터 - 원본]");
+        System.out.println(THIN_SEPARATOR);
+
+        String description = videoData.description() != null ? videoData.description() : "";
+        String comments    = videoData.comments()    != null ? videoData.comments()    : "";
+
+        System.out.println("▶ 설명글 (앞 1500자):");
+        System.out.println(description.length() > 1500 ? description.substring(0, 1500) + "...(생략)" : description);
+
+        System.out.println("\n▶ 댓글 (앞 3000자):");
+        System.out.println(comments.length() > 3000 ? comments.substring(0, 3000) + "...(생략)" : comments);
+
+        // ─── 3. 자막 전처리 및 재료 힌트 추출 ────────────────────────
+        String[] lines = videoData.scriptTimecoded() != null
+                ? videoData.scriptTimecoded().split("\\r?\\n")
+                : new String[0];
+
+        List<String> plainLines      = new ArrayList<>();
+        List<String> ingredientLines = new ArrayList<>();
+
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("WEBVTT") || trimmed.startsWith("NOTE") || trimmed.contains("-->")) continue;
+            String content = trimmed.replaceAll("<[^>]+>", "").replace("&nbsp;", " ").trim();
+            if (content.isEmpty()) continue;
+            plainLines.add(content);
+            if (UNIT_PATTERN.matcher(content).find() || NUMBER_UNIT_IN_LINE.matcher(content).find() || INGREDIENT_KEYWORD_PATTERN.matcher(content).find()) {
+                ingredientLines.add(content);
+            }
+        }
+
+        System.out.println("\n▶ 자막에서 추출된 재료·수량 관련 라인 (" + ingredientLines.size() + "줄):");
+        if (ingredientLines.isEmpty()) {
+            System.out.println("  (재료 관련 자막 없음)");
+        } else {
+            ingredientLines.forEach(l -> System.out.println("  " + l));
+        }
+
+        // ─── 4. AI 추출 ───────────────────────────────────────────────
+        String plainScriptForContext = String.join("\n", plainLines);
+        String ingredientHintBlock = ingredientLines.isEmpty()
+                ? "(재료·양 언급 구간 없음)"
+                : "[재료·양 언급 구간]\n" + String.join("\n", ingredientLines);
+
+        String fullContext = String.format("""
+                영상 URL: %s
+                영상 제목: %s
+                영상 설명: %s
+                고정/인기 댓글: %s
+
+                %s
+
+                [자막 전문]
+                %s
+                """, url, videoData.title(), description, comments, ingredientHintBlock, plainScriptForContext);
+
+        System.out.println("\n🤖 [2] Grok Step1 추출 중...");
+        RecipeCreateRequestDto recipeDto = grokClientService.generateRecipeStep1(getSystemPrompt(), fullContext).join();
+
+        System.out.println("🤖 [3] Grok Step2 재료 정제 중...");
+        List<RecipeIngredientRequestDto> refinedIngredients =
+                grokClientService.refineIngredientsOnly("식재료 데이터 정제 AI", recipeDto.getIngredients()).join();
+
+        // ─── 5. 결과 출력 ─────────────────────────────────────────────
+        System.out.println("\n📊 [추출 결과 비교]");
+        System.out.println(THIN_SEPARATOR);
+
+        System.out.printf("🔴 Step1 재료 (%d개):%n", recipeDto.getIngredients().size());
+        recipeDto.getIngredients().forEach(i ->
+                System.out.printf("  %-20s | %s %s  [추정=%s]%n",
+                        i.getName(), i.getQuantity(), i.getCustomUnit(),
+                        Boolean.TRUE.equals(i.getIsEstimated()) ? "Y" : "N"));
+
+        System.out.printf("%n🟢 Step2 재료 (%d개):%n", refinedIngredients.size());
+        refinedIngredients.forEach(i ->
+                System.out.printf("  %-20s | %s %s%n",
+                        i.getName(), i.getQuantity(), i.getCustomUnit()));
+
+        // Step1→Step2 변경 감지
+        System.out.println("\n⚠️  Step1→Step2 변경 감지:");
+        boolean anyChange = false;
+        for (int j = 0; j < Math.min(recipeDto.getIngredients().size(), refinedIngredients.size()); j++) {
+            RecipeIngredientRequestDto s1 = recipeDto.getIngredients().get(j);
+            RecipeIngredientRequestDto s2 = refinedIngredients.get(j);
+            boolean unitChanged = !eq(s1.getCustomUnit(), s2.getCustomUnit());
+            boolean qtyChanged  = !eq(s1.getQuantity(),   s2.getQuantity());
+            if (unitChanged || qtyChanged) {
+                anyChange = true;
+                System.out.printf("  %-20s | %s %s  →  %s %s%s%n",
+                        s1.getName(),
+                        s1.getQuantity(), s1.getCustomUnit(),
+                        s2.getQuantity(), s2.getCustomUnit(),
+                        unitChanged ? "  ⚡단위변환" : "");
+            }
+        }
+        if (!anyChange) System.out.println("  (변경 없음)");
+
+        long elapsed = System.currentTimeMillis() - startTime;
+        System.out.printf("%n⏱  소요시간: %dms%n", elapsed);
+    }
+
+    private boolean eq(String a, String b) {
+        if (a == null && b == null) return true;
+        if (a == null || b == null) return false;
+        return a.trim().equals(b.trim());
+    }
+
+    private String getSystemPrompt() {
+        return """
+당신은 레시피 추출 AI입니다. 오직 유효한 JSON만 출력하세요.
+
+## 최우선 규칙
+- 단일 JSON 객체만 출력 (마크다운, 코드펜스, 설명 절대 금지)
+- timeline과 nonRecipeReason만 null 허용
+- 모든 숫자 필드는 0 이상 (빈 문자열, null 금지)
+- 영상에 없는 정보는 절대 창작 금지
+
+## 1단계: 레시피 판별
+조리법이 아니면 즉시 반환:
+{
+  "isRecipe": false,
+  "nonRecipeReason": "먹방/리뷰/브이로그 - 조리법 없음"
+}
+
+제외 키워드: 먹방, mukbang, ASMR, 리뷰, 브이로그, vlog, 장보기, 언박싱, 예능, 챌린지, 공지, 라이브
+
+## 2단계: 데이터 추출 (isRecipe=true일 때만)
+
+### [CRITICAL] 다중 레시피 처리 규칙
+영상에 두 가지 이상의 레시피가 나올 경우:
+1. 가장 비중 있거나 제목과 일치하는 메인 레시피 1개만 선택
+2. 선택하지 않은 버전의 재료나 조리법 절대 혼합 금지
+
+근거 우선순위: Script(자막) > Description > Title > Comments
+
+### 출력 구조
+{
+  "isRecipe": true,
+  "nonRecipeReason": null,
+  "title": "영상의 요리명",
+  "dishType": "11개 중 정확히 1개",
+  "description": "1-2문장: 맛/식감 + 핵심특징",
+  "cookingTime": 15,
+  "cookingTools": ["도구1"],
+  "servings": 1,
+  "ingredients": [...],
+  "steps": [...],
+  "tags": ["태그1","태그2","태그3"],
+  "marketPrice": 1500,
+  "cookingTips": "문장으로 3-5개 팁 (불릿 금지)"
+}
+
+**dishType** - 정확히 1개만 선택:
+"볶음", "국/찌개/탕", "구이", "무침/샐러드", "튀김/부침", "찜/조림", "오븐요리", "생식/회", "절임/피클류", "밥/면/파스타", "디저트/간식류"
+
+**ingredients** - 핵심 규칙:
+1. 단일 명사 원칙
+2. quantity 형식: "2", "0.5", "1/2"
+3. [단위 보존]: 영상에서 나온 단위 그대로 (컵, 국자, 개 등 무리하게 변환 금지)
+4. 소스 분해, 부재료 포착 필수
+5. [🚨필수 플래그🚨]: 수량이 영상에 명시됐으면 isEstimated:false, 추론이면 isEstimated:true
+
+**steps**:
+- stepNumber: 0부터 시작
+- timeline: "MM:SS" 또는 null
+- instruction: 2-3문장 상세
+- action: "썰기","다지기","볶기","튀기기","끓이기","찌기","데치기","굽기","조림","무치기","씻기","부치기" 중 1개
+
+**tags** - 최대 3개:
+"🏠 홈파티","🌼 피크닉","🏕️ 캠핑","🥗 다이어트 / 건강식","👶 아이와 함께","🍽️ 혼밥","🍶 술안주","🥐 브런치","🌙 야식","⚡ 초스피드 / 간단 요리","🎉 기념일 / 명절","🍱 도시락","🔌 에어프라이어","🍲 해장","👨‍🍳 셰프 레시피"
+
+## 절대 금지
+- 코드펜스, 설명문
+- 근거 없는 추측
+- 빈 문자열/null (허용 필드 제외)
+- 중복 재료
+""";
+    }
+}


### PR DESCRIPTION
## Why
테스트 코드 스타일이 파일마다 달라 일관성이 없었음.
일부 파일은 `when().thenReturn()`, 일부는 `given().willReturn()` 혼용.
또한 `lenient().given()` 오용으로 인한 컴파일 에러가 존재했음.

## What
- 전체 19개 테스트 파일의 stubbing을 BDDMockito `given().willReturn()` 스타일로 통일
- 모든 테스트 메서드에 `// Given / // When / // Then` 블록 주석 추가
- `@DisplayName` 한글 설명 일괄 보완
- `assertThat()` (AssertJ) 스타일로 assertions 통일
- `lenient().given()` → `given()` 수정 (컴파일 에러 해결)
  - `LenientStubber`에 BDD `given()` 메서드 없음
  - 클래스 레벨 `@MockitoSettings(strictness = LENIENT)` 이 이미 적용되어 있어 중복 불필요

## Side-effect
- 없음 (테스트 코드만 변경, 프로덕션 코드 변경 없음)

## Test
- `./gradlew compileTestJava` 로 컴파일 에러 0건 확인
- 기존 테스트 로직은 그대로 유지, 스타일만 변경