### PR TITLE
chore(auth): refresh 실패 진단 강화 및 /api/token/refresh 필터 bypass 누락 수정

### DIFF
--- a/src/main/java/com/jdc/recipe_service/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/jdc/recipe_service/jwt/JwtAuthenticationFilter.java
@@ -82,7 +82,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || path.startsWith("/css/") || path.startsWith("/js/")
                 || path.startsWith("/images/") || path.startsWith("/oauth2")
                 || path.startsWith("/h2-console") || path.equals("/favicon.ico")
-                || path.startsWith("/ws/notifications");
+                || path.startsWith("/ws/notifications")
+                || path.equals("/api/token/refresh");
     }
 
     @Override

--- a/src/main/java/com/jdc/recipe_service/service/AuthService.java
+++ b/src/main/java/com/jdc/recipe_service/service/AuthService.java
@@ -39,10 +39,6 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class AuthService {
 
-    // Android WebView CookieManager가 새 refresh 쿠키를 디스크에 flush하기 전에 앱이
-    // 백그라운드로 가거나 죽었을 때를 메우기 위한 유예 시간. 사람이 "한 번 더 탭"하는 동안
-    // 옛 토큰이 재전송되어도 로그아웃되지 않게 해준다. 너무 길면 토큰 재전송 공격 창이 커지고,
-    // 너무 짧으면 재시도 여유가 없어 원래 문제로 돌아간다.
     private static final Duration REFRESH_GRACE_WINDOW = Duration.ofSeconds(30);
 
     private final ClientRegistrationRepository clientRegistrationRepository;
@@ -79,7 +75,6 @@ public class AuthService {
 
         LocalDateTime now = LocalDateTime.now();
 
-        // 1단계: 현재 유효 토큰으로 조회. UNIQUE 인덱스(uk_rt_token) 위에서 정확히 0/1 row.
         var currentRow = refreshTokenRepository.findByTokenForUpdate(oldToken);
         if (currentRow.isPresent()) {
             RefreshToken row = currentRow.get();
@@ -92,8 +87,6 @@ public class AuthService {
             return rotate(row, oldToken, now);
         }
 
-        // 2단계: grace 윈도우 안의 옛 토큰으로 조회.
-        // 플로우상 "최근에 T1→T2로 회전된 row"가 여기서 잡힌다.
         var graceRow = refreshTokenRepository.findByPreviousTokenInGraceForUpdate(oldToken, now);
         if (graceRow.isPresent()) {
             RefreshToken row = graceRow.get();
@@ -106,10 +99,6 @@ public class AuthService {
             return graceReplay(row);
         }
 
-        // 3단계: 두 lookup 모두 miss. 이 토큰이 "grace가 만료된 옛 refresh의 재전송"인지
-        // "한 번도 발급된 적 없는 토큰"인지 관찰용으로 구분한다. previous_token에 X-lock을 걸
-        // 필요는 없고, UNIQUE가 아닌 INDEX 위의 단순 exists 쿼리다. 프론트 응답은 동일하게
-        // INVALID_REFRESH_TOKEN로 유지하여 사용자 경험/계약은 바꾸지 않는다.
         boolean graceExpiredReplay = refreshTokenRepository.existsByPreviousToken(oldToken);
         String reason = graceExpiredReplay ? "replay_suspected" : "invalid";
         incrementRefresh(reason);
@@ -137,8 +126,6 @@ public class AuthService {
         return row.getExpiredAt() != null && row.getExpiredAt().isBefore(now);
     }
 
-    // 정상 회전: 새 access/refresh를 발급하고 옛 토큰을 previous_token으로 접어넣는다.
-    // 엔티티는 @Transactional 변경감지로 flush되므로 save() 호출은 하지 않는다.
     private RefreshResult rotate(RefreshToken row, String oldToken, LocalDateTime now) {
         User user = row.getUser();
 
@@ -162,8 +149,6 @@ public class AuthService {
                 .build();
     }
 
-    // grace 재전송: 회전은 하지 않는다. 이미 발급된 current 토큰을 그대로 재송신하고
-    // access만 새로 만든다. 같은 grace 토큰이 여러 번 들어와도 idempotent하게 동작한다.
     private RefreshResult graceReplay(RefreshToken row) {
         User user = row.getUser();
         String newAccess = jwtTokenProvider.createAccessToken(user);
@@ -183,8 +168,6 @@ public class AuthService {
         meterRegistry.counter("auth_refresh_total", "result", result).increment();
     }
 
-    // AuthController.fingerprint와 동일 포맷. 실패 로그의 refreshFp와 컨트롤러의
-    // "result=start" 로그의 refreshFp가 동일 토큰이면 정확히 같은 값이 찍히도록 맞춘다.
     private String fingerprint(String token) {
         if (token == null || token.isBlank()) {
             return "none";

--- a/src/main/java/com/jdc/recipe_service/service/AuthService.java
+++ b/src/main/java/com/jdc/recipe_service/service/AuthService.java
@@ -28,6 +28,9 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
@@ -82,6 +85,8 @@ public class AuthService {
             RefreshToken row = currentRow.get();
             if (isExpired(row, now)) {
                 incrementRefresh("expired");
+                log.warn("[AUTH_REFRESH] result=fail reason=db_expired stage=current refreshFp={} userId={}",
+                        fingerprint(oldToken), row.getUser().getId());
                 throw new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED);
             }
             return rotate(row, oldToken, now);
@@ -94,6 +99,8 @@ public class AuthService {
             RefreshToken row = graceRow.get();
             if (isExpired(row, now)) {
                 incrementRefresh("expired");
+                log.warn("[AUTH_REFRESH] result=fail reason=db_expired stage=grace refreshFp={} userId={}",
+                        fingerprint(oldToken), row.getUser().getId());
                 throw new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED);
             }
             return graceReplay(row);
@@ -104,7 +111,9 @@ public class AuthService {
         // 필요는 없고, UNIQUE가 아닌 INDEX 위의 단순 exists 쿼리다. 프론트 응답은 동일하게
         // INVALID_REFRESH_TOKEN로 유지하여 사용자 경험/계약은 바꾸지 않는다.
         boolean graceExpiredReplay = refreshTokenRepository.existsByPreviousToken(oldToken);
-        incrementRefresh(graceExpiredReplay ? "replay_suspected" : "invalid");
+        String reason = graceExpiredReplay ? "replay_suspected" : "invalid";
+        incrementRefresh(reason);
+        log.warn("[AUTH_REFRESH] result=fail reason={} refreshFp={}", reason, fingerprint(oldToken));
         throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
     }
 
@@ -115,9 +124,11 @@ public class AuthService {
             boolean expired = e.getMessage() != null && e.getMessage().contains("만료");
             if (expired) {
                 incrementRefresh("jwt_expired");
+                log.warn("[AUTH_REFRESH] result=fail reason=jwt_expired refreshFp={}", fingerprint(token));
                 throw new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED, e.getMessage());
             }
             incrementRefresh("jwt_invalid");
+            log.warn("[AUTH_REFRESH] result=fail reason=jwt_invalid refreshFp={}", fingerprint(token));
             throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN, e.getMessage());
         }
     }
@@ -170,6 +181,25 @@ public class AuthService {
 
     private void incrementRefresh(String result) {
         meterRegistry.counter("auth_refresh_total", "result", result).increment();
+    }
+
+    // AuthController.fingerprint와 동일 포맷. 실패 로그의 refreshFp와 컨트롤러의
+    // "result=start" 로그의 refreshFp가 동일 토큰이면 정확히 같은 값이 찍히도록 맞춘다.
+    private String fingerprint(String token) {
+        if (token == null || token.isBlank()) {
+            return "none";
+        }
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(token.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 4; i++) {
+                sb.append(String.format("%02x", digest[i]));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return Integer.toHexString(token.hashCode());
+        }
     }
 
     /**


### PR DESCRIPTION
  ## 해결하려는 문제가 무엇인가요?
  프로덕션에서 "잘 되다가 가끔 한 번씩" refresh가 실패해 강제 로그아웃되는 증상이 관찰되고 있다. 서버
  메트릭(`auth_refresh_total{result="..."}`) 기준으로 최근 표본은 rotated=47 / grace_replay=8 / replay_suspected=4 /
  expired=2 / invalid=1 이지만, 실패 로그에는 어떤 분기로 떨어졌는지 기록되지 않아 token 단위 재현 분석이 어렵다.

  그 과정에서 `JwtAuthenticationFilter`가 `/api/token/refresh`에 대한 `SecurityConfig`의 `permitAll` 의도를 무효화하는
  잠재 버그가 같이 발견됐다. 현재 운영 메트릭상 주 실패 원인은 아니지만, 만료된 accessToken 쿠키가 동봉된 refresh 요청은
   컨트롤러 진입 전에 401로 끊겨 refresh가 한 번도 시도되지 못하는 경로가 열려 있다.

  ## 어떻게 해결했나요?
  - **AS-IS**
    - `AuthService.refresh` 실패 시 메트릭만 증가. WARN 로그는 없음. 컨트롤러 `[AUTH_REFRESH] result=start` 로그와 상호
  연결할 단서가 없음.
    - `/api/token/refresh`가 `JwtAuthenticationFilter`의 `shouldNotFilter` 목록에 없음. `SecurityConfig:217`에
  `permitAll`이 선언돼 있지만 필터가 먼저 돌면서 만료된 accessToken 쿠키가 있으면 401로 끊음.
  - **TO-BE**
    - `AuthService`의 모든 실패 분기(`jwt_expired`, `jwt_invalid`, `db_expired`, `invalid`, `replay_suspected`)에
  `log.warn("[AUTH_REFRESH] result=fail reason=... refreshFp=... [userId=...]")` 추가. fingerprint는 컨트롤러와 동일
  포맷(SHA-256 앞 8자).
    - `JwtAuthenticationFilter.shouldNotFilter`에 `path.equals("/api/token/refresh")` 한 줄 추가.
  `/api/token/logout/all`은 accessToken으로 userId를 추출하므로 bypass 대상 아님.
  - **리뷰어가 먼저 볼 파일/영역**
    - `service/AuthService.java`의 `refresh`, `validateJwtOrThrow`, `fingerprint`
    - `jwt/JwtAuthenticationFilter.java`의 `shouldNotFilter`

  ## Test plan
  - [ ] 로컬에서 만료된 refresh token으로 `/api/token/refresh` 호출 → `[AUTH_REFRESH] result=fail reason=jwt_expired
  refreshFp=...` 로그가 찍히는지
  - [ ] 존재하지 않는 token으로 호출 → `reason=invalid`
  - [ ] grace 윈도우 지난 옛 token으로 호출 → `reason=replay_suspected`
  - [ ] 만료된 accessToken + 유효한 refreshToken 쿠키 동시 전송 → 필터에서 끊기지 않고 정상 회전되는지 (이 PR의 필터
  수정 검증)
  - [ ] 기존 AuthService/AuthController 테스트가 있으면 green 유지
  - 단위 테스트 신규 추가는 이 PR에 포함하지 않음 (behavior 변경 없음, 로깅/필터 설정만 바뀜)

  ## Rollout / DB / API impact
  - **DB**: 해당 없음
  - **API 계약**: 변경 없음. 에러 코드(`INVALID_REFRESH_TOKEN`, `REFRESH_TOKEN_EXPIRED`), 응답 body, HTTP status 모두
  그대로
  - **메트릭**: 이름/태그 변경 없음 (`auth_refresh_total{result}` 유지)
  - **로그 볼륨**: 실패 경로에만 WARN 추가. 현재 일 5건 내외라 부담 없음
  - **필터 bypass**: 정확히 `/api/token/refresh` 1개 path에만 적용. prefix match 아님
  - **Feature flag / 스케줄러**: 해당 없음

  ## Risks and rollback
  - **리스크**
    - 필터 bypass로 refresh 경로에서 accessToken JWT 검증이 빠진다. 다만 `AuthController.refreshAccessToken`과
  `AuthService.refresh`는 `SecurityContext`와 accessToken 쿠키를 읽지 않는다 (`@CookieValue(name="refreshToken")` 하나만
   사용). `SecurityConfig`에서 이미 `permitAll`이 의도된 경로이므로 의미적 변화는 없음.
    - 로그에 refreshToken fingerprint(SHA-256 앞 8자)가 찍힌다. 원문이 아니며 역산 불가. `logging.md` 기준 민감정보
  아님.
  - **롤백**: 단순 revert. DB/API 변경 없어 backward compat 우려 없음.

  ## Related
  - 원인 분석 대화에서 확정된 우선순위 중 이 PR은 2번(백엔드 진단 로그)과 5번(필터 bypass)만 포함
  - 후속 작업 (별도 PR)
    - 프론트 BFF `/api/auth/refresh`에 refresh fingerprint 로그 추가
    - 프론트 `auth.ts` refresh 실패를 401(실제 invalid) vs 5xx/network로 분기
    - 앱(WebView) `AppState` listener + `CookieManager.flush()` 연동
  - Skill: `review`