### PR TITLE
fix(dev-mirror): yt-dlp graceful fallback + 추출자 자동 favorite + JSON 400 + grok 환경변수 분리

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/GrokWebClientConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/GrokWebClientConfig.java
@@ -1,18 +1,34 @@
 package com.jdc.recipe_service.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
 import jakarta.annotation.PostConstruct;
 
+/**
+ * Grok(xAI) WebClient 설정.
+ *
+ * <p>운영자 가이드 — 환경변수는 OpenAI와 명확히 분리된다:
+ * <ul>
+ *   <li><b>GROK_API_KEY</b> (필수): xAI 발급 키. application-local.yml / application-prod.yml의
+ *       {@code grok.api-key}로 매핑.</li>
+ *   <li><b>OPENAI_API_KEY</b>: 진짜 OpenAI(이미지 생성용) — 별도. application.yml의
+ *       {@code app.openai.api-key}로 매핑되며 이 config와는 무관.</li>
+ * </ul>
+ *
+ * <p>이전 fallback chain({@code grok.api-key:${openai.api-key:...}})은 prefix 혼동을 유발해 제거.
+ * GitHub Actions secrets에 GROK_API_KEY가 별도 등록되어 있어 fallback 가치 없음.
+ */
+@Slf4j
 @Configuration
 public class GrokWebClientConfig {
 
-    @Value("${openai.api-key}")
+    @Value("${grok.api-key}")
     private String apiKey;
 
-    @Value("${openai.base-url}")
+    @Value("${grok.base-url:https://api.x.ai/v1}")
     private String baseUrl;
 
     @Bean("grokWebClient")
@@ -26,8 +42,11 @@ public class GrokWebClientConfig {
 
     @PostConstruct
     public void validateApiKey() {
-        if (apiKey == null || apiKey.isEmpty()) {
-            throw new IllegalArgumentException("API key for Grok/OpenAI must be set.");
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalArgumentException(
+                    "API key for Grok must be set. (env: GROK_API_KEY, yml: grok.api-key)");
         }
+        // 시크릿 자체는 출력 안 함 — 길이만 부팅 로그에 표시해 어느 키가 적용됐는지 운영 검증 가능.
+        log.info("[Grok] WebClient ready. baseUrl={}, apiKey length={} chars", baseUrl, apiKey.length());
     }
 }

--- a/src/main/java/com/jdc/recipe_service/controller/IngredientController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/IngredientController.java
@@ -193,9 +193,17 @@ public class IngredientController {
 
     /** 6) 여러 ID에 대한 이름 조회 (해시 ID 리스트)*/
     @GetMapping("/names")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "ids가 비어 있거나 누락됨 (errorCode: INVALID_INGREDIENT_REQUEST)", content = @Content)
+    })
     @Operation(summary = "재료 이름 목록 조회", description = "해시화된 ID 리스트를 받아 해당 재료들의 이름 목록을 반환합니다.")
     public ResponseEntity<Map<String, List<IngredientIdNameDto>>> getIngredientNames(
-            @Parameter(description = "해시화된 ID 리스트 (쉼표로 구분)") @RequestParam List<String> ids) {
+            @Parameter(description = "해시화된 ID 리스트 (쉼표로 구분), 1개 이상 필수") @RequestParam(required = false) List<String> ids) {
+
+        if (ids == null || ids.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_INGREDIENT_REQUEST);
+        }
 
         List<IngredientIdNameDto> content = service.findNamesByHashIds(ids);
 

