### PR TITLE
fix(global): 배포 전 auth, recipe, dev 생성 흐름 보정

### DIFF
--- a/src/main/java/com/jdc/recipe_service/controller/AuthController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/AuthController.java
@@ -108,7 +108,7 @@ public class AuthController {
         var accessBuilder = ResponseCookie.from("accessToken", result.getAccessToken())
                 .path("/")
                 .httpOnly(true)
-                .maxAge(15 * 60)
+                .maxAge(jwtTokenProvider.getAccessTokenValidityInSeconds())
                 .sameSite("Lax");
 
         if (!isLocalRequest) {
@@ -198,7 +198,7 @@ public class AuthController {
 
         savedToken.setUser(testUser);
         savedToken.setToken(refreshToken);
-        savedToken.setExpiredAt(LocalDateTime.now().plusDays(7));
+        savedToken.setExpiredAt(jwtTokenProvider.getRefreshTokenExpiryAsLocalDateTime());
         refreshTokenRepository.save(savedToken);
 
         String origin = request.getHeader("Origin");
@@ -207,12 +207,12 @@ public class AuthController {
         var refreshBuilder = ResponseCookie.from("refreshToken", refreshToken)
                 .path("/")
                 .httpOnly(true)
-                .maxAge(7 * 24 * 60 * 60)
+                .maxAge(jwtTokenProvider.getRefreshTokenValidityInSeconds())
                 .sameSite("Lax");
         var accessBuilder  = ResponseCookie.from("accessToken", accessToken)
                 .path("/")
                 .httpOnly(true)
-                .maxAge(15 * 60)
+                .maxAge(jwtTokenProvider.getAccessTokenValidityInSeconds())
                 .sameSite("Lax");
 
         if (!isLocalRequest) {

--- a/src/main/java/com/jdc/recipe_service/controller/LocalAuthController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/LocalAuthController.java
@@ -40,14 +40,14 @@ public class LocalAuthController {
                 .path("/")
                 .httpOnly(true)
                 .sameSite("Lax")
-                .maxAge(60 * 60)
+                .maxAge(jwtTokenProvider.getAccessTokenValidityInSeconds())
                 .build();
 
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
                 .path("/")
                 .httpOnly(true)
                 .sameSite("Lax")
-                .maxAge(60 * 60 * 24 * 7)
+                .maxAge(jwtTokenProvider.getRefreshTokenValidityInSeconds())
                 .build();
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/jdc/recipe_service/controller/OAuthController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/OAuthController.java
@@ -2,6 +2,7 @@ package com.jdc.recipe_service.controller;
 
 import com.jdc.recipe_service.domain.dto.auth.AuthTokens;
 import com.jdc.recipe_service.domain.dto.auth.CodeDto;
+import com.jdc.recipe_service.jwt.JwtTokenProvider;
 import com.jdc.recipe_service.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class OAuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/login/oauth2/code/{provider}")
     public ResponseEntity<Void> oauthCallback(
@@ -35,13 +37,13 @@ public class OAuthController {
                 .path("/")
                 .httpOnly(true)
                 .sameSite("Lax")
-                .maxAge(15 * 60);
+                .maxAge(jwtTokenProvider.getAccessTokenValidityInSeconds());
 
         var refreshB = ResponseCookie.from("refreshToken", tokens.getRefreshToken())
                 .path("/")
                 .httpOnly(true)
                 .sameSite("Lax")
-                .maxAge(7 * 24 * 60 * 60);
+                .maxAge(jwtTokenProvider.getRefreshTokenValidityInSeconds());
 
         if ("prod".equalsIgnoreCase(env)) {
             accessB.secure(true).domain(".recipio.kr");

--- a/src/main/java/com/jdc/recipe_service/dev/domain/dto/recipe/DevMyRecipeSummaryDto.java
+++ b/src/main/java/com/jdc/recipe_service/dev/domain/dto/recipe/DevMyRecipeSummaryDto.java
@@ -54,4 +54,7 @@ public class DevMyRecipeSummaryDto {
 
     @Schema(description = "source", example = "USER")
     private String source;
+
+    @Schema(description = "이미지 생성 상태. owner 목록에서는 PENDING/FAILED도 내려올 수 있음", example = "READY")
+    private String imageStatus;
 }

--- a/src/main/java/com/jdc/recipe_service/dev/facade/DevAiRecipeFacade.java
+++ b/src/main/java/com/jdc/recipe_service/dev/facade/DevAiRecipeFacade.java
@@ -18,7 +18,9 @@ import com.jdc.recipe_service.domain.type.AiRecipeConcept;
 import com.jdc.recipe_service.domain.type.JobStatus;
 import com.jdc.recipe_service.domain.type.JobType;
 import com.jdc.recipe_service.domain.type.QuotaType;
+import com.jdc.recipe_service.domain.type.RecipeImageStatus;
 import com.jdc.recipe_service.domain.type.recipe.RecipeSourceType;
+import com.jdc.recipe_service.domain.type.recipe.RecipeVisibility;
 import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.service.DailyQuotaService;
@@ -280,6 +282,7 @@ public class DevAiRecipeFacade {
 
             log.info("⏱️ [DevAi V3] 이미지 생성 소요: {}ms", System.currentTimeMillis() - imageGenStart);
 
+            markImageFailedIfStillPending(recipeId, imageGenModel);
             job.setResultRecipeId(recipeId);
             updateProgress(job, JobStatus.COMPLETED, 100);
 
@@ -324,6 +327,21 @@ public class DevAiRecipeFacade {
     public void updateProgress(RecipeGenerationJob job, JobStatus status, int progress) {
         job.updateProgress(status, progress);
         jobRepository.saveAndFlush(job);
+    }
+
+    private void markImageFailedIfStillPending(Long recipeId, String imageGenModel) {
+        transactionTemplate.executeWithoutResult(status -> {
+            recipeRepository.findById(recipeId).ifPresent(recipe -> {
+                RecipeImageStatus current = recipe.getImageStatus();
+                if (current != null && current != RecipeImageStatus.PENDING) {
+                    return;
+                }
+                recipe.updateImageKey(AsyncImageService.DEFAULT_IMAGE_KEY);
+                recipe.updateImageStatus(RecipeImageStatus.FAILED);
+                recipe.updateImageGenerationModel(imageGenModel);
+                recipe.applyVisibility(RecipeVisibility.PUBLIC);
+            });
+        });
     }
 
     // --- private helpers (V2와 동일) ---

--- a/src/main/java/com/jdc/recipe_service/dev/facade/DevYoutubeRecipeExtractionFacade.java
+++ b/src/main/java/com/jdc/recipe_service/dev/facade/DevYoutubeRecipeExtractionFacade.java
@@ -245,10 +245,7 @@ public class DevYoutubeRecipeExtractionFacade {
             // 7. 이미지 생성 — DevImageGenRouterService로 모델 라우팅
             updateProgress(job, JobStatus.IN_PROGRESS, 60);
             String imageUrl = generateImageWithRouter(result.recipeDto(), imageGenModel, videoId);
-            if (imageUrl != null && !imageUrl.isBlank()) {
-                result.recipeDto().setImageKey(YoutubeExtractionHelpers.extractS3Key(imageUrl));
-                result.recipeDto().setImageStatus(RecipeImageStatus.READY);
-            }
+            applyImageGenerationResult(result.recipeDto(), imageUrl);
 
             // 8. legacy Recipe.youtube* 필드 dual-write (운영 V1/V2 호환)
             applyYoutubeFieldsToDto(result.recipeDto(), videoId, videoData);
@@ -417,6 +414,17 @@ public class DevYoutubeRecipeExtractionFacade {
                     YoutubeExtractionHelpers.safeMsg(e));
             return null;
         }
+    }
+
+    private void applyImageGenerationResult(RecipeCreateRequestDto dto, String imageUrl) {
+        if (imageUrl != null && !imageUrl.isBlank()) {
+            dto.setImageKey(YoutubeExtractionHelpers.extractS3Key(imageUrl));
+            dto.setImageStatus(RecipeImageStatus.READY);
+            return;
+        }
+
+        dto.setImageKey(AsyncImageService.DEFAULT_IMAGE_KEY);
+        dto.setImageStatus(RecipeImageStatus.FAILED);
     }
 
     /**

--- a/src/main/java/com/jdc/recipe_service/dev/repository/recipe/DevUserRecipesQueryRepository.java
+++ b/src/main/java/com/jdc/recipe_service/dev/repository/recipe/DevUserRecipesQueryRepository.java
@@ -20,6 +20,9 @@ import java.util.List;
  * 운영의 owner-all-visible 정책과 다름 — dev V3는 ACTIVE에 한정. invariant 일관성 우선.
  *
  * imageReady (READY 또는 null + AI는 imageKey 필수) 조건은 운영 패턴 그대로.
+ *
+ * Owner image policy: non-owner/anonymous keep imageReady filters, but owner lists include PENDING/FAILED
+ * and imageKey-null rows so generation failures are visible in "my recipes".
  */
 public interface DevUserRecipesQueryRepository {
 

--- a/src/main/java/com/jdc/recipe_service/dev/repository/recipe/DevUserRecipesQueryRepositoryImpl.java
+++ b/src/main/java/com/jdc/recipe_service/dev/repository/recipe/DevUserRecipesQueryRepositoryImpl.java
@@ -39,13 +39,18 @@ public class DevUserRecipesQueryRepositoryImpl implements DevUserRecipesQueryRep
                                                    @Nullable List<RecipeSourceType> sourceTypes,
                                                    Pageable pageable) {
         QRecipe recipe = QRecipe.recipe;
+        boolean ownerView = viewerId != null && viewerId.equals(targetUserId);
 
         BooleanExpression whereClause = recipe.user.id.eq(targetUserId)
-                .and(DevRecipeQueryPredicates.accessibleBy(recipe, viewerId))
-                // 운영 "completed recipes" 조건: AI는 imageKey 없으면 noisy(생성 중) → 차단
-                .and(recipe.isAiGenerated.isFalse().or(recipe.imageKey.isNotNull()))
-                // imageReady — A2/A3 정합. PENDING/FAILED는 dev 노출 차단 (인터페이스 javadoc 정합).
-                .and(recipe.imageStatus.eq(RecipeImageStatus.READY).or(recipe.imageStatus.isNull()));
+                .and(DevRecipeQueryPredicates.accessibleBy(recipe, viewerId));
+
+        // Owner should see in-progress/failed image generation rows in "my recipes".
+        // Public profile viewers only see displayable recipes.
+        if (!ownerView) {
+            whereClause = whereClause
+                    .and(recipe.isAiGenerated.isFalse().or(recipe.imageKey.isNotNull()))
+                    .and(recipe.imageStatus.eq(RecipeImageStatus.READY).or(recipe.imageStatus.isNull()));
+        }
 
         if (sourceTypes != null && !sourceTypes.isEmpty()) {
             whereClause = whereClause.and(recipe.source.in(sourceTypes));

--- a/src/main/java/com/jdc/recipe_service/dev/service/user/DevUserRecipesService.java
+++ b/src/main/java/com/jdc/recipe_service/dev/service/user/DevUserRecipesService.java
@@ -89,6 +89,7 @@ public class DevUserRecipesService {
                 .listingStatus(recipe.getListingStatus() != null ? recipe.getListingStatus().name() : null)
                 .lifecycleStatus(recipe.getLifecycleStatus() != null ? recipe.getLifecycleStatus().name() : null)
                 .source(recipe.getSource() != null ? recipe.getSource().name() : null)
+                .imageStatus(recipe.getImageStatus() != null ? recipe.getImageStatus().name() : null)
                 .build());
     }
 }

--- a/src/main/java/com/jdc/recipe_service/domain/repository/IngredientCandidateRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/IngredientCandidateRepository.java
@@ -2,6 +2,9 @@ package com.jdc.recipe_service.domain.repository;
 
 import com.jdc.recipe_service.domain.entity.IngredientCandidate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -16,4 +19,8 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface IngredientCandidateRepository extends JpaRepository<IngredientCandidate, Long> {
+
+    @Modifying(flushAutomatically = true)
+    @Query("UPDATE IngredientCandidate c SET c.sourceRecipeId = null WHERE c.sourceRecipeId = :recipeId")
+    int clearSourceRecipeId(@Param("recipeId") Long recipeId);
 }

--- a/src/main/java/com/jdc/recipe_service/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/jdc/recipe_service/jwt/JwtTokenProvider.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -73,6 +74,14 @@ public class JwtTokenProvider {
         return Instant.ofEpochMilli(expiryDate.getTime())
                 .atZone(ZoneId.systemDefault())
                 .toLocalDateTime();
+    }
+
+    public long getAccessTokenValidityInSeconds() {
+        return Math.max(Duration.ofMillis(accessTokenValidityInMilliseconds).getSeconds(), 0L);
+    }
+
+    public long getRefreshTokenValidityInSeconds() {
+        return Math.max(Duration.ofMillis(refreshTokenValidityInMilliseconds).getSeconds(), 0L);
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/jdc/recipe_service/security/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -18,7 +18,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.net.URI;
-import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
 
@@ -44,7 +43,7 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
         refreshTokenRepository.save(RefreshToken.builder()
                 .user(oAuth2User.getUser())
                 .token(refreshToken)
-                .expiredAt(LocalDateTime.now().plusDays(7))
+                .expiredAt(jwtTokenProvider.getRefreshTokenExpiryAsLocalDateTime())
                 .build());
 
         List<RefreshToken> tokens = refreshTokenRepository
@@ -82,7 +81,7 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
                     .path("/")
                     .httpOnly(true)
                     .secure(true)
-                    .maxAge(7 * 24 * 60 * 60)
+                    .maxAge(jwtTokenProvider.getRefreshTokenValidityInSeconds())
                     .sameSite("Lax")
                     .domain(".recipio.kr")
                     .build();
@@ -90,7 +89,7 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
                     .path("/")
                     .httpOnly(true)
                     .secure(true)
-                    .maxAge(15 * 60)
+                    .maxAge(jwtTokenProvider.getAccessTokenValidityInSeconds())
                     .sameSite("Lax")
                     .domain(".recipio.kr")
                     .build();

--- a/src/main/java/com/jdc/recipe_service/service/AdminRecipeService.java
+++ b/src/main/java/com/jdc/recipe_service/service/AdminRecipeService.java
@@ -40,6 +40,9 @@ public class AdminRecipeService {
     private final RecipeLikeService recipeLikeService;
     private final RecipeFavoriteService recipeFavoriteService;
     private final CommentService commentService;
+    private final RecipeRatingRepository recipeRatingRepository;
+    private final CookingRecordRepository cookingRecordRepository;
+    private final IngredientCandidateRepository ingredientCandidateRepository;
     private final RecipeRepository recipeRepository;
     private final UserRepository userRepository;
     private final S3Util s3Util;
@@ -176,9 +179,12 @@ public class AdminRecipeService {
         recipeLikeService.deleteByRecipeId(recipeId);
         recipeFavoriteService.deleteByRecipeId(recipeId);
         commentService.deleteAllByRecipeId(recipeId);
+        recipeRatingRepository.deleteByRecipeId(recipeId);
+        cookingRecordRepository.deleteByRecipeId(recipeId);
         recipeStepService.deleteAllByRecipeId(recipeId);
         recipeIngredientService.deleteAllByRecipeId(recipeId);
         recipeTagService.deleteAllByRecipeId(recipeId);
+        ingredientCandidateRepository.clearSourceRecipeId(recipeId);
 
         recipeRepository.delete(recipe);
         return recipeId;

--- a/src/main/java/com/jdc/recipe_service/service/RecipeService.java
+++ b/src/main/java/com/jdc/recipe_service/service/RecipeService.java
@@ -52,6 +52,8 @@ public class RecipeService {
     private final CommentService commentService;
     private final RecipeImageService recipeImageService;
     private final RecipeLikeService recipeLikeService;
+    private final CookingRecordRepository cookingRecordRepository;
+    private final IngredientCandidateRepository ingredientCandidateRepository;
     private final RecipeIndexingService recipeIndexingService;
     private final S3Util s3Util;
     private final EntityManager em;
@@ -450,21 +452,15 @@ public class RecipeService {
         validateOwnership(recipe, userId);
 
         recipeImageService.deleteImagesByRecipeId(recipeId);
-
-        /*recipeLikeService.deleteByRecipeId(recipeId);
-
+        recipeLikeService.deleteByRecipeId(recipeId);
         recipeFavoriteService.deleteByRecipeId(recipeId);
-
         commentService.deleteAllByRecipeId(recipeId);
-
         recipeRatingRepository.deleteByRecipeId(recipeId);
-
+        cookingRecordRepository.deleteByRecipeId(recipeId);
         recipeStepService.deleteAllByRecipeId(recipeId);
-
         recipeIngredientService.deleteAllByRecipeId(recipeId);
-
         recipeTagService.deleteAllByRecipeId(recipeId);
-        */
+        ingredientCandidateRepository.clearSourceRecipeId(recipeId);
 
         recipeRepository.deleteByIdDirectly(recipeId);
 

--- a/src/main/java/com/jdc/recipe_service/service/image/AsyncImageService.java
+++ b/src/main/java/com/jdc/recipe_service/service/image/AsyncImageService.java
@@ -51,7 +51,7 @@ public class AsyncImageService {
     private final Hashids hashids;
 
     private final TransactionTemplate transactionTemplate;
-    private static final String DEFAULT_IMAGE_KEY =
+    public static final String DEFAULT_IMAGE_KEY =
             "images/icons/no_image.webp";
     private static final List<String> LIGHTING_OPTIONS = List.of(
             "Natural morning sunlight streaming through a kitchen window (Bright & Fresh)",

--- a/src/test/java/com/jdc/recipe_service/dev/facade/DevAiRecipeFacadeTest.java
+++ b/src/test/java/com/jdc/recipe_service/dev/facade/DevAiRecipeFacadeTest.java
@@ -14,8 +14,10 @@ import com.jdc.recipe_service.domain.entity.recipe.RecipeGenerationJob;
 import com.jdc.recipe_service.domain.repository.RecipeGenerationJobRepository;
 import com.jdc.recipe_service.domain.repository.RecipeRepository;
 import com.jdc.recipe_service.domain.type.AiRecipeConcept;
+import com.jdc.recipe_service.domain.type.RecipeImageStatus;
 import com.jdc.recipe_service.domain.type.QuotaType;
 import com.jdc.recipe_service.domain.type.recipe.RecipeSourceType;
+import com.jdc.recipe_service.domain.type.recipe.RecipeVisibility;
 import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.service.DailyQuotaService;
@@ -39,6 +41,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -50,6 +53,7 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -361,6 +365,61 @@ class DevAiRecipeFacadeTest {
         assertThat(generatedDto.getSteps().get(0).getIngredients())
                 .as("원본 step의 ingredients도 보존")
                 .containsExactly(rawStepIng);
+    }
+
+    @Test
+    @DisplayName("이미지 생성 실패: PENDING recipe를 FAILED/default image로 확정한 뒤 job COMPLETED")
+    @SuppressWarnings("unchecked")
+    void asyncImageFailure_marksRecipeFailedBeforeJobCompleted() {
+        Long jobId = 301L;
+        Long recipeId = 1000L;
+        RecipeGenerationJob job = mockJob(jobId);
+        given(jobRepository.findById(jobId)).willReturn(Optional.of(job));
+        given(surveyService.getSurvey(USER_ID)).willReturn(null);
+        given(ingredientBuilder.buildPrompt(any())).willReturn("system-prompt");
+
+        RecipeIngredientRequestDto rawIng = RecipeIngredientRequestDto.builder()
+                .name("양파").quantity("1").customUnit("개").build();
+
+        RecipeCreateRequestDto generatedDto = new RecipeCreateRequestDto();
+        generatedDto.setTitle("AI recipe");
+        generatedDto.setIngredients(new ArrayList<>(List.of(rawIng)));
+        generatedDto.setSteps(new ArrayList<>());
+
+        given(grokClientService.generateRecipeJson(any(), any()))
+                .willReturn(CompletableFuture.completedFuture(generatedDto));
+
+        given(transactionTemplate.execute(any())).willAnswer(inv -> {
+            TransactionCallback<Long> cb = inv.getArgument(0);
+            return cb.doInTransaction(null);
+        });
+        org.mockito.Mockito.doAnswer(inv -> {
+            Consumer<TransactionStatus> cb = inv.getArgument(0);
+            cb.accept(null);
+            return null;
+        }).when(transactionTemplate).executeWithoutResult(any());
+
+        PresignedUrlResponse savedResponse = mock(PresignedUrlResponse.class);
+        given(savedResponse.getRecipeId()).willReturn(recipeId);
+        given(recipeService.createRecipeAndGenerateUrls(
+                any(RecipeWithImageUploadRequest.class), eq(USER_ID), eq(RecipeSourceType.AI), any()))
+                .willReturn(savedResponse);
+
+        Recipe recipeEntity = mock(Recipe.class);
+        given(recipeEntity.getImageStatus()).willReturn(RecipeImageStatus.PENDING);
+        given(recipeRepository.findById(recipeId)).willReturn(Optional.of(recipeEntity));
+        given(asyncImageService.generateAndUploadAiImage(recipeId, true, VALID_MODEL))
+                .willThrow(new RuntimeException("image down"));
+
+        facade.processAiGenerationAsync(jobId, validRequest, AiRecipeConcept.INGREDIENT_FOCUS,
+                VALID_MODEL, USER_ID, /* usedToken= */ true);
+
+        verify(recipeEntity).updateImageKey(AsyncImageService.DEFAULT_IMAGE_KEY);
+        verify(recipeEntity).updateImageStatus(RecipeImageStatus.FAILED);
+        verify(recipeEntity).updateImageGenerationModel(VALID_MODEL);
+        verify(recipeEntity).applyVisibility(RecipeVisibility.PUBLIC);
+        assertThat(job.getStatus()).isEqualTo(com.jdc.recipe_service.domain.type.JobStatus.COMPLETED);
+        assertThat(job.getResultRecipeId()).isEqualTo(recipeId);
     }
 
     private RecipeGenerationJob mockJob(Long id) {

--- a/src/test/java/com/jdc/recipe_service/dev/facade/DevYoutubeRecipeExtractionFacadeTest.java
+++ b/src/test/java/com/jdc/recipe_service/dev/facade/DevYoutubeRecipeExtractionFacadeTest.java
@@ -3,9 +3,11 @@ package com.jdc.recipe_service.dev.facade;
 import com.jdc.recipe_service.dev.facade.DevYoutubeRecipeExtractionFacade.JobCreateResult;
 import com.jdc.recipe_service.dev.service.image.DevImageGenRouterService;
 import com.jdc.recipe_service.dev.service.quota.DevYoutubeQuotaService;
+import com.jdc.recipe_service.dev.service.recipe.ingredient.DevRecipeIngredientPersistService;
 import com.jdc.recipe_service.dev.service.youtube.YoutubeSignalDetector;
 import com.jdc.recipe_service.domain.dto.recipe.RecipeCreateRequestDto;
 import com.jdc.recipe_service.domain.dto.recipe.ingredient.RecipeIngredientRequestDto;
+import com.jdc.recipe_service.domain.dto.url.PresignedUrlResponse;
 import com.jdc.recipe_service.domain.entity.Recipe;
 import com.jdc.recipe_service.domain.entity.media.RecipeYoutubeInfo;
 import com.jdc.recipe_service.domain.entity.recipe.RecipeGenerationJob;
@@ -13,6 +15,9 @@ import com.jdc.recipe_service.domain.repository.RecipeGenerationJobRepository;
 import com.jdc.recipe_service.domain.repository.RecipeRepository;
 import com.jdc.recipe_service.domain.repository.meta.RecipeYoutubeExtractionInfoRepository;
 import com.jdc.recipe_service.domain.repository.meta.RecipeYoutubeInfoRepository;
+import com.jdc.recipe_service.domain.type.RecipeImageStatus;
+import com.jdc.recipe_service.domain.type.media.EvidenceLevel;
+import com.jdc.recipe_service.domain.type.recipe.RecipeSourceType;
 import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.service.RecipeService;
@@ -28,6 +33,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -84,6 +90,7 @@ class DevYoutubeRecipeExtractionFacadeTest {
     @Mock RecipeGenerationJobRepository jobRepository;
     @Mock RecipeYoutubeInfoRepository recipeYoutubeInfoRepository;
     @Mock RecipeYoutubeExtractionInfoRepository extractionInfoRepository;
+    @Mock DevRecipeIngredientPersistService devIngredientPersist;
     @Mock TransactionTemplate transactionTemplate;
 
     @InjectMocks DevYoutubeRecipeExtractionFacade facade;
@@ -233,6 +240,71 @@ class DevYoutubeRecipeExtractionFacadeTest {
             cb.accept(null);
             return null;
         }).when(transactionTemplate).executeWithoutResult(any());
+    }
+
+    @Test
+    @DisplayName("이미지 생성 실패: recipe는 FAILED/default image로 저장한 뒤 job COMPLETED")
+    @SuppressWarnings("unchecked")
+    void async_imageGenerationFails_savesFailedImageAndCompletesJob() {
+        Long jobId = 120L;
+        Long recipeId = 700L;
+        LocalDate consumedOn = LocalDate.of(2026, 4, 30);
+        RecipeGenerationJob job = mockJobWithCost(jobId, DevYoutubeQuotaService.COST_BASIC, consumedOn);
+        given(jobRepository.findById(jobId)).willReturn(Optional.of(job));
+        stubTransactionTemplate();
+        given(transactionTemplate.execute(any())).willAnswer(inv -> {
+            TransactionCallback<Long> cb = inv.getArgument(0);
+            return cb.doInTransaction(null);
+        });
+
+        given(recipeYoutubeInfoRepository.findByVideoId(VIDEO_ID)).willReturn(Optional.empty());
+        given(recipeRepository.findFirstOfficialByYoutubeUrl(any(), any())).willReturn(Optional.empty());
+
+        YtDlpService.YoutubeFullDataDto data = new YtDlpService.YoutubeFullDataDto(
+                VIDEO_ID, "", "title", "description with ingredients",
+                "", "scriptTimecoded", "scriptPlain",
+                "channel", "channelId", "thumbnail", "profile", 100L, 200L, 300L);
+        given(ytDlpService.getVideoDataFull(VALID_URL)).willReturn(data);
+
+        YoutubeSignalDetector.SignalReport signals =
+                new YoutubeSignalDetector.SignalReport(true, true, false);
+        given(signalDetector.detectSignals(any(), any(), any())).willReturn(signals);
+        given(signalDetector.computeEvidence(signals, false)).willReturn(EvidenceLevel.HIGH);
+
+        RecipeCreateRequestDto dto = new RecipeCreateRequestDto();
+        dto.setIsRecipe(true);
+        dto.setTitle("youtube recipe");
+        dto.setIngredients(List.of(
+                ing("감자", "1", "개"),
+                ing("양파", "1", "개"),
+                ing("소금", "1", "작은술")));
+        given(grokClientService.generateRecipeStep1(any(), any()))
+                .willReturn(CompletableFuture.completedFuture(dto));
+
+        given(asyncImageService.buildPromptFromDto(any())).willReturn("image prompt");
+        given(devImageGenRouterService.generate(any(), any(), any(), any())).willReturn(List.of());
+
+        PresignedUrlResponse response = PresignedUrlResponse.builder()
+                .recipeId(recipeId)
+                .uploads(List.of())
+                .build();
+        given(recipeService.createRecipeAndGenerateUrls(
+                any(), eq(90121L), eq(RecipeSourceType.YOUTUBE), any()))
+                .willReturn(response);
+        Recipe recipe = mock(Recipe.class);
+        given(recipeRepository.findById(recipeId)).willReturn(Optional.of(recipe));
+
+        facade.processYoutubeExtractionAsync(jobId, VALID_URL, VALID_MODEL, USER_ID);
+
+        ArgumentCaptor<com.jdc.recipe_service.domain.dto.recipe.RecipeWithImageUploadRequest> requestCaptor =
+                ArgumentCaptor.forClass(com.jdc.recipe_service.domain.dto.recipe.RecipeWithImageUploadRequest.class);
+        verify(recipeService).createRecipeAndGenerateUrls(
+                requestCaptor.capture(), eq(90121L), eq(RecipeSourceType.YOUTUBE), any());
+        RecipeCreateRequestDto savedDto = requestCaptor.getValue().getRecipe();
+        assertThat(savedDto.getImageStatus()).isEqualTo(RecipeImageStatus.FAILED);
+        assertThat(savedDto.getImageKey()).isEqualTo(AsyncImageService.DEFAULT_IMAGE_KEY);
+        assertThat(job.getStatus()).isEqualTo(com.jdc.recipe_service.domain.type.JobStatus.COMPLETED);
+        assertThat(job.getResultRecipeId()).isEqualTo(recipeId);
     }
 
     private RecipeGenerationJob mockJobWithCost(Long jobId, int tokenCost) {

--- a/src/test/java/com/jdc/recipe_service/dev/repository/recipe/DevUserRecipesQueryRepositoryImplTest.java
+++ b/src/test/java/com/jdc/recipe_service/dev/repository/recipe/DevUserRecipesQueryRepositoryImplTest.java
@@ -135,7 +135,7 @@ class DevUserRecipesQueryRepositoryImplTest {
                 RecipeListingStatus.LISTED, RecipeImageStatus.READY, false, null);
         em.flush(); em.clear();
 
-        Page<Recipe> result = repo.findUserRecipesAccessible(owner.getId(), owner.getId(), null, PAGE_10);
+        Page<Recipe> result = repo.findUserRecipesAccessible(owner.getId(), other.getId(), null, PAGE_10);
 
         assertThat(result.getContent()).extracting(Recipe::getTitle)
                 .containsExactlyInAnyOrder("ai-with-image", "user-noimage");
@@ -154,7 +154,7 @@ class DevUserRecipesQueryRepositoryImplTest {
                 RecipeListingStatus.LISTED, RecipeImageStatus.FAILED, false, null);
         em.flush(); em.clear();
 
-        Page<Recipe> result = repo.findUserRecipesAccessible(owner.getId(), owner.getId(), null, PAGE_10);
+        Page<Recipe> result = repo.findUserRecipesAccessible(owner.getId(), other.getId(), null, PAGE_10);
 
         assertThat(result.getContent()).extracting(Recipe::getTitle)
                 .containsExactlyInAnyOrder("ready", "nullImage");
@@ -162,7 +162,27 @@ class DevUserRecipesQueryRepositoryImplTest {
     }
 
     @Test
-    @DisplayName("source filter: sourceTypes 명시 시 IN 절로 추가 필터")
+    @DisplayName("owner 목록: PENDING/FAILED와 AI imageKey=null도 숨기지 않는다")
+    void owner_includesUnreadyAndAiWithoutImageKey() {
+        persistRecipeWithFlags(owner, "ai-noimage", RecipeLifecycleStatus.ACTIVE, RecipeVisibility.PUBLIC,
+                RecipeListingStatus.LISTED, RecipeImageStatus.PENDING, true, null);
+        persistRecipeWithFlags(owner, "pending", RecipeLifecycleStatus.ACTIVE, RecipeVisibility.PUBLIC,
+                RecipeListingStatus.LISTED, RecipeImageStatus.PENDING, false, null);
+        persistRecipeWithFlags(owner, "failed", RecipeLifecycleStatus.ACTIVE, RecipeVisibility.PUBLIC,
+                RecipeListingStatus.LISTED, RecipeImageStatus.FAILED, false, null);
+        persistRecipeWithFlags(owner, "ready", RecipeLifecycleStatus.ACTIVE, RecipeVisibility.PUBLIC,
+                RecipeListingStatus.LISTED, RecipeImageStatus.READY, false, "ready.webp");
+        em.flush(); em.clear();
+
+        Page<Recipe> result = repo.findUserRecipesAccessible(owner.getId(), owner.getId(), null, PAGE_10);
+
+        assertThat(result.getContent()).extracting(Recipe::getTitle)
+                .containsExactlyInAnyOrder("ai-noimage", "pending", "failed", "ready");
+        assertThat(result.getTotalElements()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("source filter: sourceTypes IN filter")
     void sourceFilter_appliesInClause() {
         persistWithSource(owner, "user-recipe", RecipeSourceType.USER);
         persistWithSource(owner, "ai-recipe", RecipeSourceType.AI);

--- a/src/test/java/com/jdc/recipe_service/dev/service/user/DevUserRecipesServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/dev/service/user/DevUserRecipesServiceTest.java
@@ -8,6 +8,7 @@ import com.jdc.recipe_service.domain.entity.User;
 import com.jdc.recipe_service.domain.repository.RecipeLikeRepository;
 import com.jdc.recipe_service.domain.repository.UserRepository;
 import com.jdc.recipe_service.domain.type.DishType;
+import com.jdc.recipe_service.domain.type.RecipeImageStatus;
 import com.jdc.recipe_service.domain.type.recipe.RecipeLifecycleStatus;
 import com.jdc.recipe_service.domain.type.recipe.RecipeListingStatus;
 import com.jdc.recipe_service.domain.type.recipe.RecipeSourceType;
@@ -143,6 +144,7 @@ class DevUserRecipesServiceTest {
                 .source(RecipeSourceType.AI)
                 .isAiGenerated(true)
                 .imageKey("ai.webp")  // AI는 imageKey 있어야 service 변환 정상 (service 자체는 통과시키지만 의미상)
+                .imageStatus(RecipeImageStatus.FAILED)
                 .isPrivate(false)
                 .build();
         ReflectionTestUtils.setField(restricted, "id", 999L);
@@ -159,6 +161,7 @@ class DevUserRecipesServiceTest {
         assertThat(dto.getListingStatus()).isEqualTo("UNLISTED");
         assertThat(dto.getLifecycleStatus()).isEqualTo("ACTIVE");
         assertThat(dto.getSource()).isEqualTo("AI");
+        assertThat(dto.getImageStatus()).isEqualTo("FAILED");
         // V1 base 필드 매핑 — isAiGenerated가 true로 정확히 전파
         assertThat(dto.getId()).isEqualTo(999L);
         assertThat(dto.isAiGenerated()).isTrue();

--- a/src/test/java/com/jdc/recipe_service/service/AdminRecipeServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/AdminRecipeServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -44,8 +45,44 @@ class AdminRecipeServiceTest {
     @Mock private RecipeLikeService recipeLikeService;
     @Mock private RecipeFavoriteService recipeFavoriteService;
     @Mock private CommentService commentService;
+    @Mock private RecipeRatingRepository recipeRatingRepository;
+    @Mock private CookingRecordRepository cookingRecordRepository;
+    @Mock private IngredientCandidateRepository ingredientCandidateRepository;
     @Mock private UserRepository userRepository;
     @Mock private com.jdc.recipe_service.util.S3Util s3Util;
+
+    @Test
+    @DisplayName("deleteRecipe: 관리자는 연관 데이터를 정리한 뒤 레시피를 삭제한다")
+    void deleteRecipe_admin_cleansDependentsBeforeDelete() {
+        // Given
+        Long recipeId = 99L;
+        Recipe recipe = Recipe.builder()
+                .id(recipeId)
+                .user(User.builder().id(10L).build())
+                .build();
+        given(recipeRepository.findWithUserById(recipeId)).willReturn(Optional.of(recipe));
+
+        // When
+        Long result = adminRecipeService.deleteRecipe(recipeId, 1L, true);
+
+        // Then
+        assertThat(result).isEqualTo(recipeId);
+        verify(recipeImageService).deleteImagesByRecipeId(recipeId);
+        verify(recipeLikeService).deleteByRecipeId(recipeId);
+        verify(recipeFavoriteService).deleteByRecipeId(recipeId);
+        verify(commentService).deleteAllByRecipeId(recipeId);
+        verify(recipeRatingRepository).deleteByRecipeId(recipeId);
+        verify(cookingRecordRepository).deleteByRecipeId(recipeId);
+        verify(recipeStepService).deleteAllByRecipeId(recipeId);
+        verify(recipeIngredientService).deleteAllByRecipeId(recipeId);
+        verify(recipeTagService).deleteAllByRecipeId(recipeId);
+        verify(ingredientCandidateRepository).clearSourceRecipeId(recipeId);
+        verify(recipeRepository).delete(recipe);
+
+        InOrder deleteOrder = inOrder(ingredientCandidateRepository, recipeRepository);
+        deleteOrder.verify(ingredientCandidateRepository).clearSourceRecipeId(recipeId);
+        deleteOrder.verify(recipeRepository).delete(recipe);
+    }
 
     @Test
     @DisplayName("재료 일괄 수정: 삭제, 생성, 수정(표준↔커스텀), 신고처리, 재계산이 모두 완벽하게 동작해야 한다.")

--- a/src/test/java/com/jdc/recipe_service/service/RecipeServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/RecipeServiceTest.java
@@ -7,6 +7,8 @@ import com.jdc.recipe_service.domain.dto.url.FileInfoRequest;
 import com.jdc.recipe_service.domain.dto.url.PresignedUrlResponse;
 import com.jdc.recipe_service.domain.entity.Recipe;
 import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.repository.CookingRecordRepository;
+import com.jdc.recipe_service.domain.repository.IngredientCandidateRepository;
 import com.jdc.recipe_service.domain.repository.RecipeIngredientRepository;
 import com.jdc.recipe_service.domain.repository.RecipeRatingRepository;
 import com.jdc.recipe_service.domain.repository.RecipeRepository;
@@ -59,6 +61,8 @@ class RecipeServiceTest {
     @Mock private CommentService commentService;
     @Mock private RecipeImageService recipeImageService;
     @Mock private RecipeLikeService recipeLikeService;
+    @Mock private CookingRecordRepository cookingRecordRepository;
+    @Mock private IngredientCandidateRepository ingredientCandidateRepository;
     @Mock private RecipeIndexingService recipeIndexingService;
     @Mock private RecipeAnalysisService recipeAnalysisService;
     @Mock private RecipeActivityService recipeActivityService;
@@ -361,12 +365,21 @@ class RecipeServiceTest {
 
         verify(recipeRepository, times(1)).findWithUserById(400L);
         verify(recipeImageService, times(1)).deleteImagesByRecipeId(400L);
+        verify(recipeLikeService, times(1)).deleteByRecipeId(400L);
+        verify(recipeFavoriteService, times(1)).deleteByRecipeId(400L);
+        verify(commentService, times(1)).deleteAllByRecipeId(400L);
+        verify(recipeRatingRepository, times(1)).deleteByRecipeId(400L);
+        verify(cookingRecordRepository, times(1)).deleteByRecipeId(400L);
+        verify(recipeStepService, times(1)).deleteAllByRecipeId(400L);
+        verify(recipeIngredientService, times(1)).deleteAllByRecipeId(400L);
+        verify(recipeTagService, times(1)).deleteAllByRecipeId(400L);
+        verify(ingredientCandidateRepository, times(1)).clearSourceRecipeId(400L);
         verify(recipeRepository, times(1)).deleteByIdDirectly(400L);
         verify(recipeIndexingService, times(1)).deleteRecipeSafelyWithRetry(400L);
-        // 연관 테이블 정리는 DB cascade 로 이동했으므로 서비스에서는 호출하지 않는다
-        verifyNoInteractions(recipeLikeService, recipeFavoriteService, commentService,
-                recipeStepService, recipeIngredientService, recipeTagService);
-        verify(recipeRatingRepository, never()).deleteByRecipeId(anyLong());
+        // ingredient_candidates는 후보 큐 보존을 위해 삭제하지 않고 recipe FK만 끊는다.
+        InOrder deleteOrder = inOrder(ingredientCandidateRepository, recipeRepository);
+        deleteOrder.verify(ingredientCandidateRepository).clearSourceRecipeId(400L);
+        deleteOrder.verify(recipeRepository).deleteByIdDirectly(400L);
     }
 
     @Test
@@ -382,7 +395,8 @@ class RecipeServiceTest {
 
         verify(recipeRepository, times(1)).findWithUserById(500L);
         verifyNoMoreInteractions(recipeImageService, recipeLikeService, recipeFavoriteService,
-                commentService, recipeStepService, recipeIngredientService, recipeTagService, recipeIndexingService);
+                commentService, recipeRatingRepository, cookingRecordRepository, recipeStepService,
+                recipeIngredientService, recipeTagService, ingredientCandidateRepository, recipeIndexingService);
     }
 
     @Test
@@ -405,7 +419,8 @@ class RecipeServiceTest {
 
         verify(recipeRepository, times(1)).findWithUserById(600L);
         verifyNoMoreInteractions(recipeImageService, recipeLikeService, recipeFavoriteService,
-                commentService, recipeStepService, recipeIngredientService, recipeTagService, recipeIndexingService);
+                commentService, recipeRatingRepository, cookingRecordRepository, recipeStepService,
+                recipeIngredientService, recipeTagService, ingredientCandidateRepository, recipeIndexingService);
     }
 
     @Test


### PR DESCRIPTION
 ## 해결하려는 문제가 무엇인가요?
  배포 전 smoke test에서 확인된 dev 생성 흐름과 recipe 삭제 경계 문제를 보정합니다.
  이미지 생성 실패 시 job은 완료됐지만 recipe imageStatus가 PENDING으로 남거나, owner 목록에서 실패/진행 중 레시피가 숨
  겨지는 문제가 있었습니다.
  또한 recipe hard delete 시 ingredient_candidates FK 때문에 삭제가 막힐 수 있고, auth cookie 만료 시간이 설정값과 어긋
  날 수 있었습니다.

  ## 어떻게 해결했나요?
  - **AS-IS:**
    - dev YouTube 생성은 이미지 실패/빈 응답 시 recipe 저장 DTO에 imageStatus를 확정하지 않아 PENDING으로 남을 수 있었습
  니다.
    - dev AI 생성은 이미지 실패 시 AsyncImageService가 FAILED 처리하지만, facade 레벨의 보정 장치가 없어 terminal 상태
  보장이 약했습니다.
    - `/api/dev/me/recipes` owner 목록도 imageReady 필터를 적용해 본인 레시피의 PENDING/FAILED 상태가 숨겨질 수 있었습니
  다.
    - recipe 삭제 시 ingredient_candidates.source_recipe_id FK 정리가 없어 hard delete가 실패할 수 있었습니다.
    - refresh/access token cookie maxAge가 JwtTokenProvider 설정값과 분리돼 있었습니다.

  - **TO-BE:**
    - dev YouTube 생성은 이미지 시도 후 `READY` 또는 `FAILED`를 DTO에 확정한 뒤 recipe를 저장하고 job을 COMPLETED 처리합
  니다.
    - dev AI 생성은 job 완료 직전 recipe imageStatus가 `PENDING/null`이면 `FAILED + default image`로 보정합니다.
    - `/api/dev/me/recipes` owner 목록은 본인 레시피에 한해 PENDING/FAILED/imageKey=null 레시피도 노출하고 `imageStatus`
  를 응답에 포함합니다.
    - recipe/admin recipe 삭제 전 ingredient candidate FK를 clear하여 삭제 충돌을 방지합니다.
    - auth 응답 cookie 만료 시간을 JwtTokenProvider의 access/refresh 설정값과 맞춥니다.

  ## Test plan
  - `./gradlew test --tests "*.RecipeServiceTest" --tests "*.AdminRecipeServiceTest" --rerun-tasks`
  - `./gradlew test --tests "*.DevUserRecipes*" --rerun-tasks`
  - `./gradlew test --tests "*.DevAiRecipeFacadeTest" --tests "*.DevYoutubeRecipeExtractionFacadeTest" --rerun-tasks`

  ## Rollout / DB / API impact
  - DB schema 변경 없음.
  - 신규 Flyway 없음.
  - API breaking change 없음.
  - `/api/dev/me/recipes` 응답에 `imageStatus` 필드가 추가됩니다.
  - dev AI/YouTube job 완료 의미가 더 엄격해집니다.
    - `IN_PROGRESS`: 이미지 생성 아직 진행 중일 수 있음
    - `COMPLETED`: 이미지가 READY 또는 FAILED로 확정됨

  ## Risks and rollback
  - dev 생성 job 정책 변경으로 기존보다 job COMPLETED 시점이 이미지 처리 종료 이후로 늦어질 수 있습니다.
  - 이미지 생성 실패 레시피는 default image + FAILED 상태로 owner 목록에 노출됩니다.
  - 문제 발생 시 이 PR revert로 기존 동작으로 되돌릴 수 있습니다. DB 변경이 없어 rollback은 코드 revert 중심입니다.

  ## Related
  - dev recipe generation smoke test
  - image generation fallback policy
  - recipe hard delete FK cleanup