### PR TITLE
  feat(auth): Android WebView 쿠키 flush 누락 복구용 refresh 토큰 grace 회전 추가

### DIFF
--- a/docs/runbook/refresh-grace-rotation.md
+++ b/docs/runbook/refresh-grace-rotation.md
@@ -1,0 +1,174 @@
+# Refresh Grace Rotation — 배포 Runbook
+
+이 문서는 Android WebView CookieManager flush 누락을 메우기 위한 DB grace 기반 refresh 회전
+변경의 **배포 순서, precheck, 롤백, 모니터링**을 정리한다. 관련 변경 범위:
+
+- `V20260418_001__add_unique_index_refresh_tokens_token.sql`
+- `V20260418_002__add_grace_columns_refresh_tokens.sql`
+- `AuthService#refresh` + `RefreshTokenRepository#findByTokenForUpdate` / `findByPreviousTokenInGraceForUpdate`
+- `GlobalExceptionHandler#handleConcurrencyFailure` (refresh 경로 한정)
+- 메트릭: `auth_refresh_total{result}`
+
+---
+
+## 1. 배포 전 precheck (필수)
+
+### 1-1. refresh_tokens.token 중복 검사
+
+V20260418_001이 UNIQUE 제약을 추가하므로, 이미 중복된 token 값이 존재하면 Flyway가 실패한다.
+운영 MySQL에서 아래 쿼리를 반드시 먼저 실행한다.
+
+```sql
+SELECT token, COUNT(*) AS c
+FROM refresh_tokens
+GROUP BY token
+HAVING c > 1;
+```
+
+**기대 결과: 0 rows.**
+
+### 1-2. 중복이 발견되었을 때
+
+마이그레이션을 건드리지 않고, 운영 SQL로 정리한 뒤 다시 1-1을 0 rows로 만든다. 각 중복 그룹에서
+`expired_at`이 가장 크고(동률이면 id가 가장 큰) row 1개만 남기고 나머지는 삭제한다. `MAX(expired_at)`
+기준 JOIN은 같은 만료시각을 공유하는 행이 여러 개일 때 여러 행을 남겨 UNIQUE 추가를 다시 막는다.
+MySQL 8의 ROW_NUMBER()로 그룹당 정확히 1행만 남기게 한다.
+
+```sql
+-- 1) 유지할 row들의 id 집합 (그룹별로 expired_at DESC, id DESC 기준 정확히 1행)
+CREATE TEMPORARY TABLE rt_keep AS
+SELECT id
+FROM (
+    SELECT id,
+           token,
+           ROW_NUMBER() OVER (
+               PARTITION BY token
+               ORDER BY expired_at DESC, id DESC
+           ) AS rn
+    FROM refresh_tokens
+) ranked
+WHERE ranked.rn = 1;
+
+-- 2) 중복 그룹(>= 2행)에서 keep 집합 외 row 삭제
+DELETE rt
+FROM refresh_tokens rt
+JOIN (
+    SELECT token
+    FROM refresh_tokens
+    GROUP BY token
+    HAVING COUNT(*) > 1
+) g ON g.token = rt.token
+WHERE rt.id NOT IN (SELECT id FROM rt_keep);
+
+-- 3) 정리
+DROP TEMPORARY TABLE rt_keep;
+
+-- 4) 재확인: 0 rows여야 한다
+SELECT token, COUNT(*) AS c
+FROM refresh_tokens
+GROUP BY token
+HAVING c > 1;
+```
+
+> 정리 과정에서 일부 세션이 로그아웃될 수 있다. 이 side effect를 **스키마 변경 히스토리에
+> 묻지 말고** 별도 운영 작업으로 기록한다.
+
+### 1-3. long-running tx 확인
+
+ALTER TABLE은 metadata lock을 잡는다. 트래픽이 낮은 시간대에 적용하고, 적용 직전 실행 중인
+장시간 트랜잭션이 없는지 확인한다.
+
+```sql
+SELECT * FROM information_schema.innodb_trx ORDER BY trx_started ASC LIMIT 5;
+SHOW PROCESSLIST;
+```
+
+---
+
+## 2. 배포 순서
+
+1. **DB**: Flyway가 V20260418_001 → V20260418_002 순으로 적용한다. (app 시작 전 또는 CI에서)
+   - 001: UNIQUE 인덱스 추가. precheck가 통과했으면 실패하지 않는다.
+   - 002: previous_token, previous_token_grace_until 컬럼 + idx_rt_prev_token 추가. nullable이므로
+     기존 row 영향 없음.
+2. **App**: 새 AuthService/Controller/Handler가 포함된 JAR 배포.
+   - 구 버전 app + 새 스키마 조합도 호환된다(기존 쿼리는 새 컬럼을 쓰지 않음).
+   - 새 app은 새 컬럼을 읽고 쓰지만, row에 NULL이 들어 있어도 2단계 lookup 모두 cleanly fallthrough.
+3. **Monitor**: 아래 §4 대시보드 주시.
+
+---
+
+## 3. 롤백 계획
+
+### 3-1. 앱 롤백
+
+새 버전 app에 문제가 있으면 **구 버전 app으로 즉시 롤백 가능**하다. 새 컬럼은 구 app이
+무시하므로 호환성이 유지된다. 스키마를 되돌릴 필요 없다.
+
+### 3-2. 스키마 롤백 (극단적인 경우에만)
+
+`previous_token` / `previous_token_grace_until` 컬럼은 additive라 drop해도 데이터 손실은 없다.
+UNIQUE 인덱스(uk_rt_token)는 일단 걸리고 나면 중복 insert가 실패하게 되므로, 구 app에서
+"동일 token 덮어쓰기" 경로가 있다면 영향을 받을 수 있다. 단 현재 코드에는 그런 경로가 없다.
+
+```sql
+-- 필요 시 (역순으로)
+ALTER TABLE refresh_tokens
+    DROP INDEX idx_rt_prev_token,
+    DROP COLUMN previous_token_grace_until,
+    DROP COLUMN previous_token;
+
+ALTER TABLE refresh_tokens
+    DROP INDEX uk_rt_token;
+```
+
+Flyway 히스토리와 어긋나므로 스키마 롤백 시 `flyway_schema_history`에서 해당 row를 함께 정리한다.
+
+---
+
+## 4. 모니터링 (배포 후 24시간 집중)
+
+### 4-1. 주요 메트릭
+
+`auth_refresh_total{result=...}` counter에 다음 result 태그가 올라온다.
+
+| result | 의미 | 기대 비율 |
+|---|---|---|
+| `rotated` | 정상 회전 (현재 토큰 매치) | 대부분 (> 95%) |
+| `grace_replay` | grace 윈도우 재전송 (주로 Android) | 소수 (< 5%, 플랫폼 비중 따름) |
+| `invalid` | JWT 유효하지만 DB 어디에도 없음 | 아주 드묾 |
+| `expired` | DB row expired_at 초과 | 드묾 |
+| `jwt_invalid` | JWT 서명/형식 오류 | 매우 드묾 |
+| `jwt_expired` | JWT 만료 | 간헐적 |
+| `lock_timeout` | innodb_lock_wait_timeout 만료 | 0에 가까워야 함 |
+
+### 4-2. 경보 기준 (후속 제안)
+
+- `rate(auth_refresh_total{result="lock_timeout"}[5m]) > 0.1 /s` → 지속되면 문의
+- `rate(auth_refresh_total{result="invalid"}[5m])`가 갑자기 상승 → 쿠키 유실 폭증 가능
+- `rate(auth_refresh_total{result="grace_replay"}[1h])` 일평균 대비 2배 급등 → 앱 재시도 로직
+  또는 배포 이슈 의심
+
+### 4-3. Android 증상 회복 확인
+
+변경의 원래 목표는 **Android 간헐 force-logout 감소**다. 아래 지표를 함께 본다.
+
+- 프론트 `REFRESH_TOKEN_EXPIRED` force-logout 이벤트 (프론트 텔레메트리)
+- User-Agent 기준 Android 비중이 높은 실패가 줄었는지
+- 같은 userId가 짧은 시간 내 재로그인하는 패턴 감소
+
+---
+
+## 5. 관련 테스트
+
+- `AuthServiceTest` — 단위 테스트 (Mockito, SimpleMeterRegistry). rotated / grace_replay /
+  jwt_invalid / jwt_expired / expired / invalid / replay_suspected 각 카운터 경로 검증
+- `GlobalExceptionHandlerTest` — 단위 테스트 (Mockito). refresh 경로 한정으로
+  `ConcurrencyFailureException`을 INVALID_REFRESH_TOKEN으로 매핑하고 `lock_timeout` 카운터를 올리는지,
+  비 refresh 경로에서는 원 예외가 rethrow되는지 검증
+- `RefreshTokenRepositoryTest` — @DataJpaTest + H2. 쿼리 shape 고정 (MySQL 고유 기능을 쓰지 않으므로
+  testing rule 기본값인 H2로 빠르게 돈다). `existsByPreviousToken`, `findAllByTokenOrPreviousToken`도 포함
+- `RefreshTokenConcurrencyIT` — @SpringBootTest + Testcontainers(MySQL), `@Tag("concurrency")`.
+  InnoDB row-lock + UNIQUE 동작에 의존하는 시나리오라 Testcontainers가 필요하다. 기본 CI에서는
+  태그로 제외하고 별도 잡에서 돌리는 것을 권장. 동시 refresh 2개에 대해 ROTATED 1 + GRACE_REPLAY 1
+  불변성 검증

