### PR TITLE
feat(RecipeBookItemResponse): 레시피북 상세 응답에 검색과 동일한 레시피 메타 필드 추가

### DIFF
--- a/src/main/java/com/jdc/recipe_service/domain/dto/recipebook/RecipeBookItemResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/recipebook/RecipeBookItemResponse.java
@@ -48,9 +48,49 @@ public class RecipeBookItemResponse {
     @Schema(description = "레시피북에 추가된 시간")
     private LocalDateTime addedAt;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    @Schema(description = "레시피 생성 시간")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "즐겨찾기 수", example = "12")
+    private Long favoriteCount;
+
+    @Schema(description = "조리 시간(분)", example = "20")
+    private Integer cookingTime;
+
+    @Schema(description = "유튜브 채널명")
+    private String youtubeChannelName;
+
+    @Schema(description = "유튜브 채널 ID")
+    private String youtubeChannelId;
+
+    @Schema(description = "유튜브 영상 제목")
+    private String youtubeVideoTitle;
+
+    @Schema(description = "유튜브 영상 썸네일 URL")
+    private String youtubeThumbnailUrl;
+
+    @Schema(description = "유튜브 채널 프로필 URL")
+    private String youtubeChannelProfileUrl;
+
+    @Schema(description = "유튜브 구독자 수")
+    private Long youtubeSubscriberCount;
+
+    @Schema(description = "유튜브 영상 조회 수")
+    private Long youtubeVideoViewCount;
+
+    @Schema(description = "유튜브에서 가져온 레시피 여부", example = "false")
+    private boolean isYoutube;
+
+    @Schema(description = "AI가 생성한 레시피 여부", example = "false")
+    private boolean isAiGenerated;
+
     public static RecipeBookItemResponse from(RecipeBookItem item, String imageUrl) {
         Recipe recipe = item.getRecipe();
         User author = recipe.getUser();
+        String youtubeUrl = recipe.getYoutubeUrl();
+        boolean isYoutube = youtubeUrl != null && !youtubeUrl.isEmpty();
+
         return RecipeBookItemResponse.builder()
                 .recipeId(recipe.getId())
                 .title(recipe.getTitle())
@@ -60,6 +100,18 @@ public class RecipeBookItemResponse {
                 .authorName(author != null ? author.getNickname() : null)
                 .profileImage(author != null ? author.getProfileImage() : null)
                 .addedAt(item.getCreatedAt())
+                .createdAt(recipe.getCreatedAt())
+                .favoriteCount(recipe.getFavoriteCount())
+                .cookingTime(recipe.getCookingTime())
+                .youtubeChannelName(recipe.getYoutubeChannelName())
+                .youtubeChannelId(recipe.getYoutubeChannelId())
+                .youtubeVideoTitle(recipe.getYoutubeVideoTitle())
+                .youtubeThumbnailUrl(recipe.getYoutubeThumbnailUrl())
+                .youtubeChannelProfileUrl(recipe.getYoutubeChannelProfileUrl())
+                .youtubeSubscriberCount(recipe.getYoutubeSubscriberCount())
+                .youtubeVideoViewCount(recipe.getYoutubeVideoViewCount())
+                .isYoutube(isYoutube)
+                .isAiGenerated(recipe.isAiGenerated())
                 .build();
     }
 }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
  레시피북 상세 조회(`GET /api/me/recipe-books/{bookId}`)의 각 레시피 항목이 검색(`/api/recipes/search`)보다 훨씬 빈약한
   필드만 내려주고 있어서, 프론트에서 레시피 카드 컴포넌트를 두 엔드포인트에 재사용할 수 없었다. 두 응답의 레시피 항목
  스키마를 정렬해 프론트가 같은 카드로 렌더링할 수 있게 한다.

  ## 어떻게 해결했나요?
  - **AS-IS:** `RecipeBookItemResponse`가 `recipeId, title, imageUrl, dishType, authorId, authorName, profileImage,
  addedAt` 8개 필드만 노출
  - **TO-BE:** 검색 응답(`RecipeSimpleDto`)과 맞추기 위해 11개 필드를 추가. `createdAt`, `favoriteCount`, `cookingTime`,
   `youtubeChannelName`, `youtubeChannelId`, `youtubeVideoTitle`, `youtubeThumbnailUrl`, `youtubeChannelProfileUrl`,
  `youtubeSubscriberCount`, `youtubeVideoViewCount`, `isYoutube`(계산값: `youtubeUrl != null && !isEmpty`),
  `isAiGenerated`.
  - 좋아요·별점 기능이 제거되어 `likeCount`, `likedByCurrentUser`, `avgRating`, `ratingCount` 4개는 **의도적으로 제외**.
  - 리뷰어가 먼저 볼 파일: `domain/dto/recipebook/RecipeBookItemResponse.java` 단일 파일.

  ## Test plan
  - [ ] `GET /api/me/recipe-books/{bookId}` 호출 시 items[]의 각 항목에 추가 필드 11개가 내려오는지 확인
  - [ ] 유튜브에서 임포트한 레시피가 섞인 북에서 `isYoutube: true`와 youtube* 필드가 채워지는지 확인
  - [ ] 일반 레시피는 `isYoutube: false`, youtube* 필드가 `null`인지 확인
  - [ ] AI 생성 레시피가 섞인 경우 `isAiGenerated: true` 노출 확인
  - [ ] `addedAt`(레시피북에 담은 시각)과 `createdAt`(레시피 생성 시각)이 구분되어 내려오는지 확인

  ## Rollout / DB / API impact
  - **DB:** 해당 없음 (스키마/쿼리 변경 없음).
  - **API:** non-breaking. optional 필드 11개 추가만 발생. 기존 프론트는 새 필드를 무시하면 기존 동작 유지.
  - **쿼리 영향:** 기존 `@EntityGraph(recipe, recipe.user)` 페치에 모든 소스 컬럼이 이미 포함되어 있어 추가 쿼리·N+1
  없음.
  - **필드명 주의:** Jackson 기본 규칙으로 JSON 키가 `youtube`, `aiGenerated`로 나간다(`boolean isXxx` + `isXxx()`
  getter 관례). 기존 응답 스타일을 그대로 유지하기로 한 의사결정이며, 검색 응답(`isYoutube`, `isAiGenerated`)과는 키
  네이밍이 다르다는 점을 프론트에 공유 필요.
  - feature flag / 스케줄러: 해당 없음.

  ## Risks and rollback
  - optional 필드 추가만 있어 롤백은 단순 revert로 충분.
  - 검색 응답과 JSON 키가 다르므로(`youtube` vs `isYoutube`, `aiGenerated` vs `isAiGenerated`) 프론트가 두 엔드포인트를
  동일 로직으로 소비할 때 분기 필요. 추후 통일을 원하면 `@JsonProperty`로 맞추는 후속 PR로 진행.

  ## Related
  - 관련 이전 PR: `f46e9a9 feat(RecipeBookItemResponse): 레시피북 상세 응답에 작성자 정보 노출`
  - Skill: `git-workflow`, `api-contract-docs`(계약 추가이나 non-breaking)