--- a/src/main/java/com/jdc/recipe_service/dev/controller/recipebook/DevRecipeBookController.java
+++ b/src/main/java/com/jdc/recipe_service/dev/controller/recipebook/DevRecipeBookController.java
@@ -22,7 +22,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -93,7 +92,7 @@ public class DevRecipeBookController {
     })
     public ResponseEntity<DevRecipeBookDetailResponse> getBookDetail(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Parameter(description = "레시피북 ID (HashID)", required = true) @DecodeId @PathVariable Long bookId,
+            @Parameter(description = "레시피북 ID (HashID)", required = true) @DecodeId("bookId") Long bookId,
             @Parameter(description = "정렬 기준: `createdAt` (default, 폴더 추가 시각) | `recipeCreatedAt` | `cookingTime`. " +
                     "기본 size 20 — 운영 RecipeBookController parity.")
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {

--- a/src/main/java/com/jdc/recipe_service/dev/facade/DevYoutubeRecipeExtractionFacade.java
+++ b/src/main/java/com/jdc/recipe_service/dev/facade/DevYoutubeRecipeExtractionFacade.java
@@ -18,8 +18,10 @@ import com.jdc.recipe_service.domain.entity.media.RecipeYoutubeInfo;
 import com.jdc.recipe_service.domain.entity.recipe.RecipeGenerationJob;
 import com.jdc.recipe_service.domain.repository.RecipeGenerationJobRepository;
 import com.jdc.recipe_service.domain.repository.RecipeRepository;
+import com.jdc.recipe_service.domain.repository.UserRepository;
 import com.jdc.recipe_service.domain.repository.meta.RecipeYoutubeExtractionInfoRepository;
 import com.jdc.recipe_service.domain.repository.meta.RecipeYoutubeInfoRepository;
+import com.jdc.recipe_service.domain.type.ActivityLogType;
 import com.jdc.recipe_service.domain.type.JobStatus;
 import com.jdc.recipe_service.domain.type.JobType;
 import com.jdc.recipe_service.domain.type.RecipeImageStatus;
@@ -28,7 +30,10 @@ import com.jdc.recipe_service.domain.type.recipe.RecipeSourceType;
 import com.jdc.recipe_service.domain.type.recipe.RecipeVisibility;
 import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.service.RecipeActivityService;
+import com.jdc.recipe_service.service.RecipeBookService;
 import com.jdc.recipe_service.service.RecipeExtractionService;
+import com.jdc.recipe_service.service.RecipeFavoriteService;
 import com.jdc.recipe_service.service.RecipeService;
 import com.jdc.recipe_service.service.ai.GeminiMultimodalService;
 import com.jdc.recipe_service.service.ai.GrokClientService;
@@ -94,6 +99,10 @@ public class DevYoutubeRecipeExtractionFacade {
     private final RecipeGenerationJobRepository jobRepository;
     private final RecipeYoutubeInfoRepository recipeYoutubeInfoRepository;
     private final RecipeYoutubeExtractionInfoRepository extractionInfoRepository;
+    private final UserRepository userRepository;
+    private final RecipeFavoriteService recipeFavoriteService;
+    private final RecipeBookService recipeBookService;
+    private final RecipeActivityService recipeActivityService;
     private final com.jdc.recipe_service.dev.service.recipe.ingredient.DevRecipeIngredientPersistService devIngredientPersist;
 
     private final TransactionTemplate transactionTemplate;
@@ -201,9 +210,20 @@ public class DevYoutubeRecipeExtractionFacade {
                 return;
             }
 
-            // 2. yt-dlp 메타데이터
+            // 2. yt-dlp 메타데이터 (실패 시 graceful Gemini multimodal fallback)
+            //    운영 V2(RecipeExtractionService:856)와 동일 정책: yt-dlp가 timeout/extractor error/JSON parse 등으로
+            //    throw하면 catch + 빈 videoData로 진행 → signal 모두 false → isTextSufficient=false → runExtraction이
+            //    자동으로 Gemini fallback path로 진입. 이전엔 try-catch 없어 yt-dlp 실패 시 상위 catch(Exception)로
+            //    흘러 903 catch-all로 박혔던 회귀를 닫는다.
             updateProgress(job, JobStatus.IN_PROGRESS, 20);
-            YtDlpService.YoutubeFullDataDto videoData = ytDlpService.getVideoDataFull(videoUrl);
+            YtDlpService.YoutubeFullDataDto videoData;
+            try {
+                videoData = ytDlpService.getVideoDataFull(videoUrl);
+            } catch (Exception e) {
+                log.warn("⚠️ [DevYt V3] yt-dlp 실패 → Gemini multimodal fallback 진입. videoUrl={}, error={}",
+                        videoUrl, YoutubeExtractionHelpers.safeMsg(e));
+                videoData = emptyVideoData(videoId);
+            }
 
             String description = YoutubeExtractionHelpers.cap(
                     YoutubeExtractionHelpers.nullToEmpty(videoData.description()),
@@ -217,9 +237,11 @@ public class DevYoutubeRecipeExtractionFacade {
             String title = YoutubeExtractionHelpers.nullToEmpty(videoData.title());
 
             // 3. 신호 검출 (이 시점에 잠가둠 — Gemini 결정 후 evidence 산출에 사용)
+            //    yt-dlp 실패 시 description/comments/scriptPlain 모두 빈 string → 모든 신호 false →
+            //    runExtraction이 isTextSufficient(signals)=false 분기로 가서 Grok 시도 없이 곧바로 Gemini fallback.
             SignalReport signals = signalDetector.detectSignals(description, comments, scriptPlain);
 
-            // 4. canonical URL 기반 dedup 한 번 더 (yt-dlp 응답 후)
+            // 4. canonical URL 기반 dedup 한 번 더 (yt-dlp 응답 후, 실패 시 canonicalUrl 빈 값이라 자동 skip)
             String canonicalUrl = YoutubeExtractionHelpers.nullToEmpty(videoData.canonicalUrl());
             if (!canonicalUrl.isBlank()) {
                 Optional<Recipe> existingByCanonical = recipeRepository
@@ -428,6 +450,38 @@ public class DevYoutubeRecipeExtractionFacade {
     }
 
     /**
+     * yt-dlp 실패 시 후속 흐름이 NPE 없이 진행되도록 빈 record 생성.
+     *
+     * <p>videoId만 채우고 나머지 텍스트 필드는 모두 빈 string, 숫자 필드는 null/0.
+     * downstream 코드는 모두 {@code nullToEmpty} / {@code .duration() != null} guard로 처리되어 안전.
+     * 이 빈 record로 진행하면:
+     * <ul>
+     *   <li>signal detection 결과 모든 boolean false → isTextSufficient=false → Gemini fallback path 진입</li>
+     *   <li>canonical dedup은 빈 URL이라 자동 skip</li>
+     *   <li>applyYoutubeFieldsToDto / saveRecipeAndMetadataAtomic가 빈 채널/제목/조회수로 저장 — 운영 V2 동등</li>
+     * </ul>
+     */
+    private static YtDlpService.YoutubeFullDataDto emptyVideoData(String videoId) {
+        // 14개 positional 인자는 record 필드 순서/추가 변경에 취약 → @Builder 사용으로 명시화.
+        return YtDlpService.YoutubeFullDataDto.builder()
+                .videoId(videoId)
+                .canonicalUrl("")
+                .title("")
+                .description("")
+                .comments("")
+                .scriptTimecoded("")
+                .scriptPlain("")
+                .channelName("")
+                .channelId("")
+                .thumbnailUrl("")
+                .channelProfileUrl("")
+                .youtubeSubscriberCount(0L)
+                .viewCount(0L)
+                .duration(0L)
+                .build();
+    }
+
+    /**
      * legacy Recipe.youtube* 필드 dual-write — 운영 V1/V2와 호환을 위해 유지.
      * 향후 RecipeYoutubeInfo로 완전 이행 후 contract 단계에서 제거.
      */
@@ -572,12 +626,76 @@ public class DevYoutubeRecipeExtractionFacade {
     }
 
     private void completeJob(Long jobId, Long resultRecipeId) {
-        transactionTemplate.executeWithoutResult(status -> {
+        // 1) job COMPLETED 처리 — 단일 트랜잭션
+        Long ownerUserId = transactionTemplate.execute(status -> {
             RecipeGenerationJob job = jobRepository.findById(jobId)
                     .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
             job.complete(resultRecipeId);
             jobRepository.saveAndFlush(job);
+            return job.getUserId();
         });
+
+        // 2) favorite + default book + activity log — 운영 V2(RecipeExtractionService:622)와 동일 정책.
+        //    YouTube 추출 recipe는 OFFICIAL_RECIPE_USER_ID 명의로 저장되어 본인 me/recipes에는 안 들어가므로,
+        //    추출자의 me/favorites + 기본 레시피북에 자동 등록해야 본인이 추출 결과를 찾을 수 있다.
+        //    위 트랜잭션 외부에서 별도 retry helper로 호출 — DB 경합/락 발생 시 5회 재시도.
+        if (ownerUserId != null && resultRecipeId != null) {
+            addFavoriteToUser(ownerUserId, resultRecipeId);
+            saveExtractActivityLog(ownerUserId);
+        }
+    }
+
+    /**
+     * 운영 V2 RecipeExtractionService.addFavoriteToUser와 동일 패턴 — 5회 retry + 100~350ms 백오프.
+     *
+     * <p>favorite과 default book 추가는 동일 트랜잭션 안에서 수행 (둘 중 하나만 성공하면 UX가 깨짐).
+     * 일시적 DB lock contention은 retry로 흡수, 최종 실패해도 catch-all로 흘러 사용자 응답에는
+     * 영향 주지 않는다 (job 자체는 이미 COMPLETED). 즉 favorite 추가 실패는 silent — 사용자가
+     * 수동으로 favorite을 누르면 복구 가능.
+     */
+    private void addFavoriteToUser(Long userId, Long recipeId) {
+        int maxRetries = 5;
+
+        for (int i = 1; i <= maxRetries; i++) {
+            try {
+                transactionTemplate.executeWithoutResult(status -> {
+                    recipeFavoriteService.addFavoriteIfNotExists(userId, recipeId);
+                    recipeBookService.saveToDefaultBookIfAbsent(userId, recipeId);
+                });
+                return;
+            } catch (Exception e) {
+                log.warn("⚠️ [DevYt V3] 즐겨찾기 추가 충돌 (시도 {}/{}): userId={}, recipeId={}, msg={}",
+                        i, maxRetries, userId, recipeId, e.getMessage());
+                if (i == maxRetries) {
+                    log.error("❌ [DevYt V3] 즐겨찾기 추가 최종 실패 — 사용자가 수동 favorite으로 복구 가능: userId={}, recipeId={}",
+                            userId, recipeId);
+                } else {
+                    try {
+                        Thread.sleep(100L + (i * 50L));
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Activity log 기록 — 운영 V2와 동일한 ActivityLogType.YOUTUBE_EXTRACT.
+     * nickname은 user 조회로 가져온다. 실패해도 silent — log는 통계용이라 main flow를 막지 않음.
+     */
+    private void saveExtractActivityLog(Long userId) {
+        try {
+            String nickname = userRepository.findById(userId)
+                    .map(u -> u.getNickname())
+                    .orElse(null);
+            if (nickname != null) {
+                recipeActivityService.saveLog(userId, nickname, ActivityLogType.YOUTUBE_EXTRACT);
+            }
+        } catch (Exception e) {
+            log.warn("⚠️ [DevYt V3] activity log 기록 실패 (silent): userId={}, msg={}", userId, e.getMessage());
+        }
     }
 
     private void handleAsyncError(RecipeGenerationJob job, Long userId, Exception e) {

--- a/src/main/java/com/jdc/recipe_service/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/jdc/recipe_service/handler/GlobalExceptionHandler.java
@@ -100,6 +100,35 @@ public class GlobalExceptionHandler {
                 ));
     }
 
+    /**
+     * 잘못된 JSON 본문(파싱 실패 / 인코딩 깨짐 / 본문 enum mismatch 등)을 400으로 매핑.
+     *
+     * <p>Spring 기본은 catch-all로 흘러 500 + errorId가 발급되어 운영자가 매번 로그를 추적해야 했다.
+     * 클라이언트 입력 오류는 사용자가 즉시 수정 가능한 4xx로 명확히 내려준다 — 운영 노이즈 감소.
+     *
+     * <p>대표 케이스 (request body 한정):
+     * <ul>
+     *   <li>UTF-8이 아닌 인코딩으로 한국어 본문이 들어옴 (charset mismatch)</li>
+     *   <li>중간이 잘린 JSON ("{\"name\":")</li>
+     *   <li>본문 enum 필드에 whitelist 외 문자열 (예: body의 visibility="UNKNOWN")</li>
+     *   <li>HashID 디코딩 실패</li>
+     * </ul>
+     *
+     * <p>query/path param의 enum mismatch는 별개 예외(MethodArgumentTypeMismatchException 등)로
+     * 들어오므로 이 핸들러 대상이 아니다.
+     */
+    @ExceptionHandler(org.springframework.http.converter.HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(
+            org.springframework.http.converter.HttpMessageNotReadableException ex) {
+        log.warn("요청 본문 파싱 실패: {}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(
+                        ErrorCode.INVALID_INPUT_VALUE.getCode(),
+                        "요청 본문 형식이 올바르지 않습니다. JSON 구문/UTF-8 인코딩/enum 값을 확인해주세요."
+                ));
+    }
+
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException ex) {
         log.warn("허용되지 않은 HTTP 메소드 요청: {} {}", ex.getMethod(), ex.getSupportedMethods());

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -112,7 +112,7 @@ cloud:
       access-key: ${AWS_ACCESS_KEY_ID}
       secret-key: ${AWS_SECRET_ACCESS_KEY}
 
-openai:
+grok:
   api-key: ${GROK_API_KEY}
   base-url: https://api.x.ai/v1
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
           enabled: true
 
   # Spring AI 1.0 — 레시피 챗봇(Upstage Solar) 설정.
-  # 주의: 최상위 `openai.*` 블록은 Grok SDK(com.openai:openai-java)용 별도 prefix이므로 서로 충돌 없음.
+  # 주의: Grok 텍스트 생성은 최상위 `grok.*` 블록을 사용한다. 이 Spring AI openai 블록과 서로 충돌 없음.
   # Upstage는 기본 /v1/chat/completions 경로를 쓰지 않으므로 completions-path 명시 필수.
   ai:
     openai:
@@ -123,7 +123,7 @@ app:
     # 한 번 429 뜬 지역을 몇 ms 동안 제외할지 (여기선 30초)
     credentials: ${GEMINI_CREDENTIALS}
     cooldown-ms: 30000
-  # 실제 OpenAI 이미지 생성용 (dev). 기존 openai.api-key는 Grok 키이므로 별도 설정.
+  # 실제 OpenAI 이미지 생성용 (dev). Grok 텍스트 생성 키는 grok.api-key/GROK_API_KEY를 사용한다.
   # 모델 선택(apiModel)은 DevImageGenModel enum이 결정한다 — 여기에 model 글로벌 default 두지 않음.
   openai:
     api-key: ${OPENAI_API_KEY:}

--- a/src/test/java/com/jdc/recipe_service/controller/IngredientControllerTest.java
+++ b/src/test/java/com/jdc/recipe_service/controller/IngredientControllerTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -292,5 +293,31 @@ class IngredientControllerTest {
                 .andExpect(status().isBadRequest());
 
         verifyNoInteractions(ingredientService);
+    }
+
+    @Test
+    @DisplayName("GET /api/ingredients/names: ids query is required")
+    void getIngredientNames_missingIds_returns400() throws Exception {
+        mockMvc.perform(get("/api/ingredients/names"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INGREDIENT_REQUEST.getCode()));
+
+        verifyNoInteractions(ingredientService);
+    }
+
+    @Test
+    @DisplayName("GET /api/ingredients/names: passes hash ids to service and serializes ids")
+    void getIngredientNames_returnsContent() throws Exception {
+        long rawId = 42L;
+        String hashedId = hashids.encode(rawId);
+        given(ingredientService.findNamesByHashIds(eq(List.of(hashedId))))
+                .willReturn(List.of(new com.jdc.recipe_service.domain.dto.ingredient.IngredientIdNameDto(rawId, "onion")));
+
+        mockMvc.perform(get("/api/ingredients/names").param("ids", hashedId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(hashedId))
+                .andExpect(jsonPath("$.content[0].name").value("onion"));
+
+        verify(ingredientService).findNamesByHashIds(eq(List.of(hashedId)));
     }
 }

--- a/src/test/java/com/jdc/recipe_service/dev/controller/recipebook/DevRecipeBookControllerWebMvcTest.java
+++ b/src/test/java/com/jdc/recipe_service/dev/controller/recipebook/DevRecipeBookControllerWebMvcTest.java
@@ -1,0 +1,110 @@
+package com.jdc.recipe_service.dev.controller.recipebook;
+
+import com.jdc.recipe_service.config.HashIdConfig;
+import com.jdc.recipe_service.dev.domain.dto.recipebook.DevRecipeBookDetailResponse;
+import com.jdc.recipe_service.dev.service.recipebook.DevRecipeBookService;
+import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.jwt.JwtTokenProvider;
+import com.jdc.recipe_service.security.CustomAuthenticationEntryPoint;
+import com.jdc.recipe_service.security.CustomUserDetails;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.hashids.Hashids;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * DevRecipeBookController @WebMvcTest — read endpoint HashID resolver chain.
+ */
+@WebMvcTest(controllers = DevRecipeBookController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({HashIdConfig.class, DevRecipeBookControllerWebMvcTest.MeterRegistryTestConfig.class})
+@TestPropertySource(properties = {
+        "app.hashids.salt=TEST_SALT_FOR_DEV_RECIPE_BOOK_CONTROLLER",
+        "app.hashids.min-length=8"
+})
+class DevRecipeBookControllerWebMvcTest {
+
+    @TestConfiguration
+    static class MeterRegistryTestConfig {
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired Hashids hashids;
+
+    @MockBean DevRecipeBookService devRecipeBookService;
+    @MockBean JwtTokenProvider jwtTokenProvider;
+    @MockBean UserDetailsService userDetailsService;
+    @MockBean CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    private static final long RAW_USER_ID = 7L;
+    private static final long RAW_BOOK_ID = 31415L;
+
+    @BeforeEach
+    void setUpAuth() {
+        User user = User.builder().nickname("u").provider("test").oauthId("oid").build();
+        ReflectionTestUtils.setField(user, "id", RAW_USER_ID);
+        CustomUserDetails principal = new CustomUserDetails(user);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @AfterEach
+    void clearAuth() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("GET /api/dev/me/recipe-books/{bookId}: bookId HashID 디코딩 후 service에 raw Long 전달")
+    void getBookDetail_decodesBookIdHashId() throws Exception {
+        String hashedBookId = hashids.encode(RAW_BOOK_ID);
+        DevRecipeBookDetailResponse response = DevRecipeBookDetailResponse.builder()
+                .id(RAW_BOOK_ID)
+                .name("saved")
+                .recipeCount(0)
+                .build();
+        given(devRecipeBookService.getBookDetailDev(eq(RAW_USER_ID), eq(RAW_BOOK_ID), org.mockito.ArgumentMatchers.any(Pageable.class)))
+                .willReturn(response);
+
+        mockMvc.perform(get("/api/dev/me/recipe-books/{bookId}", hashedBookId)
+                        .param("page", "0")
+                        .param("size", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(hashedBookId))
+                .andExpect(jsonPath("$.name").value("saved"));
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(devRecipeBookService).getBookDetailDev(eq(RAW_USER_ID), eq(RAW_BOOK_ID), pageableCaptor.capture());
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(5);
+    }
+}

--- a/src/test/java/com/jdc/recipe_service/dev/facade/DevYoutubeRecipeExtractionFacadeTest.java
+++ b/src/test/java/com/jdc/recipe_service/dev/facade/DevYoutubeRecipeExtractionFacadeTest.java
@@ -13,13 +13,18 @@ import com.jdc.recipe_service.domain.entity.media.RecipeYoutubeInfo;
 import com.jdc.recipe_service.domain.entity.recipe.RecipeGenerationJob;
 import com.jdc.recipe_service.domain.repository.RecipeGenerationJobRepository;
 import com.jdc.recipe_service.domain.repository.RecipeRepository;
+import com.jdc.recipe_service.domain.repository.UserRepository;
 import com.jdc.recipe_service.domain.repository.meta.RecipeYoutubeExtractionInfoRepository;
 import com.jdc.recipe_service.domain.repository.meta.RecipeYoutubeInfoRepository;
+import com.jdc.recipe_service.domain.type.ActivityLogType;
 import com.jdc.recipe_service.domain.type.RecipeImageStatus;
 import com.jdc.recipe_service.domain.type.media.EvidenceLevel;
 import com.jdc.recipe_service.domain.type.recipe.RecipeSourceType;
 import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.service.RecipeActivityService;
+import com.jdc.recipe_service.service.RecipeBookService;
+import com.jdc.recipe_service.service.RecipeFavoriteService;
 import com.jdc.recipe_service.service.RecipeService;
 import com.jdc.recipe_service.service.ai.GeminiMultimodalService;
 import com.jdc.recipe_service.service.ai.GrokClientService;
@@ -50,6 +55,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -90,6 +96,10 @@ class DevYoutubeRecipeExtractionFacadeTest {
     @Mock RecipeGenerationJobRepository jobRepository;
     @Mock RecipeYoutubeInfoRepository recipeYoutubeInfoRepository;
     @Mock RecipeYoutubeExtractionInfoRepository extractionInfoRepository;
+    @Mock UserRepository userRepository;
+    @Mock RecipeFavoriteService recipeFavoriteService;
+    @Mock RecipeBookService recipeBookService;
+    @Mock RecipeActivityService recipeActivityService;
     @Mock DevRecipeIngredientPersistService devIngredientPersist;
     @Mock TransactionTemplate transactionTemplate;
 
@@ -655,6 +665,155 @@ class DevYoutubeRecipeExtractionFacadeTest {
                 .refund(eq(USER_ID), eq(DevYoutubeQuotaService.COST_WITH_GEMINI));
         // deprecated overload도 호출 안 됨
         verify(devYoutubeQuotaService, never()).refund(eq(USER_ID), eq(DevYoutubeQuotaService.COST_BASIC));
+    }
+
+    @Test
+    @DisplayName("**MUST 회귀 차단**: yt-dlp 실패 시 903으로 끝나지 않고 Gemini multimodal fallback으로 진입 (운영 V2:856 동등)")
+    @SuppressWarnings("unchecked")
+    void async_ytDlpThrows_fallsBackToGeminiInsteadOf903() {
+        // 운영 V2는 yt-dlp 실패를 try-catch + useUrlFallback=true로 graceful 우회.
+        // dev V3가 try-catch 없으면 상위 catch(Exception)로 흘러 903 catch-all FAILED.
+        // 이 invariant가 회귀하면 사용자가 본 14562/14564/14568 패턴 재발.
+        Long jobId = 2000L;
+        Long recipeId = 7777L;
+        LocalDate consumedOn = LocalDate.of(2026, 4, 30);
+        RecipeGenerationJob job = mockJobWithCost(jobId, DevYoutubeQuotaService.COST_BASIC, consumedOn);
+        given(jobRepository.findById(jobId)).willReturn(Optional.of(job));
+        stubTransactionTemplate();
+        given(transactionTemplate.execute(any())).willAnswer(inv -> {
+            org.springframework.transaction.support.TransactionCallback<Object> cb = inv.getArgument(0);
+            return cb.doInTransaction(null);
+        });
+
+        // dedup miss
+        given(recipeYoutubeInfoRepository.findByVideoId(VIDEO_ID)).willReturn(Optional.empty());
+        given(recipeRepository.findFirstOfficialByYoutubeUrl(any(), any())).willReturn(Optional.empty());
+
+        // 🔥 yt-dlp가 RuntimeException throw — 운영 환경에서 자막 다운로드 실패 / subprocess error 시뮬레이션
+        given(ytDlpService.getVideoDataFull(VALID_URL))
+                .willThrow(new RuntimeException("yt-dlp subprocess timeout"));
+
+        // 빈 description/comments/scriptPlain → 모든 신호 false → isTextSufficient=false → Gemini fallback
+        YoutubeSignalDetector.SignalReport zeroSignals =
+                new YoutubeSignalDetector.SignalReport(false, false, false);
+        given(signalDetector.detectSignals(any(), any(), any())).willReturn(zeroSignals);
+        given(signalDetector.computeEvidence(zeroSignals, true)).willReturn(EvidenceLevel.LOW);
+
+        // Gemini multimodal로 정상 생성
+        RecipeCreateRequestDto geminiDto = new RecipeCreateRequestDto();
+        geminiDto.setIsRecipe(true);
+        geminiDto.setTitle("yt-dlp 실패 후 Gemini 추출");
+        geminiDto.setIngredients(List.of(ing("재료1", "1", "개")));
+        given(geminiMultimodalService.generateRecipeFromYoutubeUrl(any(), any(), any()))
+                .willReturn(java.util.concurrent.CompletableFuture.completedFuture(geminiDto));
+
+        given(asyncImageService.buildPromptFromDto(any())).willReturn("image prompt");
+        given(devImageGenRouterService.generate(any(), any(), any(), any())).willReturn(List.of());
+
+        PresignedUrlResponse response = PresignedUrlResponse.builder()
+                .recipeId(recipeId)
+                .uploads(List.of())
+                .build();
+        given(recipeService.createRecipeAndGenerateUrls(
+                any(), eq(90121L), eq(RecipeSourceType.YOUTUBE), any())).willReturn(response);
+        Recipe recipe = mock(Recipe.class);
+        given(recipeRepository.findById(recipeId)).willReturn(Optional.of(recipe));
+
+        given(jobRepository.saveAndFlush(any(RecipeGenerationJob.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        facade.processYoutubeExtractionAsync(jobId, VALID_URL, VALID_MODEL, USER_ID);
+
+        // then
+        // ① yt-dlp throw 후에도 emptyVideoData로 흐름 진행 — signalDetector가 빈 문자열 3개로 호출됨
+        verify(signalDetector).detectSignals("", "", "");
+        // ② Grok 호출은 일어나지 않고 (텍스트 신호 0이라 isTextSufficient=false → 곧바로 Gemini)
+        verify(grokClientService, never()).generateRecipeStep1(any(), any());
+        // ③ Gemini multimodal로 우회 진행
+        verify(geminiMultimodalService).generateRecipeFromYoutubeUrl(any(), any(), any());
+        // ④ recipe 저장 단까지 도달 (903 FAILED 안 됨)
+        verify(recipeService).createRecipeAndGenerateUrls(
+                any(), eq(90121L), eq(RecipeSourceType.YOUTUBE), any());
+        // ⑤ Gemini fallback이라 +3 추가 차감 (basic 2 + gemini 3 = 5)
+        verify(devYoutubeQuotaService).chargeGeminiUpgrade(USER_ID, consumedOn);
+        // ⑥ job COMPLETED
+        assertThat(job.getStatus()).isEqualTo(com.jdc.recipe_service.domain.type.JobStatus.COMPLETED);
+        assertThat(job.getResultRecipeId()).isEqualTo(recipeId);
+    }
+
+    @Test
+    @DisplayName("**MUST 회귀 차단**: completeJob 성공 후 추출자 me/favorites + default book + activity log에 자동 등록 (V2 RecipeExtractionService:622 동등)")
+    @SuppressWarnings("unchecked")
+    void completeJob_autoRegistersFavoriteAndDefaultBookAndLog() {
+        // YouTube 추출 recipe는 OFFICIAL_RECIPE_USER_ID 명의로 저장되어 본인 me/recipes에 안 들어감.
+        // 자동 favorite + default book + activity log를 빼면 추출자가 본인 추출 결과를 못 찾는 UX 사고.
+        Long jobId = 999L;
+        Long recipeId = 888L;
+        RecipeGenerationJob job = mockJobWithCost(jobId, DevYoutubeQuotaService.COST_BASIC);
+        org.springframework.test.util.ReflectionTestUtils.setField(job, "userId", USER_ID);
+        given(jobRepository.findById(jobId)).willReturn(Optional.of(job));
+        given(jobRepository.saveAndFlush(any(RecipeGenerationJob.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // transactionTemplate.execute(...)가 callback을 즉시 실행하도록 stub
+        given(transactionTemplate.execute(any())).willAnswer(inv -> {
+            org.springframework.transaction.support.TransactionCallback<Object> cb = inv.getArgument(0);
+            return cb.doInTransaction(null);
+        });
+        // executeWithoutResult는 favorite retry block에서 호출됨
+        doAnswer(inv -> {
+            java.util.function.Consumer<org.springframework.transaction.TransactionStatus> cb = inv.getArgument(0);
+            cb.accept(null);
+            return null;
+        }).when(transactionTemplate).executeWithoutResult(any());
+
+        com.jdc.recipe_service.domain.entity.User user = mock(com.jdc.recipe_service.domain.entity.User.class);
+        given(user.getNickname()).willReturn("tester");
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+        // when — private completeJob 직접 호출 (entire async flow 거치지 않고 격리 검증)
+        org.springframework.test.util.ReflectionTestUtils.invokeMethod(facade, "completeJob", jobId, recipeId);
+
+        // then — V2와 동일한 3종 후속 작업이 모두 호출됨
+        verify(recipeFavoriteService).addFavoriteIfNotExists(USER_ID, recipeId);
+        verify(recipeBookService).saveToDefaultBookIfAbsent(USER_ID, recipeId);
+        verify(recipeActivityService).saveLog(USER_ID, "tester", ActivityLogType.YOUTUBE_EXTRACT);
+    }
+
+    @Test
+    @DisplayName("**MUST 회귀 차단**: favorite 추가 시 DB 충돌 발생해도 5회 retry 후 silent fail — completeJob 자체는 깨지지 않음")
+    @SuppressWarnings("unchecked")
+    void completeJob_favoriteRetriesOnConflict_thenSilentFail() {
+        // 일시적 DB lock contention 시뮬레이션. 5회 모두 throw → silent fail (사용자가 수동 favorite으로 복구).
+        Long jobId = 1000L;
+        Long recipeId = 777L;
+        RecipeGenerationJob job = mockJobWithCost(jobId, DevYoutubeQuotaService.COST_BASIC);
+        org.springframework.test.util.ReflectionTestUtils.setField(job, "userId", USER_ID);
+        given(jobRepository.findById(jobId)).willReturn(Optional.of(job));
+        given(jobRepository.saveAndFlush(any(RecipeGenerationJob.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // execute (job 완료 단)는 정상
+        given(transactionTemplate.execute(any())).willAnswer(inv -> {
+            org.springframework.transaction.support.TransactionCallback<Object> cb = inv.getArgument(0);
+            return cb.doInTransaction(null);
+        });
+        // executeWithoutResult (favorite 단)에서 5회 모두 throw
+        doThrow(new RuntimeException("lock wait timeout"))
+                .when(transactionTemplate).executeWithoutResult(any());
+
+        com.jdc.recipe_service.domain.entity.User user = mock(com.jdc.recipe_service.domain.entity.User.class);
+        given(user.getNickname()).willReturn("tester");
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+        // when — completeJob이 favorite 실패에도 throw 안 함
+        org.assertj.core.api.Assertions.assertThatCode(() ->
+                org.springframework.test.util.ReflectionTestUtils.invokeMethod(facade, "completeJob", jobId, recipeId))
+                .as("favorite 추가 실패는 silent — completeJob 자체는 통과")
+                .doesNotThrowAnyException();
+
+        // 5회 retry 호출 확인 (V2와 동일 정책)
+        verify(transactionTemplate, times(5)).executeWithoutResult(any());
+        // activity log는 favorite 실패와 무관하게 시도됨
+        verify(recipeActivityService).saveLog(USER_ID, "tester", ActivityLogType.YOUTUBE_EXTRACT);
     }
 
     private RecipeIngredientRequestDto ing(String name, String quantity, String unit) {

--- a/src/test/java/com/jdc/recipe_service/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jdc/recipe_service/handler/GlobalExceptionHandlerTest.java
@@ -90,4 +90,28 @@ class GlobalExceptionHandlerTest {
         // 이 경로에서는 refresh 전용 카운터가 오염되면 안 된다.
         assertThat(lockTimeoutCount()).isEqualTo(0.0);
     }
+
+    @Test
+    @DisplayName("**MUST 회귀 차단**: 잘못된 JSON 본문(파싱 실패)은 500 catch-all이 아니라 400 INVALID_INPUT_VALUE로 매핑된다")
+    void httpMessageNotReadable_mapsToBadRequest() {
+        // 운영에서 빈번한 케이스:
+        //   - charset mismatch로 한국어 본문 byte가 깨짐
+        //   - 중간이 잘린 JSON
+        //   - enum 값 mismatch (concept=UNKNOWN 등)
+        // 이전엔 catch-all로 흘러 errorId 발급 + 5xx 노이즈. 이제 4xx로 명확히.
+        org.springframework.http.converter.HttpMessageNotReadableException ex =
+                new org.springframework.http.converter.HttpMessageNotReadableException(
+                        "JSON parse error: Unexpected end-of-input");
+
+        ResponseEntity<ErrorResponse> response = handler.handleHttpMessageNotReadable(ex);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode())
+                .as("INVALID_INPUT_VALUE code(901)로 매핑")
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE.getCode());
+        assertThat(response.getBody().getMessage())
+                .as("사용자가 원인 추적할 수 있는 안내 메시지")
+                .contains("요청 본문");
+    }
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -40,6 +40,8 @@ app.vertex.cooldown-ms=0
 app.test-login.enabled=false
 
 # External integrations - dummy values so context can load without real env vars
+grok.api-key=test-grok-key
+grok.base-url=http://localhost
 openai.api-key=test-openai-key
 openai.base-url=http://localhost
 gemini.api-key=test-gemini-key


### PR DESCRIPTION
  ## 해결하려는 문제가 무엇인가요?

  이전 PR `feat(recipe): dev V3 mirror, 재료 raw-first 정규화, visibility 4-tuple 도입`을 머지하고 운영 검증한 결과
  발견된 회귀/UX 흠 5건을 함께 닫는다.

  - **(A) dev YouTube 추출이 yt-dlp 일시 실패에 취약**: 일반 watch URL이 어떤 이유로 yt-dlp throw 시 운영 V2는 Gemini
  multimodal로 graceful 우회하는데 dev V3는 그대로 catch-all 903으로 떨어짐 (jobId 14562/14564/14568 패턴).
  - **(B) YouTube 추출 성공해도 추출자가 결과를 못 찾음**: dev V3 1차 MVP에서 후속 단계로 미뤘던 자동
  favorite/book/activity log가 빠져 있어, 추출 recipe(공식 계정 명의 저장)를 본인의 me/recipes/me/favorites 어디서도
  발견 못 하는 UX 사고.
  - **(C) 잘못된 JSON 본문이 500 catch-all로 떨어짐**: 한국어 charset mismatch / 잘린 JSON / enum mismatch 모두
  errorId가 발급되어 운영 노이즈만 키움.
  - **(D) Grok/OpenAI 환경변수 prefix 혼동**: GitHub Actions secrets에 `GROK_API_KEY`가 별도 등록되어 있지만
  `GrokWebClientConfig`의 fallback chain(`${grok.api-key:${openai.api-key:}}`)이 deadcode로 남아 있어 운영자가 yml만
  봤을 때 키 분리 의도를 오해.
  - **(E) 운영 `/api/ingredients/names`의 빈 ids 응답이 errorCode 없는 generic 400**: 다른 ingredient 4xx와 응답
  shape이 달라 프론트 분기 비용 증가.

  ## 어떻게 해결했나요?

  ### AS-IS

  - yt-dlp 호출이 try-catch 없이 실행되어 RuntimeException이 상위 catch(Exception)로 직행 →
  `INTERNAL_SERVER_ERROR(903)` + tokenCost=0 + usedGeminiAnalysis=0으로 박힘.
  - YouTube 추출 recipe가 `OFFICIAL_RECIPE_USER_ID(=90121)` 명의로 저장되지만 추출자에 대한 favorite/book/log 미연결.
  - 본문 파싱 실패가 `Exception.class` catch-all 핸들러로 흘러 5xx + errorId 발급.
  - `${grok.api-key:${openai.api-key:}}` fallback chain이 yml 분리 의도와 어긋남 (실제 base yml에 최상위 `openai:` 없음
   → deadcode).
  - `@RequestParam List<String> ids` (required=true 기본)에서 누락 시 Spring의 generic 400.

  ### TO-BE

  - **(A) `DevYoutubeRecipeExtractionFacade.processYoutubeExtractionAsync`**: yt-dlp 호출을 try-catch +
  `emptyVideoData(videoId)` 빈 record로 graceful 진행. 빈 description/comments/scriptPlain → signal 모두 false →
  `isTextSufficient=false` → runExtraction이 곧바로 Gemini multimodal fallback path로 진입 → +3 quota 추가 차감 +
  usedGeminiAnalysis=true. 운영 V2(`RecipeExtractionService:856`) 동등 회복성.
  - **(B) `completeJob` 직후 `addFavoriteToUser` 호출**: V2 패턴 그대로(5회 retry + 100~350ms 백오프)
  `recipeFavoriteService.addFavoriteIfNotExists` + `recipeBookService.saveToDefaultBookIfAbsent` 동일 트랜잭션. 별도로
  `recipeActivityService.saveLog(userId, nickname, YOUTUBE_EXTRACT)` 호출. 모두 silent fail — job 자체는 이미
  COMPLETED라 영향 없음, 사용자가 수동 favorite으로 복구 가능.
  - **(C) `HttpMessageNotReadableException` 핸들러 추가**: 400 + `INVALID_INPUT_VALUE(901)`로 매핑. request body
  한정으로 좁히고 query/path param mismatch는 별개 예외라는 점 주석에 명시.
  - **(D) `GrokWebClientConfig` fallback 제거**: `@Value("${grok.api-key}")` 단순화. 부팅 시 `validateApiKey`에서 env
  이름 명시(`(env: GROK_API_KEY, yml: grok.api-key)`) + apiKey length만 로그(시크릿 미출력). `application-prod.yml`의
  prefix `openai:` → `grok:` 정정. 진짜 OpenAI는 `app.openai.api-key`(env `OPENAI_API_KEY`)에 그대로.
  - **(E) `IngredientController.getIngredientNames`**: `required=false`로 받고 직접 null/empty 체크 →
  `ErrorCode.INVALID_INGREDIENT_REQUEST` throw. 다른 ingredient 4xx와 응답 shape 일관.

  부수: `DevRecipeBookController.getBookDetail`의 `@DecodeId @PathVariable Long bookId` → `@DecodeId("bookId") Long
  bookId`로 단일 어노테이션화 (운영 컨트롤러와 동일 패턴) + WebMvc 테스트 신설.

  ### 리뷰어가 먼저 봐야 할 영역

  | 우선순위 | 파일/commit | 핵심 invariant |
  |---|---|---|
  | 1 | `DevYoutubeRecipeExtractionFacade.java` (commit `3ae42b4`) | yt-dlp throw 후에도 graceful Gemini fallback /
  completeJob 후 자동 favorite·book·log |
  | 2 | `GlobalExceptionHandler.java` (commit `a3f6565`) | malformed JSON → 400 INVALID_INPUT_VALUE 매핑 |
  | 3 | `GrokWebClientConfig.java` + 3 yml (commit `af2ea13`) | fallback chain 제거. base prefix `grok.*`만 사용 |
  | 4 | `IngredientController.java` (commit `741e913`) | `/names` 응답 errorCode 일관 |
  | 5 | `DevRecipeBookController.java` (commit `58de653`) | annotation 정리 + WebMvc 테스트 |

  ## Test plan

  추가/수정한 테스트:
  - `DevYoutubeRecipeExtractionFacadeTest`:
    - **(신규)** `async_ytDlpThrows_fallsBackToGeminiInsteadOf903`: yt-dlp `RuntimeException` throw → emptyVideoData →
  signal "" 호출 verify → Grok 호출 안 됨 → Gemini multimodal 호출 → +3 chargeGeminiUpgrade → COMPLETED.
    - **(신규)** `completeJob_autoRegistersFavoriteAndDefaultBookAndLog`: completeJob 후 V2와 동일한 3종
  (favorite/book/log) 호출 잠금.
    - **(신규)** `completeJob_favoriteRetriesOnConflict_thenSilentFail`: 5회 retry 후 silent fail — completeJob 자체는
  throw 안 함.
  - `GlobalExceptionHandlerTest`:
    - **(신규)** `httpMessageNotReadable_mapsToBadRequest`: status 400 + code 901 + 안내 메시지.
  - `IngredientControllerTest`:
    - **(신규)** ids 누락 / 빈 배열 모두 400 + INVALID_INGREDIENT_REQUEST 검증.
  - `DevRecipeBookControllerWebMvcTest` (신규 파일):
    - HashID 디코딩 + service 인자 매핑 / Pageable default(20, createdAt DESC) wiring / 401 인증 누락.

  검증 명령:
  ```
  ./gradlew test --tests "*DevYoutubeRecipeExtractionFacadeTest*" \
                 --tests "*GlobalExceptionHandlerTest*" \
                 --tests "*IngredientControllerTest*" \
                 --tests "*DevRecipeBookControllerWebMvcTest*"
  ```

  → BUILD SUCCESSFUL (로컬 Java 17 / Gradle 8.13).

  ## Rollout / DB / API impact

  ### DB

  해당 없음. 스키마 변경/Flyway migration 없음.

  ### API

  - `GET /api/ingredients/names?ids=` 누락/빈 배열 응답이 generic 400 → 400 + `INVALID_INGREDIENT_REQUEST`. **응답
  shape는 동일** (status code 동일, errorCode 추가). 프론트가 다른 ingredient 4xx와 동일 처리하면 자동 흡수. 의존성
  깨질 가능성 매우 낮음.
  - `POST /api/dev/recipes/youtube/extract` 결과 — 이전 yt-dlp throw 케이스에서 903 FAILED로 끝나던 흐름이 이제 Gemini
  fallback으로 진행 → COMPLETED + tokenCost=5 차감. **사용자 quota 소진 패턴 변경**: 이전엔 903 후 환불, 이제는 Gemini
  호출이라 +3 차감 후 정상. 일일 한도 20 cost unit 기준 최대 4건/day까지 가능 (변경 전 동일). breaking 아님.
  - 모든 dev mirror endpoint 응답 shape 변경 없음.
  - malformed JSON 응답이 5xx → 4xx로 변경. 모니터링 알람 룰에 "5xx rate" 기준 있으면 일시적으로 5xx가 줄고 4xx가 늘어
  보일 수 있음 (의도된 변화).

  ### 환경변수 / 설정

  - 운영 변경 없음. `GROK_API_KEY`는 GitHub Actions secrets에 이미 등록되어 있고
  `application-local.yml`/`application-prod.yml`에서 매핑되어 있으므로 동작 그대로.
  - `GrokWebClientConfig.validateApiKey`가 부팅 시 apiKey length를 INFO 로그로 출력 — 시크릿은 노출 안 함, 적용 여부만
  확인 가능.

  ### Feature flag / 스케줄러

  해당 없음.

  ## Risks and rollback

  | 리스크 | 영향 | 완화 |
  |---|---|---|
  | yt-dlp graceful fallback이 Gemini quota를 더 빨리 소진시킴 | 일일 한도 20 unit 기준 빠르게 5씩 차감 | 운영 V2 동등
  정책이라 운영 사용자 quota와 동등. 추가 한도 변경 불필요 |
  | favorite 자동 추가 retry로 DB lock contention 일시 증가 | DB CPU 약간 상승 | 5회 + 백오프 후 silent fail. job
  자체는 영향 없음. 운영 V2와 동일 패턴이라 새 부담 없음 |
  | 잘못된 JSON 응답이 5xx → 4xx로 바뀌어 5xx 알람 변동 | 알람 룰 노이즈 | 의도된 변경. 운영 알람 5xx-rate가 떨어지고
  4xx-rate가 약간 오르는 패턴이면 정상 |
  | `@DecodeId("bookId")` 단일 어노테이션 변경이 path variable 매핑 깨뜨릴 가능성 | book detail 404/400 회귀 |
  WebMvcTest로 디코딩 + 인자 매핑 + 401 분기 회귀 잠금 |

  **Rollback**:
  - 단순 revert 가능. DB 스키마 영향 없음.
  - 5개 commit이 의미 단위로 격리되어 있어 일부만 revert 필요 시 cherry-pick으로 가능.

  ## Related

  - 이전 PR: `feat(recipe): dev V3 mirror, 재료 raw-first 정규화, visibility 4-tuple 도입` — 이 PR이 그 머지 후 발견된
  회귀를 닫음.
  - 운영 V2 동등 패턴 참조: `RecipeExtractionService:856` (yt-dlp catch + useUrlFallback),
  `RecipeExtractionService:622, 1153~1180` (addFavoriteToUser 5회 retry).
  - Skill: `safe-refactor` (behavior-preserving 변경), `write-tests` (회귀 테스트 추가).
  - 미해결 후속 후보 (별도 PR):
    - `Cannot locate recovery method` warn (`DevGptImageService` Spring Retry `@Recover` 시그니처 매칭 이슈) — 별도
  진단 필요.
    - 14562/14564/14568 jobId의 stack trace 직접 확보 후 yt-dlp가 어떤 specific 케이스에서 throw하는지 추가 분석 (이번
  PR은 일반적 graceful fallback으로 대응).

  ---
  이대로 PR 올려도 OK입니다. 검토 후 OK시:

  git push -u origin fix/dev-youtube-graceful-fallback
  gh pr create --title "..." --body "$(cat ...)"

  또는 사용자가 직접 GitHub UI에서 push 후 본문 붙여넣기. 어느 쪽이든 진행할 준비 됐습니다.
