### PR TITLE
  fix(recipe): RecipeBook 접근가능 카운트와 Recipe 삭제 cascade 일관성 수정

### DIFF
--- a/src/main/java/com/jdc/recipe_service/domain/dto/recipebook/RecipeBookDetailResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/recipebook/RecipeBookDetailResponse.java
@@ -27,7 +27,8 @@ public class RecipeBookDetailResponse {
     @Schema(description = "기본 레시피북 여부")
     private boolean isDefault;
 
-    @Schema(description = "포함된 레시피 수")
+    @Schema(description = "현재 사용자가 볼 수 있는 레시피 수 (공개 레시피 + 본인 레시피). "
+            + "타인이 비공개로 전환한 레시피는 집계에서 제외된다.")
     private int recipeCount;
 
     @Schema(description = "레시피 목록 (최신순)")

--- a/src/main/java/com/jdc/recipe_service/domain/dto/recipebook/RecipeBookResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/recipebook/RecipeBookResponse.java
@@ -29,16 +29,17 @@ public class RecipeBookResponse {
     @Schema(description = "표시 순서")
     private int displayOrder;
 
-    @Schema(description = "포함된 레시피 수")
+    @Schema(description = "현재 사용자가 볼 수 있는 레시피 수 (공개 레시피 + 본인 레시피). "
+            + "타인이 비공개로 전환한 레시피는 집계에서 제외된다.")
     private int recipeCount;
 
-    public static RecipeBookResponse from(RecipeBook book) {
+    public static RecipeBookResponse from(RecipeBook book, int recipeCount) {
         return RecipeBookResponse.builder()
                 .id(book.getId())
                 .name(book.getName())
                 .isDefault(book.isDefault())
                 .displayOrder(book.getDisplayOrder())
-                .recipeCount(book.getRecipeCount())
+                .recipeCount(recipeCount)
                 .build();
     }
 }

--- a/src/main/java/com/jdc/recipe_service/domain/entity/media/RecipeYoutubeInfo.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/media/RecipeYoutubeInfo.java
@@ -4,6 +4,8 @@ import com.jdc.recipe_service.domain.entity.Recipe;
 import com.jdc.recipe_service.domain.entity.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(
@@ -28,6 +30,7 @@ public class RecipeYoutubeInfo extends BaseTimeEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipe_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Recipe recipe;
 
     @Column(name = "video_id", nullable = false, length = 32)

--- a/src/main/java/com/jdc/recipe_service/domain/entity/recipe/RecipeAccess.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/recipe/RecipeAccess.java
@@ -6,6 +6,8 @@ import com.jdc.recipe_service.domain.entity.common.BaseTimeEntity;
 import com.jdc.recipe_service.domain.type.recipe.RecipeAccessRole;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(
@@ -33,6 +35,7 @@ public class RecipeAccess extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipe_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Recipe recipe;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/jdc/recipe_service/domain/repository/RecipeBookItemRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/RecipeBookItemRepository.java
@@ -43,6 +43,17 @@ public interface RecipeBookItemRepository extends JpaRepository<RecipeBookItem, 
             @Param("bookId") Long bookId,
             @Param("userId") Long userId);
 
+    /** 유저의 모든 폴더에서 접근 가능한 레시피 수를 book_id별로 집계 (폴더 목록에서 사용) */
+    @Query("""
+      SELECT i.book.id, COUNT(i)
+      FROM RecipeBookItem i
+      JOIN i.recipe r
+      WHERE i.book.user.id = :userId
+        AND (r.isPrivate = false OR r.user.id = :userId)
+      GROUP BY i.book.id
+      """)
+    List<Object[]> countAccessibleByUserIdGroupByBookId(@Param("userId") Long userId);
+
     /** 레시피 삭제 시 영향받는 폴더별 아이템 수 조회 (count 보정용) */
     @Query("SELECT i.book.id, COUNT(i) FROM RecipeBookItem i WHERE i.recipe.id = :recipeId GROUP BY i.book.id")
     List<Object[]> countByRecipeIdGroupByBookId(@Param("recipeId") Long recipeId);

--- a/src/main/java/com/jdc/recipe_service/service/RecipeBookService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeBookService.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -107,15 +108,19 @@ public class RecipeBookService {
                 .build();
 
         bookRepo.save(book);
-        return RecipeBookResponse.from(book);
+        return RecipeBookResponse.from(book, 0);
     }
 
     @Transactional
     public List<RecipeBookResponse> listBooks(Long userId) {
         ensureDefaultBook(userId);
 
-        return bookRepo.findByUserIdOrderByDisplayOrderAsc(userId).stream()
-                .map(RecipeBookResponse::from)
+        List<RecipeBook> books = bookRepo.findByUserIdOrderByDisplayOrderAsc(userId);
+        Map<Long, Integer> countByBookId = loadAccessibleCounts(userId);
+
+        return books.stream()
+                .map(b -> RecipeBookResponse.from(
+                        b, countByBookId.getOrDefault(b.getId(), 0)))
                 .toList();
     }
 
@@ -158,7 +163,8 @@ public class RecipeBookService {
         }
 
         book.rename(request.getName());
-        return RecipeBookResponse.from(book);
+        int accessibleCount = itemRepo.countAccessibleByBookIdAndUserId(bookId, userId);
+        return RecipeBookResponse.from(book, accessibleCount);
     }
 
     @Transactional
@@ -208,10 +214,24 @@ public class RecipeBookService {
             bookMap.get(orderedIds.get(i)).updateDisplayOrder(i);
         }
 
+        Map<Long, Integer> countByBookId = loadAccessibleCounts(userId);
+
         return books.stream()
                 .sorted((a, b) -> Integer.compare(a.getDisplayOrder(), b.getDisplayOrder()))
-                .map(RecipeBookResponse::from)
+                .map(b -> RecipeBookResponse.from(
+                        b, countByBookId.getOrDefault(b.getId(), 0)))
                 .toList();
+    }
+
+    private Map<Long, Integer> loadAccessibleCounts(Long userId) {
+        List<Object[]> rows = itemRepo.countAccessibleByUserIdGroupByBookId(userId);
+        Map<Long, Integer> result = new HashMap<>();
+        for (Object[] row : rows) {
+            Long bookId = ((Number) row[0]).longValue();
+            int count = ((Number) row[1]).intValue();
+            result.put(bookId, count);
+        }
+        return result;
     }
 
     // ── 레시피북 아이템 관리 ──

--- a/src/main/resources/db/migration/V20260417_001__cascade_recipe_fk_for_youtube_info_and_access.sql
+++ b/src/main/resources/db/migration/V20260417_001__cascade_recipe_fk_for_youtube_info_and_access.sql
@@ -1,0 +1,21 @@
+-- recipes 자식 테이블 중 ON DELETE 정책이 NO ACTION으로 남아 있던 두 FK를 CASCADE로 통일한다.
+-- 기존 RecipeService.deleteRecipe 경로(JPQL bulk delete)가 이 두 테이블에 row가 있을 때
+-- FK violation으로 실패하던 문제를 해결한다. 다른 12개 자식 테이블은 이미 ON DELETE CASCADE다.
+--
+-- App 호환성: parent(recipes) row가 살아 있는 동안 child 동작은 동일.
+-- 변경되는 시점은 오직 recipes row 삭제 시점이고, "FK violation으로 거부" → "child 자동 삭제"로
+-- strict하게 더 관대해지는 방향이라 구 버전 앱과 새 스키마가 만나도 회귀 위험 없음.
+--
+-- 운영 주의: MySQL에서 DROP FOREIGN KEY + ADD CONSTRAINT는 metadata lock을 잡는다.
+-- 트래픽이 낮은 시간대에 적용하고, 적용 직전에 long-running transaction이 없는지
+-- (information_schema.innodb_trx, SHOW PROCESSLIST) 확인하는 것을 권장한다.
+
+ALTER TABLE recipe_youtube_info
+    DROP FOREIGN KEY FKh6nuvr74hlnrwtjx7rlk7ppcn,
+    ADD CONSTRAINT FK_recipe_youtube_info_recipe
+        FOREIGN KEY (recipe_id) REFERENCES recipes (id) ON DELETE CASCADE;
+
+ALTER TABLE recipe_access
+    DROP FOREIGN KEY FKrv5rsk2xhoflktwskbipk0a9s,
+    ADD CONSTRAINT FK_recipe_access_recipe
+        FOREIGN KEY (recipe_id) REFERENCES recipes (id) ON DELETE CASCADE;

--- a/src/test/java/com/jdc/recipe_service/repository/RecipeBookItemAccessibleCountTest.java
+++ b/src/test/java/com/jdc/recipe_service/repository/RecipeBookItemAccessibleCountTest.java
@@ -1,0 +1,167 @@
+package com.jdc.recipe_service.repository;
+
+import com.jdc.recipe_service.config.JpaAuditingConfig;
+import com.jdc.recipe_service.config.QuerydslConfig;
+import com.jdc.recipe_service.domain.entity.Recipe;
+import com.jdc.recipe_service.domain.entity.RecipeBook;
+import com.jdc.recipe_service.domain.entity.RecipeBookItem;
+import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.repository.RecipeBookItemRepository;
+import com.jdc.recipe_service.domain.type.DishType;
+import com.jdc.recipe_service.domain.type.Role;
+import com.jdc.recipe_service.domain.type.recipe.RecipeLifecycleStatus;
+import com.jdc.recipe_service.domain.type.recipe.RecipeListingStatus;
+import com.jdc.recipe_service.domain.type.recipe.RecipeSourceType;
+import com.jdc.recipe_service.domain.type.recipe.RecipeVisibility;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * countAccessibleByUserIdGroupByBookId invariant: countAccessibleByBookIdAndUserId와 동일한
+ * 접근성 필터(r.isPrivate = false OR r.user.id = :userId)를 모든 폴더에 대해 한 번에 집계해야 한다.
+ * 폴더 목록 응답(/api/me/recipe-books)과 폴더 상세 응답(/api/me/recipe-books/{id})의 recipeCount
+ * 의미가 어긋나지 않도록 회귀로 고정한다.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Import({QuerydslConfig.class, JpaAuditingConfig.class})
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "app.s3.bucket-name=test-bucket",
+        "cloud.aws.region.static=ap-northeast-2"
+})
+class RecipeBookItemAccessibleCountTest {
+
+    @Container
+    @ServiceConnection
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.33");
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private RecipeBookItemRepository itemRepo;
+
+    @Test
+    @DisplayName("유저의 모든 폴더에서 접근 가능한 레시피만 book_id별로 집계한다")
+    void groupsAccessibleItemsByBookId() {
+        // given
+        User owner = persistUser("google", "owner", "폴더주인");
+        User stranger = persistUser("google", "stranger", "타인");
+
+        RecipeBook defaultBook = persistBook(owner, "저장한 레시피", true, 0);
+        RecipeBook customBook = persistBook(owner, "한식 모음", false, 1);
+        RecipeBook emptyBook = persistBook(owner, "빈 폴더", false, 2);
+
+        // 공개 레시피 (타인 작성): 접근 가능
+        Recipe publicByStranger = persistRecipe(stranger, false);
+        // 비공개 레시피 (타인 작성): 접근 불가
+        Recipe privateByStranger = persistRecipe(stranger, true);
+        // 비공개 레시피 (본인 작성): 본인이므로 접근 가능
+        Recipe privateByOwner = persistRecipe(owner, true);
+
+        // defaultBook: 공개 1 + 타인 비공개 1 + 본인 비공개 1 = 접근 가능 2
+        persistItem(defaultBook, publicByStranger);
+        persistItem(defaultBook, privateByStranger);
+        persistItem(defaultBook, privateByOwner);
+
+        // customBook: 타인 비공개 1 = 접근 가능 0
+        persistItem(customBook, privateByStranger);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<Object[]> rows = itemRepo.countAccessibleByUserIdGroupByBookId(owner.getId());
+        Map<Long, Long> countByBookId = rows.stream().collect(Collectors.toMap(
+                row -> ((Number) row[0]).longValue(),
+                row -> ((Number) row[1]).longValue()));
+
+        // then
+        assertThat(countByBookId.get(defaultBook.getId()))
+                .as("공개 1 + 본인 비공개 1 = 2 (타인 비공개는 제외)")
+                .isEqualTo(2L);
+        assertThat(countByBookId.get(customBook.getId()))
+                .as("타인 비공개만 담긴 폴더는 GROUP BY에서 0 row가 아니라 아예 결과에 안 나온다")
+                .isNull();
+        assertThat(countByBookId.get(emptyBook.getId()))
+                .as("비어 있는 폴더도 결과에 안 나온다")
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("타인 폴더는 집계 대상에서 제외된다")
+    void excludesOtherUsersBooks() {
+        User owner = persistUser("google", "owner2", "주인2");
+        User otherOwner = persistUser("google", "other", "다른주인");
+
+        RecipeBook ownerBook = persistBook(owner, "내 폴더", true, 0);
+        RecipeBook otherBook = persistBook(otherOwner, "남의 폴더", true, 0);
+
+        Recipe publicRecipe = persistRecipe(owner, false);
+        persistItem(ownerBook, publicRecipe);
+        persistItem(otherBook, publicRecipe);
+
+        em.flush();
+        em.clear();
+
+        List<Object[]> rows = itemRepo.countAccessibleByUserIdGroupByBookId(owner.getId());
+
+        assertThat(rows).hasSize(1);
+        assertThat(((Number) rows.get(0)[0]).longValue()).isEqualTo(ownerBook.getId());
+        assertThat(((Number) rows.get(0)[1]).longValue()).isEqualTo(1L);
+    }
+
+    private User persistUser(String provider, String oauthId, String nickname) {
+        User u = User.builder().provider(provider).oauthId(oauthId)
+                .nickname(nickname).role(Role.USER).build();
+        em.persist(u);
+        return u;
+    }
+
+    private RecipeBook persistBook(User user, String name, boolean isDefault, int displayOrder) {
+        RecipeBook b = RecipeBook.builder()
+                .user(user).name(name).isDefault(isDefault).displayOrder(displayOrder).build();
+        em.persist(b);
+        return b;
+    }
+
+    private Recipe persistRecipe(User user, boolean isPrivate) {
+        Recipe r = Recipe.builder()
+                .user(user)
+                .title("t")
+                .dishType(DishType.SOUP_STEW)
+                .lifecycleStatus(RecipeLifecycleStatus.ACTIVE)
+                .visibility(RecipeVisibility.PUBLIC)
+                .listingStatus(RecipeListingStatus.LISTED)
+                .source(RecipeSourceType.YOUTUBE)
+                .isPrivate(isPrivate)
+                .build();
+        em.persist(r);
+        return r;
+    }
+
+    private RecipeBookItem persistItem(RecipeBook book, Recipe recipe) {
+        RecipeBookItem item = RecipeBookItem.builder().book(book).recipe(recipe).build();
+        em.persist(item);
+        return item;
+    }
+}

--- a/src/test/java/com/jdc/recipe_service/repository/RecipeDeleteCascadeTest.java
+++ b/src/test/java/com/jdc/recipe_service/repository/RecipeDeleteCascadeTest.java
@@ -1,0 +1,195 @@
+package com.jdc.recipe_service.repository;
+
+import com.jdc.recipe_service.config.JpaAuditingConfig;
+import com.jdc.recipe_service.config.QuerydslConfig;
+import com.jdc.recipe_service.domain.entity.Recipe;
+import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.entity.media.RecipeYoutubeInfo;
+import com.jdc.recipe_service.domain.entity.recipe.RecipeAccess;
+import com.jdc.recipe_service.domain.repository.RecipeRepository;
+import com.jdc.recipe_service.domain.type.DishType;
+import com.jdc.recipe_service.domain.type.Role;
+import com.jdc.recipe_service.domain.type.recipe.RecipeAccessRole;
+import com.jdc.recipe_service.domain.type.recipe.RecipeLifecycleStatus;
+import com.jdc.recipe_service.domain.type.recipe.RecipeListingStatus;
+import com.jdc.recipe_service.domain.type.recipe.RecipeSourceType;
+import com.jdc.recipe_service.domain.type.recipe.RecipeVisibility;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RecipeService.deleteRecipe는 recipeRepository.deleteByIdDirectly(JPQL bulk delete)에 의존하므로
+ * JPA cascade를 우회하고 오직 DB FK CASCADE에만 기댄다. recipe_youtube_info와 recipe_access는
+ * 과거 NO ACTION FK로 남아 있어 자식 row가 있으면 FK violation으로 삭제가 실패했다.
+ *
+ * V20260417_001 마이그레이션이 두 FK를 ON DELETE CASCADE로 통일했고, 두 entity의 @OnDelete 선언이
+ * 로컬/테스트 환경에서 동일한 schema를 보장한다. 이 테스트는 그 회귀를 고정한다.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Import({QuerydslConfig.class, JpaAuditingConfig.class})
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "app.s3.bucket-name=test-bucket",
+        "cloud.aws.region.static=ap-northeast-2"
+})
+class RecipeDeleteCascadeTest {
+
+    @Container
+    @ServiceConnection
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.33");
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private RecipeRepository recipeRepository;
+
+    @Test
+    @DisplayName("recipe_youtube_info row가 있어도 deleteByIdDirectly는 FK violation 없이 성공한다")
+    void deletesRecipeWithYoutubeInfoRow() {
+        // given
+        User author = persistUser("yt_owner");
+        Recipe recipe = persistRecipe(author, false);
+        persistYoutubeInfo(recipe, "video-abc-123");
+        em.flush();
+        em.clear();
+
+        // when
+        recipeRepository.deleteByIdDirectly(recipe.getId());
+        em.flush();
+        em.clear();
+
+        // then
+        assertThat(countRecipes(recipe.getId())).isZero();
+        assertThat(countYoutubeInfo(recipe.getId()))
+                .as("FK CASCADE로 자식 recipe_youtube_info row도 함께 삭제돼야 한다")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("recipe_access row가 있어도 deleteByIdDirectly는 FK violation 없이 성공한다")
+    void deletesRecipeWithAccessRow() {
+        // given
+        User owner = persistUser("acc_owner");
+        User collaborator = persistUser("acc_viewer");
+        Recipe recipe = persistRecipe(owner, true);
+        persistRecipeAccess(recipe, collaborator, RecipeAccessRole.VIEWER);
+        em.flush();
+        em.clear();
+
+        // when
+        recipeRepository.deleteByIdDirectly(recipe.getId());
+        em.flush();
+        em.clear();
+
+        // then
+        assertThat(countRecipes(recipe.getId())).isZero();
+        assertThat(countRecipeAccess(recipe.getId()))
+                .as("FK CASCADE로 자식 recipe_access row도 함께 삭제돼야 한다")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("youtube_info와 recipe_access를 동시에 가진 레시피도 한 번의 delete로 정리된다")
+    void deletesRecipeWithBothChildRows() {
+        // given
+        User owner = persistUser("combo_owner");
+        User viewer = persistUser("combo_viewer");
+        Recipe recipe = persistRecipe(owner, true);
+        persistYoutubeInfo(recipe, "video-combo-456");
+        persistRecipeAccess(recipe, viewer, RecipeAccessRole.VIEWER);
+        em.flush();
+        em.clear();
+
+        // when
+        recipeRepository.deleteByIdDirectly(recipe.getId());
+        em.flush();
+        em.clear();
+
+        // then
+        assertThat(countRecipes(recipe.getId())).isZero();
+        assertThat(countYoutubeInfo(recipe.getId())).isZero();
+        assertThat(countRecipeAccess(recipe.getId())).isZero();
+    }
+
+    private long countRecipes(Long recipeId) {
+        return (long) em.createQuery(
+                        "SELECT COUNT(r) FROM Recipe r WHERE r.id = :id", Long.class)
+                .setParameter("id", recipeId)
+                .getSingleResult();
+    }
+
+    private long countYoutubeInfo(Long recipeId) {
+        return (long) em.createQuery(
+                        "SELECT COUNT(y) FROM RecipeYoutubeInfo y WHERE y.recipe.id = :id", Long.class)
+                .setParameter("id", recipeId)
+                .getSingleResult();
+    }
+
+    private long countRecipeAccess(Long recipeId) {
+        return (long) em.createQuery(
+                        "SELECT COUNT(a) FROM RecipeAccess a WHERE a.recipe.id = :id", Long.class)
+                .setParameter("id", recipeId)
+                .getSingleResult();
+    }
+
+    private User persistUser(String oauthId) {
+        User u = User.builder()
+                .provider("google")
+                .oauthId(oauthId)
+                .nickname(oauthId)
+                .role(Role.USER)
+                .build();
+        em.persist(u);
+        return u;
+    }
+
+    private Recipe persistRecipe(User user, boolean isPrivate) {
+        Recipe r = Recipe.builder()
+                .user(user)
+                .title("삭제 회귀 테스트용")
+                .dishType(DishType.SOUP_STEW)
+                .lifecycleStatus(RecipeLifecycleStatus.ACTIVE)
+                .visibility(RecipeVisibility.PUBLIC)
+                .listingStatus(RecipeListingStatus.LISTED)
+                .source(RecipeSourceType.YOUTUBE)
+                .isPrivate(isPrivate)
+                .build();
+        em.persist(r);
+        return r;
+    }
+
+    private RecipeYoutubeInfo persistYoutubeInfo(Recipe recipe, String videoId) {
+        RecipeYoutubeInfo info = RecipeYoutubeInfo.builder()
+                .recipe(recipe)
+                .videoId(videoId)
+                .build();
+        em.persist(info);
+        return info;
+    }
+
+    private RecipeAccess persistRecipeAccess(Recipe recipe, User user, RecipeAccessRole role) {
+        RecipeAccess access = RecipeAccess.builder()
+                .recipe(recipe)
+                .user(user)
+                .role(role)
+                .build();
+        em.persist(access);
+        return access;
+    }
+}

--- a/src/test/java/com/jdc/recipe_service/service/RecipeBookServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeBookServiceTest.java
@@ -147,6 +147,66 @@ class RecipeBookServiceTest {
         }
     }
 
+    // ── listBooks ──
+
+    @Nested
+    @DisplayName("listBooks")
+    class ListBooks {
+
+        @Test
+        @DisplayName("응답 recipeCount는 denormalized 컬럼이 아니라 accessible count 쿼리 결과를 따른다")
+        void responseCountComesFromAccessibilityQueryNotStaleColumn() {
+            // drift 재현: 엔티티의 recipeCount(79/99)는 stale이고 실제 접근 가능 건수는 74/5
+            RecipeBook staleDefault = RecipeBook.builder()
+                    .id(defaultBook.getId()).user(user).name("저장한 레시피")
+                    .isDefault(true).displayOrder(0).recipeCount(79).build();
+            RecipeBook customBook = RecipeBook.builder()
+                    .id(20L).user(user).name("한식 모음")
+                    .displayOrder(1).recipeCount(99).build();
+
+            given(bookRepo.findByUserIdAndIsDefaultTrue(user.getId()))
+                    .willReturn(Optional.of(staleDefault));
+            given(bookRepo.findByUserIdOrderByDisplayOrderAsc(user.getId()))
+                    .willReturn(List.of(staleDefault, customBook));
+            given(itemRepo.countAccessibleByUserIdGroupByBookId(user.getId()))
+                    .willReturn(List.of(
+                            new Object[]{staleDefault.getId(), 74L},
+                            new Object[]{customBook.getId(), 5L}
+                    ));
+
+            List<RecipeBookResponse> result = bookService.listBooks(user.getId());
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getRecipeCount())
+                    .as("denormalized 79가 아니라 accessible 74를 돌려줘야 한다")
+                    .isEqualTo(74);
+            assertThat(result.get(1).getRecipeCount())
+                    .as("denormalized 99가 아니라 accessible 5를 돌려줘야 한다")
+                    .isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("배치 쿼리에 나오지 않는 폴더는 stale 컬럼 대신 0을 응답한다")
+        void returnsZeroForBookMissingFromBatchResult() {
+            RecipeBook emptyBook = RecipeBook.builder()
+                    .id(21L).user(user).name("빈 폴더")
+                    .displayOrder(1).recipeCount(10).build();
+
+            given(bookRepo.findByUserIdAndIsDefaultTrue(user.getId()))
+                    .willReturn(Optional.of(defaultBook));
+            given(bookRepo.findByUserIdOrderByDisplayOrderAsc(user.getId()))
+                    .willReturn(List.of(defaultBook, emptyBook));
+            given(itemRepo.countAccessibleByUserIdGroupByBookId(user.getId()))
+                    .willReturn(List.<Object[]>of(new Object[]{defaultBook.getId(), 3L}));
+
+            List<RecipeBookResponse> result = bookService.listBooks(user.getId());
+
+            assertThat(result.get(1).getRecipeCount())
+                    .as("배치 결과에 없는 폴더는 stale 10이 아닌 0이어야 한다")
+                    .isZero();
+        }
+    }
+
     // ── renameBook ──
 
     @Nested
@@ -201,6 +261,27 @@ class RecipeBookServiceTest {
 
             assertThat(result.getName()).isEqualTo("한식 모음");
             then(bookRepo).should(never()).existsByUserIdAndName(any(), any());
+        }
+
+        @Test
+        @DisplayName("이름 변경 성공 시 응답 recipeCount는 accessible count 쿼리 결과를 따른다")
+        void responseCountComesFromAccessibilityQueryAfterRename() {
+            RecipeBook customBook = RecipeBook.builder()
+                    .id(20L).user(user).name("기존 이름").recipeCount(99).build();
+            given(bookRepo.findById(customBook.getId())).willReturn(Optional.of(customBook));
+            given(itemRepo.countAccessibleByBookIdAndUserId(customBook.getId(), user.getId()))
+                    .willReturn(7);
+
+            RenameRecipeBookRequest request = RenameRecipeBookRequest.builder()
+                    .name("한식 모음")
+                    .build();
+
+            RecipeBookResponse result = bookService.renameBook(user.getId(), customBook.getId(), request);
+
+            assertThat(result.getName()).isEqualTo("한식 모음");
+            assertThat(result.getRecipeCount())
+                    .as("denormalized 99가 아니라 accessible 7을 돌려줘야 한다")
+                    .isEqualTo(7);
         }
 
         @Test
@@ -506,6 +587,36 @@ class RecipeBookServiceTest {
                     .isInstanceOf(CustomException.class)
                     .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_INPUT_VALUE));