--- a/src/main/java/com/jdc/recipe_service/controller/AuthController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.jdc.recipe_service.controller;
 
 import com.jdc.recipe_service.domain.dto.TokenResponseDTO;
+import com.jdc.recipe_service.domain.dto.auth.RefreshResult;
 import com.jdc.recipe_service.domain.entity.RefreshToken;
 import com.jdc.recipe_service.domain.entity.User;
 import com.jdc.recipe_service.domain.repository.RefreshTokenRepository;
@@ -9,7 +10,7 @@ import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.exception.ErrorResponse;
 import com.jdc.recipe_service.jwt.JwtTokenProvider;
-import io.jsonwebtoken.JwtException;
+import com.jdc.recipe_service.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
@@ -31,6 +32,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @RestController
@@ -43,6 +45,7 @@ public class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
+    private final AuthService authService;
 
     @PostMapping("/refresh")
     @Operation(
@@ -74,52 +77,35 @@ public class AuthController {
             throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        try {
-            jwtTokenProvider.validateToken(refreshToken);
-        } catch (JwtException e) {
-            boolean expired = e.getMessage() != null && e.getMessage().contains("만료");
-            ErrorCode errorCode = expired ? ErrorCode.REFRESH_TOKEN_EXPIRED : ErrorCode.INVALID_REFRESH_TOKEN;
-            String reason = expired ? "jwt_expired" : "jwt_invalid";
+        RefreshResult result = authService.refresh(refreshToken);
 
-            log.warn("[AUTH_REFRESH] result=fail reason={} refreshFp={} origin={} userAgent={} message={}",
-                    reason, refreshFp, origin, userAgent, e.getMessage());
-            throw new CustomException(errorCode, e.getMessage());
-        }
+        log.info("[AUTH_REFRESH] result=success path={} userId={} oldRefreshFp={} newRefreshFp={} refreshExpiredAt={} origin={} userAgent={}",
+                result.getPath(), result.getUserId(), refreshFp,
+                fingerprint(result.getRefreshToken()), result.getRefreshExpiredAt(), origin, userAgent);
 
-        RefreshToken savedToken = refreshTokenRepository.findByToken(refreshToken)
-                .orElseThrow(() -> {
-                    log.warn("[AUTH_REFRESH] result=fail reason=db_not_found refreshFp={} origin={} userAgent={}",
-                            refreshFp, origin, userAgent);
-                    return new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
-                });
+        writeAuthCookies(response, result, request);
 
-        if (savedToken.getExpiredAt().isBefore(LocalDateTime.now())) {
-            log.warn("[AUTH_REFRESH] result=fail reason=db_expired userId={} refreshFp={} dbExpiredAt={} origin={} userAgent={}",
-                    savedToken.getUser().getId(), refreshFp, savedToken.getExpiredAt(), origin, userAgent);
-            throw new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED);
-        }
+        return ResponseEntity.ok(new TokenResponseDTO(result.getAccessToken(), null));
+    }
 
-        User user = savedToken.getUser();
-        String newAccessToken = jwtTokenProvider.createAccessToken(user);
-        String newRefreshToken = jwtTokenProvider.createRefreshToken();
-        LocalDateTime newRefreshExpiry = LocalDateTime.now().plusDays(7);
-
-        savedToken.setToken(newRefreshToken);
-        savedToken.setExpiredAt(newRefreshExpiry);
-        refreshTokenRepository.save(savedToken);
-
+    // refresh/access 쿠키를 한 세트로 내려준다. refresh maxAge는 DB가 들고 있는 실제 만료 시각
+    // 기준으로 계산해 서버/클라이언트 TTL이 어긋나지 않게 한다. grace_replay 경로에서도 기존
+    // refresh가 그대로 재전송되므로 max-age 역시 기존 만료 기준으로 음수가 아닌 남은 시간을 준다.
+    private void writeAuthCookies(HttpServletResponse response, RefreshResult result, HttpServletRequest request) {
+        String origin = request.getHeader("Origin");
         boolean isLocalRequest = origin != null && origin.startsWith("http://localhost");
 
-        log.info("[AUTH_REFRESH] result=success userId={} oldRefreshFp={} newRefreshFp={} newExpiredAt={} origin={} userAgent={}",
-                user.getId(), refreshFp, fingerprint(newRefreshToken), newRefreshExpiry, origin, userAgent);
+        long refreshMaxAgeSeconds = Math.max(
+                Duration.between(LocalDateTime.now(), result.getRefreshExpiredAt()).getSeconds(),
+                0L
+        );
 
-
-        var refreshBuilder = ResponseCookie.from("refreshToken", newRefreshToken)
+        var refreshBuilder = ResponseCookie.from("refreshToken", result.getRefreshToken())
                 .path("/")
                 .httpOnly(true)
-                .maxAge(7 * 24 * 60 * 60)
+                .maxAge(refreshMaxAgeSeconds)
                 .sameSite("Lax");
-        var accessBuilder  = ResponseCookie.from("accessToken", newAccessToken)
+        var accessBuilder = ResponseCookie.from("accessToken", result.getAccessToken())
                 .path("/")
                 .httpOnly(true)
                 .maxAge(15 * 60)
@@ -131,9 +117,7 @@ public class AuthController {
         }
 
         response.addHeader(HttpHeaders.SET_COOKIE, refreshBuilder.build().toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, accessBuilder .build().toString());
-
-        return ResponseEntity.ok(new TokenResponseDTO(newAccessToken, null));
+        response.addHeader(HttpHeaders.SET_COOKIE, accessBuilder.build().toString());
     }
 
     @PostMapping("/logout")
