### PR TITLE
feat(RecipeBookItemResponse): 레시피북 상세 응답에 작성자 정보 노출

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+.gradle-local/
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/src/main/java/com/jdc/recipe_service/domain/dto/recipebook/RecipeBookItemResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/recipebook/RecipeBookItemResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.jdc.recipe_service.config.HashIdConfig.HashIdSerializer;
 import com.jdc.recipe_service.domain.entity.Recipe;
 import com.jdc.recipe_service.domain.entity.RecipeBookItem;
+import com.jdc.recipe_service.domain.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,17 +34,31 @@ public class RecipeBookItemResponse {
     @Schema(description = "요리 유형")
     private String dishType;
 
+    @JsonSerialize(using = HashIdSerializer.class)
+    @Schema(description = "작성자 ID")
+    private Long authorId;
+
+    @Schema(description = "작성자 닉네임")
+    private String authorName;
+
+    @Schema(description = "작성자 프로필 이미지")
+    private String profileImage;
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     @Schema(description = "레시피북에 추가된 시간")
     private LocalDateTime addedAt;
 
     public static RecipeBookItemResponse from(RecipeBookItem item, String imageUrl) {
         Recipe recipe = item.getRecipe();
+        User author = recipe.getUser();
         return RecipeBookItemResponse.builder()
                 .recipeId(recipe.getId())
                 .title(recipe.getTitle())
                 .imageUrl(imageUrl)
                 .dishType(recipe.getDishType() != null ? recipe.getDishType().name() : null)
+                .authorId(author != null ? author.getId() : null)
+                .authorName(author != null ? author.getNickname() : null)
+                .profileImage(author != null ? author.getProfileImage() : null)
                 .addedAt(item.getCreatedAt())
                 .build();
     }


### PR DESCRIPTION
  ## 해결하려는 문제가 무엇인가요?
  레시피북 상세 응답(`GET /api/me/recipe-books/{bookId}`)의 `recipes[]` 항목에 작성자 정보가 없어,
  프론트가 목록을 그리려면 레시피 단건 API를 추가로 호출해야 했다. 레시피 응답과 동일한 필드를
  제공해 호출을 1회로 줄인다.

  ## 어떻게 해결했나요?
  - **AS-IS:** `RecipeBookItemResponse` 는 `recipeId`, `title`, `imageUrl`, `dishType`, `addedAt` 만 내려주고 있었다.
  작성자 표시가 필요하면 프론트가 `GET /api/recipes/{id}` 를 재호출해야 했다.
  - **TO-BE:** `RecipeBookItemResponse` 에 `authorId`(Hashid 직렬화), `authorName`, `profileImage` 세 필드를 추가하고
  `from()` 팩토리가 `recipe.getUser()` 로부터 채우도록 수정했다. `RecipeSimpleDto` 와 동일한 스키마다.
  - **N+1 여부:** `RecipeBookItemRepository.findAccessibleByBookIdAndUserId` 가 이미 `@EntityGraph(attributePaths =
  {"recipe", "recipe.user"})` 로 user 를 함께 fetch 하고 있어 추가 쿼리가 발생하지 않는다.
  - **리뷰 포인트:** `src/main/java/com/jdc/recipe_service/domain/dto/recipebook/RecipeBookItemResponse.java` 한 파일이
  본질. `.gitignore` 의 `.gradle-local/` 추가는 IDE/로컬 Gradle 캐시 무시용 chore 로, 같은 PR 에 묶었다.

  ## Test plan
  - `./gradlew compileJava --rerun-tasks` → BUILD SUCCESSFUL 확인
  - `./gradlew test --tests "*RecipeBookServiceTest*"` → 통과 확인
  - 수동 검증: 로그인 상태에서 `GET /api/me/recipe-books/{bookId}` 호출 시 `recipes[*]` 각 항목에 `authorId`(Hashid
  문자열), `authorName`, `profileImage` 가 포함되는지 확인

  ## Rollout / DB / API impact
  - **DB:** 해당 없음 (스키마/데이터 변경 없음)
  - **API:** Non-breaking. 기존 필드 그대로 유지하고 세 필드만 추가한다. 프론트 액션: 필수 아님, 필요 시 새 필드 소비
  - **Feature flag / 스케줄러:** 해당 없음

  ## Risks and rollback
  - 필드 추가 성격의 변경이라 단순 revert 로 완전 롤백 가능
  - `recipe.user` 가 `nullable = false` 지만 DTO 레벨에서 `null` 방어를 두었으므로, 기존 데이터 이상으로 응답이 깨질
  위험은 없음

  ## Related
  - 관련 rule: `.claude/rules/api-design-openapi.md`, `.claude/rules/jpa-patterns.md`
  - 관련 skill: `git-workflow`
  - 별도 ADR 없음