+        }
+
+        @Test
+        @DisplayName("순서 변경 성공 시 응답 recipeCount는 accessible count 쿼리 결과를 따른다")
+        void responseCountComesFromAccessibilityQueryAfterReorder() {
+            RecipeBook book2 = RecipeBook.builder()
+                    .id(20L).user(user).name("폴더2")
+                    .displayOrder(1).recipeCount(99).build();
+            given(bookRepo.findByUserIdOrderByDisplayOrderAsc(user.getId()))
+                    .willReturn(List.of(defaultBook, book2));
+            given(itemRepo.countAccessibleByUserIdGroupByBookId(user.getId()))
+                    .willReturn(List.of(
+                            new Object[]{defaultBook.getId(), 4L},
+                            new Object[]{book2.getId(), 2L}
+                    ));
+
+            ReorderRecipeBooksRequest request = ReorderRecipeBooksRequest.builder()
+                    .bookIds(List.of(book2.getId(), defaultBook.getId()))
+                    .build();
+
+            List<RecipeBookResponse> result = bookService.reorderBooks(user.getId(), request);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getId())
+                    .as("reorder 후 displayOrder=0이 된 book2가 먼저 와야 한다")
+                    .isEqualTo(book2.getId());
+            assertThat(result.get(0).getRecipeCount())
+                    .as("denormalized 99가 아니라 accessible 2를 돌려줘야 한다")
+                    .isEqualTo(2);
+            assertThat(result.get(1).getRecipeCount()).isEqualTo(4);
         }
 
         @Test