@@ -147,8 +131,13 @@ public class AuthController {
             HttpServletResponse response) {
 
         if (refreshToken != null) {
-            refreshTokenRepository.findByToken(refreshToken)
-                    .ifPresent(refreshTokenRepository::delete);
+            // 클라이언트가 회전 직전의 옛 토큰을 들고 logout을 눌러도(Android WebView flush 지연 등)
+            // 서버의 current row가 살아 남아 "로그아웃했는데 세션이 살아있는" 상태가 되지 않도록,
+            // token/previous_token 양쪽을 같이 매칭해서 revoke한다.
+            var rows = refreshTokenRepository.findAllByTokenOrPreviousToken(refreshToken);
+            if (!rows.isEmpty()) {
+                refreshTokenRepository.deleteAll(rows);
+            }
         }
 
         ResponseCookie deleteRefresh = createDeleteCookie("refreshToken", request);

--- a/src/main/java/com/jdc/recipe_service/domain/dto/auth/RefreshResult.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/auth/RefreshResult.java
@@ -1,0 +1,32 @@
+package com.jdc.recipe_service.domain.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * refresh 회전 결과. 컨트롤러가 쿠키 maxAge, 로그 태그, 메트릭을 구성할 수 있게
+ * accessToken/refreshToken과 함께 refresh 만료 시각, 어떤 경로(rotated | grace_replay)
+ * 로 생성되었는지를 함께 전달한다.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class RefreshResult {
+
+    public enum Path {
+        // 정상 회전: 받은 토큰이 현재 유효 토큰이라 새 refresh를 발급함.
+        ROTATED,
+        // grace 재전송: Android CookieManager flush 누락 등으로 옛 토큰을 받았으나
+        // grace 윈도우 안이라 기존 현재 토큰(+새 access)을 그대로 내려줌.
+        GRACE_REPLAY
+    }
+
+    private final Long userId;
+    private final String accessToken;
+    private final String refreshToken;
+    private final LocalDateTime refreshExpiredAt;
+    private final Path path;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/entity/RefreshToken.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/RefreshToken.java
@@ -10,7 +10,11 @@ import java.time.LocalDateTime;
 @Table(
         name = "refresh_tokens",
         indexes = {
-                @Index(name = "idx_rt_user_created", columnList = "user_id, created_at")
+                @Index(name = "idx_rt_user_created", columnList = "user_id, created_at"),
+                // 아래 두 인덱스는 Flyway(V20260418_001, V20260418_002)에서 실제로 생성된다.
+                // 여기 @Index 선언은 엔티티-스키마 일치를 드러내기 위한 문서용이며 DDL은 Flyway가 소유한다.
+                @Index(name = "uk_rt_token", columnList = "token", unique = true),
+                @Index(name = "idx_rt_prev_token", columnList = "previous_token")
         }
 )
 @Getter
@@ -33,5 +37,15 @@ public class RefreshToken extends BaseTimeEntity {
 
     @Column(name = "expired_at", nullable = false)
     private LocalDateTime expiredAt;
-//createdat은 BaseTimeEntity에 상속됨
+
+    // 직전 회전에서 이 row가 들고 있던 token 값. Android WebView CookieManager가
+    // 새 refresh 쿠키를 디스크에 flush하기 전에 앱이 죽는 창을 메우기 위한 "유예 토큰"이다.
+    // grace 윈도우 안에 들어온 옛 토큰을 현재 토큰과 동등 처리하는 lookup 키로 쓴다.
+    @Column(name = "previous_token", length = 255)
+    private String previousToken;
+
+    // previousToken이 유효한 마지막 시각. 이 시점이 지나면 옛 토큰은 invalid로 취급한다.
+    @Column(name = "previous_token_grace_until")
+    private LocalDateTime previousTokenGraceUntil;
+    //createdat은 BaseTimeEntity에 상속됨
 }

--- a/src/main/java/com/jdc/recipe_service/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/RefreshTokenRepository.java
@@ -2,7 +2,9 @@ package com.jdc.recipe_service.domain.repository;
 
 import com.jdc.recipe_service.domain.entity.RefreshToken;
 import com.jdc.recipe_service.domain.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,6 +19,46 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByUser(User user);
 
     List<RefreshToken> findByUserOrderByCreatedAtAsc(User user);
+
+    // 회전 이력 관찰용. 현재/grace lookup이 모두 miss된 뒤에 "grace 윈도우가 지난 옛 토큰의 재전송"인지
+    // "한 번도 발급된 적 없는 토큰"인지 구분한다. 메트릭 태그(result=replay_suspected vs invalid)만
+    // 분리하는 용도라 X-lock은 걸지 않는다.
+    boolean existsByPreviousToken(String previousToken);
+
+    // logout 경로 전용. 클라이언트가 회전 직전의 옛 refresh를 들고 logout을 눌러도 서버쪽 row가
+    // 남아 "로그아웃했는데 세션이 살아있는" 상태가 되지 않도록, token/previous_token 양쪽을 같이 본다.
+    // grace_until 만료는 보지 않는다: 로그아웃은 어차피 revoke가 목적이므로 previous_token으로만 매칭되는
+    // 상황도 같이 지워주는 편이 안전하다. List 반환 이유: previous_token에는 UNIQUE 제약이 없어
+    // 이론상 2개 row가 match될 수 있고, 그 경우 Optional 단건 조회는 NonUniqueResultException로 logout을
+    // 깬다. logout 의도상 해당되는 row는 모두 revoke하는 게 자연스럽다.
+    @Query("""
+            select rt from RefreshToken rt
+            where rt.token = :token
+               or rt.previousToken = :token
+            """)
+    List<RefreshToken> findAllByTokenOrPreviousToken(@Param("token") String token);
+
+    // refresh 회전 전용 lookup. 반드시 @Transactional 안에서만 호출한다.
+    // UNIQUE 인덱스(uk_rt_token) 위에서 동작하므로 row-level X-lock만 잡고,
+    // next-key lock이 인접 키로 번지지 않는다.
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select rt from RefreshToken rt where rt.token = :token")
+    Optional<RefreshToken> findByTokenForUpdate(@Param("token") String token);
+
+    // grace 윈도우 안의 옛 토큰을 "현재 row"로 끌어오는 lookup. previous_token은 평문 INDEX(idx_rt_prev_token)라
+    // 같은 previous_token을 들고 있는 row가 드물게 둘 이상일 수도 있으므로, 호출자는 Optional 0/1 row 가정을 쓰되
+    // 서비스 레이어에서 grace_until 유효성을 한 번 더 확인한다(읽기와 쓰기 사이 만료 대비).
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select rt from RefreshToken rt
+            where rt.previousToken = :token
+              and rt.previousTokenGraceUntil is not null
+              and rt.previousTokenGraceUntil > :now
+            """)
+    Optional<RefreshToken> findByPreviousTokenInGraceForUpdate(
+            @Param("token") String token,
+            @Param("now") LocalDateTime now
+    );
 
     @Modifying
     @Query("delete from RefreshToken t where t.user.id = :userId")

--- a/src/main/java/com/jdc/recipe_service/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/jdc/recipe_service/handler/GlobalExceptionHandler.java
@@ -4,10 +4,13 @@ import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.exception.ErrorResponse;
 import com.jdc.recipe_service.service.DailyQuotaService;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -27,10 +30,13 @@ import java.util.concurrent.RejectedExecutionException;
 @RestControllerAdvice(annotations = {RestController.class})
 @Hidden
 @Slf4j
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
     @Value("${spring.profiles.active:default}")
     private String activeProfile;
+
+    private final MeterRegistry meterRegistry;
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex, HttpServletRequest request) {
@@ -124,6 +130,31 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(ErrorCode.NULL_POINTER.getCode(), msg));
+    }
+
+    // refresh 회전은 row-level pessimistic lock을 잡기 때문에 innodb_lock_wait_timeout 만료 시
+    // Spring이 ConcurrencyFailureException 계열(PessimisticLockingFailureException,
+    // CannotAcquireLockException, DeadlockLoserDataAccessException 등)을 올려준다.
+    // 이 상황은 프론트가 한 번 더 refresh를 시도하면 복구되는 성격이라, 500(catch-all)로
+    // 빠지지 않도록 여기서 401 계열 "유효하지 않은 토큰"으로 매핑해 force-logout까지
+    // 이어지지 않게 한다. 단, refresh 경로가 아닌 다른 도메인(댓글 좋아요 등)에서 같은
+    // 예외가 나면 의미가 다르므로 원 예외를 다시 던져 catch-all로 돌려보낸다.
+    @ExceptionHandler(ConcurrencyFailureException.class)
+    public ResponseEntity<ErrorResponse> handleConcurrencyFailure(ConcurrencyFailureException ex,
+                                                                  HttpServletRequest request) {
+        if (!isRefreshRequest(request)) {
+            throw ex;
+        }
+
+        ErrorCode errorCode = ErrorCode.INVALID_REFRESH_TOKEN;
+        log.warn("[AUTH_REFRESH] result=fail reason=lock_timeout exceptionType={} message={}",
+                ex.getClass().getSimpleName(), ex.getMessage());
+
+        meterRegistry.counter("auth_refresh_total", "result", "lock_timeout").increment();
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ErrorResponse(errorCode.getCode(), errorCode.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/jdc/recipe_service/service/AuthService.java
+++ b/src/main/java/com/jdc/recipe_service/service/AuthService.java
@@ -4,10 +4,15 @@ import com.jdc.recipe_service.domain.entity.RefreshToken;
 import com.jdc.recipe_service.domain.entity.User;
 import com.jdc.recipe_service.domain.repository.RefreshTokenRepository;
 import com.jdc.recipe_service.domain.dto.auth.AuthTokens;
+import com.jdc.recipe_service.domain.dto.auth.RefreshResult;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.jwt.JwtTokenProvider;
 import com.jdc.recipe_service.security.oauth.AppleClientSecretGenerator;
 import com.jdc.recipe_service.security.oauth.CustomOAuth2User;
 import com.jdc.recipe_service.security.oauth.CustomOAuth2UserService;
+import io.jsonwebtoken.JwtException;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
@@ -21,7 +26,9 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Slf4j
@@ -29,12 +36,141 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class AuthService {
 
+    // Android WebView CookieManager가 새 refresh 쿠키를 디스크에 flush하기 전에 앱이
+    // 백그라운드로 가거나 죽었을 때를 메우기 위한 유예 시간. 사람이 "한 번 더 탭"하는 동안
+    // 옛 토큰이 재전송되어도 로그아웃되지 않게 해준다. 너무 길면 토큰 재전송 공격 창이 커지고,
+    // 너무 짧으면 재시도 여유가 없어 원래 문제로 돌아간다.
+    private static final Duration REFRESH_GRACE_WINDOW = Duration.ofSeconds(30);
+
     private final ClientRegistrationRepository clientRegistrationRepository;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient;
     private final AppleClientSecretGenerator appleClientSecretGenerator;
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * refresh 토큰 회전. Android WebView CookieManager flush 누락으로 옛 토큰이 재전송되는
+     * 케이스를 살려주기 위해 previous_token grace 윈도우를 두고, 동시 회전을 위해
+     * 두 단계 lookup을 모두 PESSIMISTIC_WRITE로 잡는다.
+     *
+     * <p>호출 전제:
+     * <ul>
+     *   <li>컨트롤러가 쿠키 존재 여부만 확인하고 원본 token 문자열을 넘긴다.</li>
+     *   <li>본 메서드는 @Transactional이므로 두 lookup이 같은 read view에 속하지 않고,
+     *       row-level X-lock이 commit 시점까지 유지된다.</li>
+     * </ul>
+     *
+     * <p>실패 매핑:
+     * <ul>
+     *   <li>JWT 서명/형식 오류 → {@link ErrorCode#INVALID_REFRESH_TOKEN}</li>
+     *   <li>JWT 만료 → {@link ErrorCode#REFRESH_TOKEN_EXPIRED}</li>
+     *   <li>DB에서 현재/grace 어디에도 없음 → {@link ErrorCode#INVALID_REFRESH_TOKEN}</li>
+     *   <li>DB row 만료 → {@link ErrorCode#REFRESH_TOKEN_EXPIRED}</li>
+     * </ul>
+     */
+    @Transactional
+    public RefreshResult refresh(String oldToken) {
+        validateJwtOrThrow(oldToken);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // 1단계: 현재 유효 토큰으로 조회. UNIQUE 인덱스(uk_rt_token) 위에서 정확히 0/1 row.
+        var currentRow = refreshTokenRepository.findByTokenForUpdate(oldToken);
+        if (currentRow.isPresent()) {
+            RefreshToken row = currentRow.get();
+            if (isExpired(row, now)) {
+                incrementRefresh("expired");
+                throw new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+            }
+            return rotate(row, oldToken, now);
+        }
+
+        // 2단계: grace 윈도우 안의 옛 토큰으로 조회.
+        // 플로우상 "최근에 T1→T2로 회전된 row"가 여기서 잡힌다.
+        var graceRow = refreshTokenRepository.findByPreviousTokenInGraceForUpdate(oldToken, now);
+        if (graceRow.isPresent()) {
+            RefreshToken row = graceRow.get();
+            if (isExpired(row, now)) {
+                incrementRefresh("expired");
+                throw new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+            }
+            return graceReplay(row);
+        }
+
+        // 3단계: 두 lookup 모두 miss. 이 토큰이 "grace가 만료된 옛 refresh의 재전송"인지
+        // "한 번도 발급된 적 없는 토큰"인지 관찰용으로 구분한다. previous_token에 X-lock을 걸
+        // 필요는 없고, UNIQUE가 아닌 INDEX 위의 단순 exists 쿼리다. 프론트 응답은 동일하게
+        // INVALID_REFRESH_TOKEN로 유지하여 사용자 경험/계약은 바꾸지 않는다.
+        boolean graceExpiredReplay = refreshTokenRepository.existsByPreviousToken(oldToken);
+        incrementRefresh(graceExpiredReplay ? "replay_suspected" : "invalid");
+        throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    private void validateJwtOrThrow(String token) {
+        try {
+            jwtTokenProvider.validateToken(token);
+        } catch (JwtException e) {
+            boolean expired = e.getMessage() != null && e.getMessage().contains("만료");
+            if (expired) {
+                incrementRefresh("jwt_expired");
+                throw new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED, e.getMessage());
+            }
+            incrementRefresh("jwt_invalid");
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN, e.getMessage());
+        }
+    }
+
+    private boolean isExpired(RefreshToken row, LocalDateTime now) {
+        return row.getExpiredAt() != null && row.getExpiredAt().isBefore(now);
+    }
+
+    // 정상 회전: 새 access/refresh를 발급하고 옛 토큰을 previous_token으로 접어넣는다.
+    // 엔티티는 @Transactional 변경감지로 flush되므로 save() 호출은 하지 않는다.
+    private RefreshResult rotate(RefreshToken row, String oldToken, LocalDateTime now) {
+        User user = row.getUser();
+
+        String newAccess = jwtTokenProvider.createAccessToken(user);
+        String newRefresh = jwtTokenProvider.createRefreshToken();
+        LocalDateTime newExpiry = jwtTokenProvider.getRefreshTokenExpiryAsLocalDateTime();
+
+        row.setPreviousToken(oldToken);
+        row.setPreviousTokenGraceUntil(now.plus(REFRESH_GRACE_WINDOW));
+        row.setToken(newRefresh);
+        row.setExpiredAt(newExpiry);
+
+        incrementRefresh("rotated");
+
+        return RefreshResult.builder()
+                .userId(user.getId())
+                .accessToken(newAccess)
+                .refreshToken(newRefresh)
+                .refreshExpiredAt(newExpiry)
+                .path(RefreshResult.Path.ROTATED)
+                .build();
+    }
+
+    // grace 재전송: 회전은 하지 않는다. 이미 발급된 current 토큰을 그대로 재송신하고
+    // access만 새로 만든다. 같은 grace 토큰이 여러 번 들어와도 idempotent하게 동작한다.
+    private RefreshResult graceReplay(RefreshToken row) {
+        User user = row.getUser();
+        String newAccess = jwtTokenProvider.createAccessToken(user);
+
+        incrementRefresh("grace_replay");
+
+        return RefreshResult.builder()
+                .userId(user.getId())
+                .accessToken(newAccess)
+                .refreshToken(row.getToken())
+                .refreshExpiredAt(row.getExpiredAt())
+                .path(RefreshResult.Path.GRACE_REPLAY)
+                .build();
+    }
+
+    private void incrementRefresh(String result) {
+        meterRegistry.counter("auth_refresh_total", "result", result).increment();
+    }
 
     /**
      * provider: "google", "kakao" 또는 "naver"

--- a/src/main/resources/db/migration/V20260418_001__add_unique_index_refresh_tokens_token.sql
+++ b/src/main/resources/db/migration/V20260418_001__add_unique_index_refresh_tokens_token.sql
@@ -1,0 +1,23 @@
+-- refresh_tokens.token 컬럼에 UNIQUE 인덱스를 추가한다.
+--
+-- 배경: refresh 회전은 `WHERE token = :t`로 단일 row를 특정하는 게 전제다.
+-- 현재 엔티티(RefreshToken.java)도 Optional<RefreshToken> 반환을 전제로 설계되어 있어,
+-- 논리적으로 중복 token은 비정상 상태다. 그런데 테이블 생성이 Flyway 이전(ddl-auto=update 시절)에
+-- 이뤄져 실DB에 index가 없는 상태로 방치되어 있었다.
+--
+-- 회전 경로(AuthService.refresh의 findByTokenForUpdate)가 PESSIMISTIC_WRITE로 동작하려면
+-- 먼저 토큰 컬럼의 unique 인덱스가 있어야 한다. 인덱스 없이 테이블 스캔하며 row-level lock을
+-- 잡으면 next-key lock 범위가 커져 refresh 동시성이 묶인다.
+--
+-- 운영 전제(반드시 배포 전에 확인):
+--   SELECT token, COUNT(*) c FROM refresh_tokens GROUP BY token HAVING c > 1;
+-- 위 쿼리가 0 rows여야 이 마이그레이션이 안전하게 통과한다. dup가 발견되면 이 파일을
+-- 적용하기 전에 운영 SQL로 정리하고(각 dup 그룹에서 expired_at이 가장 큰 row 1개만 유지),
+-- 다시 precheck로 0 rows를 확인한 뒤에 배포한다. dup 정리는 본 migration에 포함시키지 않는다 ―
+-- 세션 일부가 끊기는 side effect를 schema change 히스토리에 묻으면 안 되기 때문이다.
+--
+-- 호환성: 읽기/쓰기 경로는 변함없이 `WHERE token=:t`다. 인덱스 추가는 additive이고
+-- 기존 쿼리 플랜을 스캔에서 seek으로 바꿔 성능이 개선되는 쪽이라 회귀 위험은 없다.
+
+ALTER TABLE refresh_tokens
+    ADD CONSTRAINT uk_rt_token UNIQUE (token);

--- a/src/main/resources/db/migration/V20260418_002__add_grace_columns_refresh_tokens.sql
+++ b/src/main/resources/db/migration/V20260418_002__add_grace_columns_refresh_tokens.sql
@@ -1,0 +1,32 @@
+-- refresh_tokens 테이블에 grace 회전을 위한 두 컬럼(previous_token, previous_token_grace_until)과
+-- previous_token 조회용 인덱스를 추가한다.
+--
+-- 배경: Android WebView의 CookieManager가 쿠키를 디스크에 flush하기 전에 앱이 백그라운드로
+-- 가거나 프로세스가 죽으면, 서버는 이미 회전된 "새 refresh token"을 Set-Cookie로 내렸음에도
+-- 클라이언트는 "옛 refresh token"을 다시 보내오는 현상이 간헐적으로 재현된다. 이 때 서버가
+-- 옛 토큰을 즉시 invalid로 끊으면 프론트는 force-logout을 발화하고 사용자는 로그아웃된다.
+--
+-- 해결: "직전 회전에서 발급했던 값"을 같은 row에 previous_token으로 들고, 짧은 유예기간
+-- (previous_token_grace_until) 안에 들어온 옛 토큰을 "이미 회전된 현재 토큰"으로 동등 처리한다.
+-- Redis에 grace 레코드를 따로 두는 안은 DB commit과 Redis write 사이의 miss window가
+-- 프론트 force-logout과 겹치면 똑같이 로그아웃을 만든다 ― 그래서 한 row에 묶었다.
+--
+-- 인덱스 결정: previous_token은 UNIQUE가 아닌 평문 INDEX로 둔다.
+--   - previous_token은 소스-오브-트루스 key가 아니라 "한 tick 전" 이력이다. 사용자 여러 기기에서
+--     동시에 회전이 일어나면 동일 previous_token을 공유하는 row가 잠깐 존재할 수 있다(드물지만).
+--   - UNIQUE를 걸면 이 drop-in 이력 처리가 schema violation으로 바뀌어 refresh가 먼저 500을 낸다.
+--   - 우리가 실제로 필요한 건 equality seek 성능이지 글로벌 유일성이 아니다.
+--
+-- 호환성: 두 컬럼 모두 NULL 허용이라 기존 row는 영향 없음(전체 row = NULL로 존재). 회전 경로
+-- (AuthService.refresh)가 이 컬럼을 읽고 쓰지만, 옛 코드/옛 row 조합에서도 정상 동작하도록
+-- previous_token IS NULL / grace_until 만료는 "기존 단일 lookup"과 동일하게 fallthrough된다.
+--
+-- 운영 주의: ALTER ADD COLUMN은 MySQL 8에서 INSTANT(또는 INPLACE)로 내려가지만, 같은 문에
+-- CREATE INDEX가 섞이면 INPLACE가 강제되어 metadata lock이 길어질 수 있다. 트래픽이 낮은
+-- 시간대에 적용하고, 적용 직전 long-running tx 유무를 확인하는 것을 권장한다
+-- (information_schema.innodb_trx, SHOW PROCESSLIST).
+
+ALTER TABLE refresh_tokens
+    ADD COLUMN previous_token VARCHAR(255) NULL,
+    ADD COLUMN previous_token_grace_until DATETIME NULL,
+    ADD INDEX idx_rt_prev_token (previous_token);

--- a/src/test/java/com/jdc/recipe_service/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jdc/recipe_service/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,93 @@
+package com.jdc.recipe_service.handler;
+
+import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.exception.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * GlobalExceptionHandler#handleConcurrencyFailure의 스코프 검증.
+ *
+ * 규칙:
+ * - refresh 경로(/api/token/refresh)에서 올라온 lock 계열 예외는 401/400 "유효하지 않은 리프레시 토큰"으로
+ *   매핑하고 auth_refresh_total{result=lock_timeout} 카운터를 1 증가시킨다.
+ * - 다른 경로에서 올라온 같은 예외는 원래대로 catch-all로 내려가도록 다시 throw해야 한다.
+ *
+ * 왜 이렇게 나눴는가: refresh 경로에서 발생하는 순간적 lock contention은 프론트가 한 번 더 시도하면 복구되는
+ * 성격이라 force-logout까지 가면 UX가 나쁘다. 반면 댓글/좋아요 등 다른 도메인에서는 같은 예외의 의미가 다르므로
+ * "refresh 경로 한정"으로만 예외 매핑을 바꾼다.
+ */
+class GlobalExceptionHandlerTest {
+
+    private MeterRegistry meterRegistry;
+    private GlobalExceptionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        handler = new GlobalExceptionHandler(meterRegistry);
+    }
+
+    private double lockTimeoutCount() {
+        return meterRegistry.counter("auth_refresh_total", "result", "lock_timeout").count();
+    }
+
+    private static HttpServletRequest requestWithUri(String uri) {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn(uri);
+        return request;
+    }
+
+    @Test
+    @DisplayName("refresh 경로의 PessimisticLockingFailure는 INVALID_REFRESH_TOKEN(400)으로 매핑되고 lock_timeout 카운터가 1 증가한다")
+    void refreshPath_mapsLockFailureToInvalidToken() {
+        HttpServletRequest request = requestWithUri("/api/token/refresh");
+        ConcurrencyFailureException ex = new PessimisticLockingFailureException("lock wait timeout");
+
+        ResponseEntity<ErrorResponse> response = handler.handleConcurrencyFailure(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN.getStatus());
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN.getCode());
+        assertThat(lockTimeoutCount()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("refresh 경로의 CannotAcquireLockException도 같은 방식으로 매핑된다")
+    void refreshPath_mapsCannotAcquireLockSameWay() {
+        // PessimisticLockingFailureException 외에 CannotAcquireLockException/DeadlockLoserDataAccessException도
+        // 같은 super type(ConcurrencyFailureException)이라 동일하게 잡혀야 한다.
+        HttpServletRequest request = requestWithUri("/api/token/refresh");
+        ConcurrencyFailureException ex = new CannotAcquireLockException("could not acquire lock");
+
+        ResponseEntity<ErrorResponse> response = handler.handleConcurrencyFailure(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN.getStatus());
+        assertThat(lockTimeoutCount()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("refresh가 아닌 경로에서 올라온 ConcurrencyFailureException은 다시 throw되어 catch-all로 내려간다")
+    void nonRefreshPath_rethrowsToCatchAll() {
+        HttpServletRequest request = requestWithUri("/api/v1/recipes/1/like");
+        ConcurrencyFailureException ex = new PessimisticLockingFailureException("deadlock on likes");
+
+        assertThatThrownBy(() -> handler.handleConcurrencyFailure(ex, request))
+                .isSameAs(ex);
+
+        // 이 경로에서는 refresh 전용 카운터가 오염되면 안 된다.
+        assertThat(lockTimeoutCount()).isEqualTo(0.0);
+    }
+}

--- a/src/test/java/com/jdc/recipe_service/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/jdc/recipe_service/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,198 @@
+package com.jdc.recipe_service.repository;
+
+import com.jdc.recipe_service.config.JpaAuditingConfig;
+import com.jdc.recipe_service.config.QuerydslConfig;
+import com.jdc.recipe_service.domain.entity.RefreshToken;
+import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.repository.RefreshTokenRepository;
+import com.jdc.recipe_service.domain.type.Role;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RefreshTokenRepository의 grace 회전 lookup 쿼리 shape을 고정한다.
+ * - findByTokenForUpdate: UNIQUE 인덱스(uk_rt_token) 위에서 정확히 0/1 row
+ * - findByPreviousTokenInGraceForUpdate: previous_token 매칭 + grace_until > now AND previous_token NOT NULL
+ * - existsByPreviousToken: grace 만료 후 "옛 토큰 재전송" 관찰용 플래그
+ * - findAllByTokenOrPreviousToken: logout이 grace 상태의 row까지 같이 revoke하게 하는 OR lookup
+ *
+ * <p>여기서는 "쿼리가 의도한 row를 고르는가"만 본다. 실제 lock semantics(PESSIMISTIC_WRITE)는
+ * MySQL InnoDB 고유 동작에 의존하므로 RefreshTokenConcurrencyIT에서 Testcontainers로 따로 검증한다.
+ * 본 테스트는 프로젝트 testing rule(`@DataJpaTest` + H2 기본)을 따른다.
+ */
+@DataJpaTest
+@Import({QuerydslConfig.class, JpaAuditingConfig.class})
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "app.s3.bucket-name=test-bucket",
+        "cloud.aws.region.static=ap-northeast-2"
+})
+class RefreshTokenRepositoryTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .provider("google")
+                .oauthId("u-1")
+                .nickname("테스터")
+                .role(Role.USER)
+                .build();
+        em.persist(user);
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("findByTokenForUpdate: token 컬럼이 정확히 일치하는 row를 반환한다")
+    void findByTokenForUpdate_exactMatch() {
+        RefreshToken row = persist("T1", null, null, futureDays(7));
+
+        Optional<RefreshToken> found = refreshTokenRepository.findByTokenForUpdate("T1");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(row.getId());
+    }
+
+    @Test
+    @DisplayName("findByTokenForUpdate: 존재하지 않는 token은 빈 결과")
+    void findByTokenForUpdate_missing() {
+        persist("T1", null, null, futureDays(7));
+
+        Optional<RefreshToken> found = refreshTokenRepository.findByTokenForUpdate("T-UNKNOWN");
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByPreviousTokenInGraceForUpdate: previousToken 일치 + grace_until 미래면 row를 반환한다")
+    void grace_hit() {
+        RefreshToken row = persist("T2", "T1", futureSeconds(30), futureDays(7));
+
+        Optional<RefreshToken> found = refreshTokenRepository
+                .findByPreviousTokenInGraceForUpdate("T1", LocalDateTime.now());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(row.getId());
+    }
+
+    @Test
+    @DisplayName("findByPreviousTokenInGraceForUpdate: grace_until이 과거면 빈 결과 (grace 만료)")
+    void grace_expired() {
+        persist("T2", "T1", pastSeconds(5), futureDays(7));
+
+        Optional<RefreshToken> found = refreshTokenRepository
+                .findByPreviousTokenInGraceForUpdate("T1", LocalDateTime.now());
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByPreviousTokenInGraceForUpdate: previousToken이 NULL인 row는 잡히지 않는다")
+    void previousToken_null_skipped() {
+        // previous_token IS NULL이면 어떤 :token 값으로도 매치되지 않아야 한다.
+        persist("T1", null, null, futureDays(7));
+
+        Optional<RefreshToken> found = refreshTokenRepository
+                .findByPreviousTokenInGraceForUpdate("T1", LocalDateTime.now());
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByPreviousTokenInGraceForUpdate: previous_token_grace_until이 NULL이면 빈 결과")
+    void grace_until_null_skipped() {
+        persist("T2", "T1", null, futureDays(7));
+
+        Optional<RefreshToken> found = refreshTokenRepository
+                .findByPreviousTokenInGraceForUpdate("T1", LocalDateTime.now());
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("existsByPreviousToken: previous_token으로 등록된 적 있는 값은 true, 없는 값은 false")
+    void existsByPreviousToken_reflectsHistory() {
+        persist("T2", "T1", pastSeconds(5), futureDays(7));
+
+        assertThat(refreshTokenRepository.existsByPreviousToken("T1")).isTrue();
+        assertThat(refreshTokenRepository.existsByPreviousToken("never-issued")).isFalse();
+    }
+
+    @Test
+    @DisplayName("findAllByTokenOrPreviousToken: 현재 토큰 일치 row를 잡는다")
+    void logoutLookup_matchesByCurrentToken() {
+        RefreshToken row = persist("T2", "T1", futureSeconds(30), futureDays(7));
+
+        List<RefreshToken> rows = refreshTokenRepository.findAllByTokenOrPreviousToken("T2");
+
+        assertThat(rows).extracting(RefreshToken::getId).containsExactly(row.getId());
+    }
+
+    @Test
+    @DisplayName("findAllByTokenOrPreviousToken: previous_token만 일치해도 잡는다 (grace 상태 logout)")
+    void logoutLookup_matchesByPreviousTokenEvenAfterGraceExpired() {
+        // grace 만료 여부와 무관하게 revoke 대상이 되어야 한다 — logout은 "어떤 경우에도 지워라"가 자연스럽다.
+        RefreshToken row = persist("T2", "T1", pastSeconds(5), futureDays(7));
+
+        List<RefreshToken> rows = refreshTokenRepository.findAllByTokenOrPreviousToken("T1");
+
+        assertThat(rows).extracting(RefreshToken::getId).containsExactly(row.getId());
+    }
+
+    @Test
+    @DisplayName("findAllByTokenOrPreviousToken: 어느 쪽에도 안 걸리면 빈 리스트")
+    void logoutLookup_returnsEmptyWhenNoMatch() {
+        persist("T2", "T1", futureSeconds(30), futureDays(7));
+
+        List<RefreshToken> rows = refreshTokenRepository.findAllByTokenOrPreviousToken("unrelated");
+
+        assertThat(rows).isEmpty();
+    }
+
+    private RefreshToken persist(String token, String previousToken,
+                                 LocalDateTime graceUntil, LocalDateTime expiredAt) {
+        RefreshToken row = RefreshToken.builder()
+                .user(user)
+                .token(token)
+                .previousToken(previousToken)
+                .previousTokenGraceUntil(graceUntil)
+                .expiredAt(expiredAt)
+                .build();
+        em.persist(row);
+        em.flush();
+        em.clear();
+        return row;
+    }
+
+    private static LocalDateTime futureDays(long days) {
+        return LocalDateTime.now().plusDays(days);
+    }
+
+    private static LocalDateTime futureSeconds(long seconds) {
+        return LocalDateTime.now().plusSeconds(seconds);
+    }
+
+    private static LocalDateTime pastSeconds(long seconds) {
+        return LocalDateTime.now().minusSeconds(seconds);
+    }
+}

--- a/src/test/java/com/jdc/recipe_service/service/AuthServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/AuthServiceTest.java
@@ -1,0 +1,269 @@
+package com.jdc.recipe_service.service;
+
+import com.jdc.recipe_service.domain.dto.auth.RefreshResult;
+import com.jdc.recipe_service.domain.entity.RefreshToken;
+import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.repository.RefreshTokenRepository;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.jwt.JwtTokenProvider;
+import com.jdc.recipe_service.security.oauth.AppleClientSecretGenerator;
+import com.jdc.recipe_service.security.oauth.CustomOAuth2UserService;
+import io.jsonwebtoken.JwtException;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService#refresh 동작")
+class AuthServiceTest {
+
+    @Mock private ClientRegistrationRepository clientRegistrationRepository;
+    @Mock private CustomOAuth2UserService customOAuth2UserService;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient;
+    @Mock private AppleClientSecretGenerator appleClientSecretGenerator;
+
+    private MeterRegistry meterRegistry;
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        authService = new AuthService(
+                clientRegistrationRepository,
+                customOAuth2UserService,
+                jwtTokenProvider,
+                refreshTokenRepository,
+                accessTokenResponseClient,
+                appleClientSecretGenerator,
+                meterRegistry
+        );
+    }
+
+    private double counter(String result) {
+        return meterRegistry.counter("auth_refresh_total", "result", result).count();
+    }
+
+    @Nested
+    @DisplayName("JWT 선검증 실패")
+    class JwtValidation {
+
+        @Test
+        @DisplayName("JWT 형식/서명이 유효하지 않으면 INVALID_REFRESH_TOKEN으로 던지고 jwt_invalid 카운터가 증가한다")
+        void rejects_invalid_jwt() {
+            given(jwtTokenProvider.validateToken("bad"))
+                    .willThrow(new JwtException("유효하지 않은 토큰입니다."));
+
+            assertThatThrownBy(() -> authService.refresh("bad"))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+
+            assertThat(counter("jwt_invalid")).isEqualTo(1.0);
+            then(refreshTokenRepository).should(never()).findByTokenForUpdate(any());
+        }
+
+        @Test
+        @DisplayName("JWT가 만료되었으면 REFRESH_TOKEN_EXPIRED로 던지고 jwt_expired 카운터가 증가한다")
+        void rejects_expired_jwt() {
+            given(jwtTokenProvider.validateToken("stale"))
+                    .willThrow(new JwtException("토큰이 만료되었습니다."));
+
+            assertThatThrownBy(() -> authService.refresh("stale"))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.REFRESH_TOKEN_EXPIRED);
+
+            assertThat(counter("jwt_expired")).isEqualTo(1.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("정상 회전 경로")
+    class RotatePath {
+
+        @Test
+        @DisplayName("현재 유효 토큰으로 조회되면 새 refresh로 회전하고 이전 토큰을 previousToken으로 접어넣는다")
+        void rotates_and_stores_previous() {
+            // given
+            String oldToken = "T1";
+            User user = User.builder().id(42L).build();
+            RefreshToken row = RefreshToken.builder()
+                    .id(1L)
+                    .user(user)
+                    .token(oldToken)
+                    .expiredAt(LocalDateTime.now().plusDays(7))
+                    .build();
+
+            given(jwtTokenProvider.validateToken(oldToken)).willReturn(true);
+            given(refreshTokenRepository.findByTokenForUpdate(oldToken)).willReturn(Optional.of(row));
+            given(jwtTokenProvider.createAccessToken(user)).willReturn("ACCESS_NEW");
+            given(jwtTokenProvider.createRefreshToken()).willReturn("T2");
+            LocalDateTime newExpiry = LocalDateTime.now().plusDays(7);
+            given(jwtTokenProvider.getRefreshTokenExpiryAsLocalDateTime()).willReturn(newExpiry);
+
+            // when
+            RefreshResult result = authService.refresh(oldToken);
+
+            // then
+            assertThat(result.getPath()).isEqualTo(RefreshResult.Path.ROTATED);
+            assertThat(result.getUserId()).isEqualTo(42L);
+            assertThat(result.getAccessToken()).isEqualTo("ACCESS_NEW");
+            assertThat(result.getRefreshToken()).isEqualTo("T2");
+            assertThat(result.getRefreshExpiredAt()).isEqualTo(newExpiry);
+
+            assertThat(row.getToken()).isEqualTo("T2");
+            assertThat(row.getPreviousToken()).isEqualTo("T1");
+            assertThat(row.getPreviousTokenGraceUntil()).isNotNull();
+            assertThat(row.getExpiredAt()).isEqualTo(newExpiry);
+
+            assertThat(counter("rotated")).isEqualTo(1.0);
+            then(refreshTokenRepository).should(never())
+                    .findByPreviousTokenInGraceForUpdate(any(), any());
+        }
+
+        @Test
+        @DisplayName("현재 토큰으로 조회된 row가 DB에서 만료 상태면 REFRESH_TOKEN_EXPIRED로 던진다")
+        void expired_db_row_throws() {
+            String oldToken = "T1";
+            RefreshToken row = RefreshToken.builder()
+                    .id(1L)
+                    .user(User.builder().id(7L).build())
+                    .token(oldToken)
+                    .expiredAt(LocalDateTime.now().minusMinutes(1))
+                    .build();
+
+            given(jwtTokenProvider.validateToken(oldToken)).willReturn(true);
+            given(refreshTokenRepository.findByTokenForUpdate(oldToken)).willReturn(Optional.of(row));
+
+            assertThatThrownBy(() -> authService.refresh(oldToken))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.REFRESH_TOKEN_EXPIRED);
+
+            assertThat(counter("expired")).isEqualTo(1.0);
+            assertThat(row.getPreviousToken()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("grace 재전송 경로")
+    class GracePath {
+
+        @Test
+        @DisplayName("현재 토큰 조회는 miss지만 grace 조회에서 잡히면 회전 없이 기존 refresh를 재송신한다")
+        void grace_hit_returns_existing_token_without_rotation() {
+            // given: Android 재전송 — 이미 회전된 row(T1→T2)에 T1이 다시 들어오는 상황
+            String replayedOld = "T1";
+            User user = User.builder().id(99L).build();
+            LocalDateTime expiry = LocalDateTime.now().plusDays(7);
+            LocalDateTime graceUntil = LocalDateTime.now().plusSeconds(20);
+            RefreshToken row = RefreshToken.builder()
+                    .id(1L)
+                    .user(user)
+                    .token("T2")
+                    .previousToken("T1")
+                    .previousTokenGraceUntil(graceUntil)
+                    .expiredAt(expiry)
+                    .build();
+
+            given(jwtTokenProvider.validateToken(replayedOld)).willReturn(true);
+            given(refreshTokenRepository.findByTokenForUpdate(replayedOld))
+                    .willReturn(Optional.empty());
+            given(refreshTokenRepository.findByPreviousTokenInGraceForUpdate(eq(replayedOld), any()))
+                    .willReturn(Optional.of(row));
+            given(jwtTokenProvider.createAccessToken(user)).willReturn("ACCESS_NEW");
+
+            // when
+            RefreshResult result = authService.refresh(replayedOld);
+
+            // then: 기존 current 토큰(T2)이 그대로 내려가고 새 access만 발급된다
+            assertThat(result.getPath()).isEqualTo(RefreshResult.Path.GRACE_REPLAY);
+            assertThat(result.getAccessToken()).isEqualTo("ACCESS_NEW");
+            assertThat(result.getRefreshToken()).isEqualTo("T2");
+            assertThat(result.getRefreshExpiredAt()).isEqualTo(expiry);
+
+            // row의 token/previous_token/만료는 건드리지 않는다 (idempotent)
+            assertThat(row.getToken()).isEqualTo("T2");
+            assertThat(row.getPreviousToken()).isEqualTo("T1");
+            assertThat(row.getPreviousTokenGraceUntil()).isEqualTo(graceUntil);
+
+            assertThat(counter("grace_replay")).isEqualTo(1.0);
+            then(jwtTokenProvider).should(never()).createRefreshToken();
+        }
+    }
+
+    @Nested
+    @DisplayName("둘 다 miss")
+    class Miss {
+
+        @Test
+        @DisplayName("현재/grace 모두 miss이고 이력에도 없으면 invalid 카운터로 INVALID_REFRESH_TOKEN을 던진다")
+        void both_miss_without_history_throws_invalid() {
+            String oldToken = "unknown";
+
+            given(jwtTokenProvider.validateToken(oldToken)).willReturn(true);
+            given(refreshTokenRepository.findByTokenForUpdate(oldToken))
+                    .willReturn(Optional.empty());
+            given(refreshTokenRepository.findByPreviousTokenInGraceForUpdate(eq(oldToken), any()))
+                    .willReturn(Optional.empty());
+            given(refreshTokenRepository.existsByPreviousToken(oldToken)).willReturn(false);
+
+            assertThatThrownBy(() -> authService.refresh(oldToken))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+
+            assertThat(counter("invalid")).isEqualTo(1.0);
+            assertThat(counter("replay_suspected")).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("grace 만료 후 옛 토큰이 재전송되면 replay_suspected 카운터가 찍히고 INVALID_REFRESH_TOKEN을 던진다")
+        void both_miss_with_history_increments_replay_suspected() {
+            // 시나리오: 클라이언트가 T1→T2 회전 후 30초 + 약간 더 지나서 T1을 재전송
+            //  - findByTokenForUpdate(T1) → empty (이미 회전됨)
+            //  - findByPreviousTokenInGraceForUpdate(T1, now) → empty (grace 만료)
+            //  - existsByPreviousToken(T1) → true (어딘가 row가 previous_token=T1을 갖고 있음)
+            String oldToken = "T1";
+
+            given(jwtTokenProvider.validateToken(oldToken)).willReturn(true);
+            given(refreshTokenRepository.findByTokenForUpdate(oldToken))
+                    .willReturn(Optional.empty());
+            given(refreshTokenRepository.findByPreviousTokenInGraceForUpdate(eq(oldToken), any()))
+                    .willReturn(Optional.empty());
+            given(refreshTokenRepository.existsByPreviousToken(oldToken)).willReturn(true);
+
+            assertThatThrownBy(() -> authService.refresh(oldToken))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+
+            // 응답 계약은 invalid와 같지만 메트릭 태그는 분리돼 관찰 가능해야 한다
+            assertThat(counter("replay_suspected")).isEqualTo(1.0);
+            assertThat(counter("invalid")).isEqualTo(0.0);
+        }
+    }
+}

--- a/src/test/java/com/jdc/recipe_service/service/RefreshTokenConcurrencyIT.java
+++ b/src/test/java/com/jdc/recipe_service/service/RefreshTokenConcurrencyIT.java
@@ -1,0 +1,154 @@
+package com.jdc.recipe_service.service;
+
+import com.jdc.recipe_service.domain.dto.auth.RefreshResult;
+import com.jdc.recipe_service.domain.entity.RefreshToken;
+import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.repository.RefreshTokenRepository;
+import com.jdc.recipe_service.domain.repository.UserRepository;
+import com.jdc.recipe_service.domain.type.Role;
+import com.jdc.recipe_service.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * refresh 동시성 보장 integration test.
+ *
+ * 목적: 같은 refresh token으로 두 요청이 동시에 들어왔을 때
+ *  - 정확히 하나만 "회전(ROTATED)"을 성공시키고,
+ *  - 나머지 하나는 "grace 재전송(GRACE_REPLAY)"으로 살아 돌아와야 한다.
+ *
+ * 왜 MySQL Testcontainer를 쓰는가: 이 시나리오는 PESSIMISTIC_WRITE가 UNIQUE 인덱스(uk_rt_token)
+ * 위에서 row-level X-lock으로 내려가는 InnoDB 동작에 의존한다. H2는 locking semantics가 달라
+ * 같은 invariant를 재현하지 못한다. 그래서 본 테스트는 Testcontainers를 쓴다.
+ *
+ * 주의: 본 테스트는 test 메서드에 @Transactional을 걸지 않는다. 두 스레드가 서로 다른
+ * 트랜잭션에서 lock을 경쟁해야 동시성 의미가 살아나기 때문이다.
+ */
+@SpringBootTest(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+@ActiveProfiles("test")
+@Tag("concurrency")
+@Testcontainers
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude=" +
+                "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration"
+})
+class RefreshTokenConcurrencyIT {
+
+    @Container
+    @ServiceConnection
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.33");
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    private User user;
+    private String initialToken;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(User.builder()
+                .provider("google")
+                .oauthId("concurrency-" + System.nanoTime())
+                .nickname("동시성유저")
+                .role(Role.USER)
+                .build());
+
+        initialToken = jwtTokenProvider.createRefreshToken();
+        refreshTokenRepository.save(RefreshToken.builder()
+                .user(user)
+                .token(initialToken)
+                .expiredAt(jwtTokenProvider.getRefreshTokenExpiryAsLocalDateTime())
+                .build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        refreshTokenRepository.deleteByUserId(user.getId());
+        userRepository.delete(user);
+    }
+
+    @Test
+    @DisplayName("동일 토큰으로 병렬 refresh가 들어오면 ROTATED 1회 + GRACE_REPLAY 1회로 갈라진다")
+    void parallel_refresh_yields_one_rotated_and_one_grace_replay() throws Exception {
+        int parties = 2;
+        ExecutorService pool = Executors.newFixedThreadPool(parties);
+        CountDownLatch startGate = new CountDownLatch(1);
+
+        try {
+            Callable<RefreshResult> task = () -> {
+                startGate.await();
+                return authService.refresh(initialToken);
+            };
+
+            Future<RefreshResult> f1 = pool.submit(task);
+            Future<RefreshResult> f2 = pool.submit(task);
+
+            // 두 스레드가 submit되어 start gate 직전에 대기하도록 잠깐 스케줄 양보
+            Thread.sleep(50);
+            startGate.countDown();
+
+            RefreshResult r1 = f1.get(15, TimeUnit.SECONDS);
+            RefreshResult r2 = f2.get(15, TimeUnit.SECONDS);
+
+            List<RefreshResult.Path> paths = List.of(r1.getPath(), r2.getPath());
+            assertThat(paths)
+                    .as("한 스레드는 정상 회전, 다른 스레드는 grace 재전송이어야 한다")
+                    .containsExactlyInAnyOrder(
+                            RefreshResult.Path.ROTATED,
+                            RefreshResult.Path.GRACE_REPLAY
+                    );
+
+            // grace 경로가 반환한 refresh는 rotated 경로가 새로 만든 refresh와 같아야 한다
+            RefreshResult rotated = r1.getPath() == RefreshResult.Path.ROTATED ? r1 : r2;
+            RefreshResult grace   = r1.getPath() == RefreshResult.Path.GRACE_REPLAY ? r1 : r2;
+            assertThat(grace.getRefreshToken())
+                    .as("grace_replay는 rotated가 새로 발급한 current 토큰을 재송신해야 한다")
+                    .isEqualTo(rotated.getRefreshToken());
+
+            // DB 상태 검증: 한 row만 남아 있고 token은 새 값, previous_token은 initialToken.
+            List<RefreshToken> rows = refreshTokenRepository.findByUserOrderByCreatedAtAsc(user);
+            assertThat(rows).hasSize(1);
+            RefreshToken stored = rows.get(0);
+            assertThat(stored.getToken()).isEqualTo(rotated.getRefreshToken());
+            assertThat(stored.getPreviousToken()).isEqualTo(initialToken);
+            assertThat(stored.getPreviousTokenGraceUntil()).isAfter(LocalDateTime.now().minusMinutes(1));
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?

  Android WebView의 `CookieManager`가 rotate된 refresh 쿠키를 즉시 flush하지 못해, 이미 갱신된 세션인데도 클라이언트가
  **옛 refresh 토큰을 다시 보내** 서버가 `invalid`로 응답 → 강제 로그아웃되는 증상이 프로덕션에서 간헐적으로 관측됐다.
  네트워크 왕복이나 탭 간 경합 수준의 짧은 시간차인데 force-logout까지 가면 UX가 과하게 나빠진다.

  ## 어떻게 해결했나요?

  - **AS-IS**: rotation 직후 옛 토큰으로 refresh 요청 → `findByToken` miss → `INVALID_REFRESH_TOKEN(601)` → 프론트
  force-logout.
  - **TO-BE**: `refresh_tokens`에 `previous_token` + `previous_token_grace_until` 컬럼을 추가하고, 회전 시 옛 토큰을
  30초 grace 윈도우로 기록한다. `AuthService#refresh`는 3단계 lookup: (1) 현재 토큰 → rotate, (2) grace 안의 옛 토큰 →
  **DB 변경 없이 current 재송신** (`grace_replay`), (3) grace 만료된 옛 토큰 → `replay_suspected`로 관측 후
  `INVALID_REFRESH_TOKEN`.
  - Logout은 `findAllByTokenOrPreviousToken`으로 `previous_token` 매칭 row까지 revoke해, 옛 토큰으로 logout을 눌러도
  current row가 살아남는 ghost session을 제거한다.
  - `GlobalExceptionHandler`는 `/api/token/refresh` 경로 한정으로 `ConcurrencyFailureException`을
  `INVALID_REFRESH_TOKEN`에 매핑하고 `lock_timeout` 카운터를 올린다(다른 도메인은 영향 없음).
  - **리뷰어가 먼저 볼 파일**: `AuthService.java`(3단계 lookup), `RefreshTokenRepository.java`(새 쿼리 3개),
  `AuthController.java`(logout revoke 범위 확대), Flyway `V20260418_001/002`.

  ## Test plan

  - 자동화 (BUILD SUCCESSFUL, 20/20):
    - `AuthServiceTest` — RotatePath / GracePath / Miss(invalid, replay_suspected) / JwtValidation 각 분기 +
  `auth_refresh_total` 카운터 증분 검증
    - `RefreshTokenRepositoryTest` — `findByTokenForUpdate`, `findByPreviousTokenInGraceForUpdate`,
  `existsByPreviousToken`, `findAllByTokenOrPreviousToken` 쿼리 shape (H2 기반 `@DataJpaTest`)
    - `GlobalExceptionHandlerTest` — refresh 경로 lock_timeout 매핑 + 비 refresh 경로 rethrow
  - 수동 (Apidog + H2 로컬): test-login → refresh × 1 → 30초 이내 옛 토큰 재전송 × 2 → 30초 후 옛 토큰 재전송 × 1
  시퀀스로 `rotated=1, grace_replay=2, replay_suspected=1` 확인. logout(옛 토큰)으로 row 0건 삭제 확인.
  - 동시성(보류): `RefreshTokenConcurrencyIT`(@Tag("concurrency"), Testcontainers MySQL). 동일 토큰 병렬 refresh 2개 →
  ROTATED 1 + GRACE_REPLAY 1 invariant 검증. Docker 필요, 별도 잡에서 실행 예정.

  ## Rollout / DB / API impact

  - **DB**:
    - `V20260418_001__add_unique_index_refresh_tokens_token.sql` — `refresh_tokens.token`에 UNIQUE 인덱스 추가. **배포
  전 precheck 필수** (중복 검사 쿼리는 runbook §1-1). 중복 row 있으면 Flyway 실패.
    - `V20260418_002__add_grace_columns_refresh_tokens.sql` — `previous_token`, `previous_token_grace_until` 컬럼 +
  `idx_rt_prev_token`. 모두 nullable additive라 기존 row 영향 없음.
    - expand-only 구조. drop/rename 없음.
  - **API**: non-breaking. 응답 shape(`TokenResponseDTO`)·status code 변화 없음. 프론트 액션 불필요.
  - **Feature flag / 스케줄러**: 해당 없음.
  - **Runbook**: `docs/runbook/refresh-grace-rotation.md`에 precheck / 배포 순서 / 롤백 / 모니터링 포함.

  ## Risks and rollback

  - **가장 큰 리스크**: precheck 누락 시 `refresh_tokens.token` 중복으로 V20260418_001 Flyway 실패. runbook §1-2의
  ROW_NUMBER() 정리 SQL로 해소 가능.
  - **앱 롤백**: 구 버전 app + 새 스키마 호환 (새 컬럼은 구 app이 무시). 스키마 되돌릴 필요 없이 즉시 이전 JAR로 롤백
  가능.
  - **스키마 롤백**: additive이므로 drop으로 가능하나, UNIQUE 인덱스는 걸린 뒤 중복 insert 경로가 새로 생기면 실패시킬
  수 있음. 현재 코드에는 그런 경로 없음.
  - **모니터링**: 배포 후 24시간 `auth_refresh_total{result}` 주시. `lock_timeout > 0.1/s` 지속 또는 `grace_replay`
  급등(2배+) 시 문의. 상세 임계값 runbook §4.

  ## Related

  - Runbook: `docs/runbook/refresh-grace-rotation.md`
  - Skills used: `db-migration`(expand-only additive), `write-tests`(H2 우선 + Testcontainers는 concurrency만)
  - PR 크기 참고: +1231 / -44 lines. feature 본체(+migration+test+runbook) 번들이라 분리 불가 — 마이그레이션만 단독
  배포하면 구 app이 새 컬럼을 무시해 무의미하고, 앱 코드만 먼저 배포하면 컬럼 부재로 NPE 발생.