### PR DESCRIPTION
  ## 해결하려는 문제가 무엇인가요?
  1. `RecipeBookResponse.recipeCount`가 `recipe_books.recipe_count` 컬럼 값을 그대로 내려주고 있어, 타인이 비공개로
  전환한 레시피까지 카운트에 포함되어 실제 사용자가 보는 목록 길이와 어긋났다.
  2. `RecipeService.deleteRecipe`(JPQL bulk delete) 경로가 `recipe_youtube_info`, `recipe_access` FK가 `NO ACTION`이라
  해당 row가 있을 때 FK violation으로 실패했다. 다른 12개 자식 테이블은 이미 `ON DELETE CASCADE`였다.

  ## 어떻게 해결했나요?
  - **AS-IS:**
    - RecipeBook 카운트는 `RecipeBook.recipeCount` 컬럼 값을 그대로 직렬화. 비공개 전환 시 stale.
    - `recipe_youtube_info`, `recipe_access`의 recipe FK는 `NO ACTION` → bulk delete 시 FK violation.
  - **TO-BE:**
    - 폴더 목록/생성/수정/순서 변경 응답을 모두 query-time 집계(`countAccessibleByUserIdGroupByBookId`)로 통일. 가시성
  조건은 `r.isPrivate = false OR r.user.id = :userId`.
    - `RecipeYoutubeInfo`, `RecipeAccess`에 `@OnDelete(CASCADE)` 추가하고, 동일 정책을 Flyway로 운영 DB에 반영.
  - 리뷰어가 먼저 봐야 할 파일:
    - `service/RecipeBookService.java` — `loadAccessibleCounts` 도입과 호출 지점
    - `repository/RecipeBookItemRepository.java` — 새 GROUP BY 쿼리
    - `resources/db/migration/V20260417_001__cascade_recipe_fk_for_youtube_info_and_access.sql`

  ## Test plan
  - 추가 테스트
    - `RecipeBookItemAccessibleCountTest` — 비공개·본인·타인 레시피 조합에서 GROUP BY 카운트가 기대값과 일치하는지 검증.
    - `RecipeBookServiceTest` — 폴더 목록/생성/수정/순서 변경 응답의 `recipeCount` 의미를 service 레벨에서 고정.
    - `RecipeDeleteCascadeTest` — `recipe_youtube_info`, `recipe_access` row가 있을 때 `deleteRecipe`가 FK violation
  없이 자식 row까지 정리되는지 검증.
  - `./gradlew test`로 그린 확인.

  ## Rollout / DB / API impact
  - **DB**
    - Flyway: `V20260417_001__cascade_recipe_fk_for_youtube_info_and_access.sql`
    - `recipe_youtube_info`, `recipe_access`의 `recipe_id` FK를 `DROP FOREIGN KEY` + `ADD CONSTRAINT ... ON DELETE
  CASCADE`로 재선언.
    - MySQL에서 metadata lock이 발생하므로 트래픽이 낮은 시점에 적용 권장. 적용 직전에 long-running transaction 부재
  확인(`information_schema.innodb_trx`, `SHOW PROCESSLIST`). 운영 메모는 마이그레이션 파일 상단 주석에 포함.
    - 구버전 앱 호환성: parent(`recipes`) row가 살아 있는 동안 child 동작 동일. 변경되는 시점은 오직 `recipes` row 삭제
  시점이며, "FK violation으로 거부 → child 자동 삭제"로 더 관대해지는 방향이라 회귀 위험 없음.
  - **API**
    - `RecipeBookResponse.recipeCount`, `RecipeBookDetailResponse.recipeCount`의 필드 이름·타입은 그대로지만 의미가 "총
  포함 수" → "현재 사용자가 볼 수 있는 수"로 변경. 프론트가 이 값을 그대로 노출한다면 자연스럽게 화면 목록과 일치.
  `@Schema` description도 함께 갱신함.
    - 새 엔드포인트, 시그니처 변경, 인증 정책 변경 없음.
  - 스케줄러/feature flag/환경변수 변경: 해당 없음.

  ## Risks and rollback
  - **마이그레이션 롤백**: Flyway down은 사용하지 않는 정책이므로, 문제 발생 시 두 FK를 다시 `NO ACTION`으로 복원하는
  후속 마이그레이션을 작성해 roll-forward한다. 지금까지 `deleteRecipe`가 FK violation으로 막혀 있었기 때문에 child row
  없이 parent만 삭제된 케이스가 발생할 수 없었어서 사전 데이터 백업이 필요한 변경은 아님.
  - **카운트 변경 영향**: 일부 사용자에게 표시되는 카운트가 줄어들 수 있음. 의도된 변경이며 실제 보이는 목록과
  일치시키는 방향.
  - **쿼리 추가 비용**: `listBooks`/`reorderBooks`에서 사용자 단위 GROUP BY 쿼리 1회 추가. 폴더 수가 사용자당 한정되어
  있어 영향은 무시 가능 수준.

  ## Related
  - 관련 skill: `db-migration`, `api-contract-docs`
  - 변경 영역: RecipeBook 카운트 집계, Recipe 삭제 시 FK cascade