### PR TITLE
  feat(curation-articles): MDX 매거진 아티클 도메인 + admin/public API + 이미지 업로드 finalize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ CLAUDE.md
 AGENTS.md
 .claude/
 .agents/
+
+### 프론트엔드 핸드오프 문서 ###
+docs/handoff/

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencyManagement {
 		mavenBom "software.amazon.awssdk:bom:2.31.29"
 		// Spring AI BOM (1.0 GA) — 레시피 챗봇(Upstage Solar) 통합용
 		mavenBom "org.springframework.ai:spring-ai-bom:1.0.0"
+		// Testcontainers 1.20.x does not detect Docker Desktop 4.69 / Engine 29 reliably on Windows.
+		mavenBom "org.testcontainers:testcontainers-bom:1.21.4"
 	}
 }
 
@@ -115,8 +117,8 @@ dependencies {
 
 	// Testcontainers (MySQL repository integration tests — H2 대신 MySQL 사용)
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-	testImplementation 'org.testcontainers:junit-jupiter:1.20.4'
-	testImplementation 'org.testcontainers:mysql:1.20.4'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:mysql'
 
 	// WireMock standalone — 챗봇 통합 테스트용 Upstage 응답 가상화
 	testImplementation 'org.wiremock:wiremock-standalone:3.10.0'

--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -108,6 +108,8 @@ public class SecurityConfig {
                                     "/api/dev/ingredients/*",  // dev V3 ingredient 상세 (운영 /api/ingredients/* 미러)
                                     "/api/dev/users/*/recipes",  // dev V3 사용자 레시피 목록 (운영 /api/users/*/recipes 미러)
                                     "/api/dev/search/**",  // dev V3 search mirrors
+                                    "/api/curation-articles",        // public 큐레이션 아티클 목록 (PUBLISHED만 service가 강제)
+                                    "/api/curation-articles/*",      // public 큐레이션 아티클 상세 (slug; PUBLISHED만 service가 강제)
                                     "/api/recipes/sitemap"
                             ).permitAll()
 
@@ -349,6 +351,8 @@ public class SecurityConfig {
                                 "/api/dev/ingredients/*",  // dev V3 ingredient 상세 — local 분기와 정합
                                 "/api/dev/users/*/recipes",  // dev V3 사용자 레시피 목록 — local 분기와 정합
                                 "/api/dev/search/**",  // dev V3 search mirrors
+                                "/api/curation-articles",        // public 큐레이션 아티클 목록 (PUBLISHED만 service가 강제)
+                                "/api/curation-articles/*",      // public 큐레이션 아티클 상세 (slug; PUBLISHED만 service가 강제)
                                 "/api/recipes/sitemap"
                         ).permitAll()
 

--- a/src/main/java/com/jdc/recipe_service/controller/CurationArticleController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/CurationArticleController.java
@@ -1,0 +1,55 @@
+package com.jdc.recipe_service.controller;
+
+import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleResponse;
+import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleSummaryResponse;
+import com.jdc.recipe_service.service.article.PublicCurationArticleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 큐레이션 아티클 (public) 조회 API.
+ *
+ * <p>이 프로젝트 컨벤션상 일반 유저용 컨트롤러는 도메인명만 쓰고 (RecipeController, IngredientController …),
+ * 특수 경계만 prefix를 붙인다 (Admin*, Dev*). 그래서 admin은 {@code AdminCurationArticleController}, public은
+ * 이 클래스가 담당한다.
+ *
+ * <p>인증 없이 접근 가능하며 항상 PUBLISHED 상태만 노출한다. DRAFT/ARCHIVED는 404로 매핑된다.
+ * 정렬은 publishedAt DESC, id DESC로 service 레이어에서 강제 — 클라이언트가 sort param을 변조해도
+ * 운영 의도와 다른 결과가 나오지 않는다.
+ */
+@RestController
+@RequestMapping("/api/curation-articles")
+@RequiredArgsConstructor
+@Tag(name = "큐레이션 아티클 API",
+        description = "발행된 큐레이션 아티클 목록/상세 공개 조회 API입니다.")
+public class CurationArticleController {
+
+    private final PublicCurationArticleService publicArticleService;
+
+    @GetMapping
+    @Operation(summary = "발행된 아티클 목록 조회",
+            description = """
+                    status=PUBLISHED 만 반환. category optional. 정렬은 publishedAt DESC, id DESC로 고정된다 (sort param은 무시됨).
+                    본문 contentMdx는 응답에서 제외.
+                    페이지 크기 정책: 기본 20, 최대 50. 50을 초과해 요청해도 service에서 50으로 clamp된다.""")
+    public ResponseEntity<Page<PublicCurationArticleSummaryResponse>> list(
+            @Parameter(description = "카테고리 필터") @RequestParam(required = false) String category,
+            @PageableDefault(size = 20) Pageable pageable) {
+        return ResponseEntity.ok(publicArticleService.listPublished(category, pageable));
+    }
+
+    @GetMapping("/{slug}")
+    @Operation(summary = "발행된 아티클 상세 조회 (slug 기준)",
+            description = "PUBLISHED 상태 아티클만 반환. DRAFT/ARCHIVED 또는 존재하지 않는 slug는 404 ARTICLE_NOT_FOUND.")
+    public ResponseEntity<PublicCurationArticleResponse> getBySlug(
+            @Parameter(description = "URL slug") @PathVariable String slug) {
+        return ResponseEntity.ok(publicArticleService.getBySlug(slug));
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/controller/admin/AdminCurationArticleController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/admin/AdminCurationArticleController.java
@@ -1,0 +1,149 @@
+package com.jdc.recipe_service.controller.admin;
+
+import com.jdc.recipe_service.domain.dto.article.ArticleImageFinalizeRequest;
+import com.jdc.recipe_service.domain.dto.article.ArticleImageFinalizeResponse;
+import com.jdc.recipe_service.domain.dto.article.ArticleImagePresignedUrlRequest;
+import com.jdc.recipe_service.domain.dto.article.ArticleImagePresignedUrlResponse;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleCreateRequest;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleResponse;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleSummaryResponse;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleUpdateRequest;
+import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import com.jdc.recipe_service.service.article.CurationArticleImageUploadService;
+import com.jdc.recipe_service.service.article.CurationArticleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * 어드민 전용 큐레이션 아티클 API.
+ *
+ * <p>SecurityConfig의 `/api/admin/**` ROLE_ADMIN 매처에 추가로 클래스 레벨 @PreAuthorize로 이중 방어한다.
+ * 일반 유저용 public API는 별도의 {@link com.jdc.recipe_service.controller.CurationArticleController}에서
+ * PUBLISHED 상태 아티클만 노출하도록 제공한다.
+ */
+@RestController
+@RequestMapping("/api/admin/curation-articles")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+@Tag(name = "관리자 전용 큐레이션 아티클 API",
+        description = "어드민 전용 큐레이션 아티클 CRUD/발행/이미지 업로드 API입니다.")
+public class AdminCurationArticleController {
+
+    private final CurationArticleService articleService;
+    private final CurationArticleImageUploadService imageUploadService;
+
+    @PostMapping
+    @Operation(summary = "아티클 생성", description = "DRAFT 상태로 새 아티클을 생성한다. recipeIds는 audit/soft link로 저장된다.")
+    public ResponseEntity<Map<String, Long>> create(
+            @RequestBody @Valid CurationArticleCreateRequest request) {
+        Long articleId = articleService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("articleId", articleId));
+    }
+
+    @GetMapping
+    @Operation(summary = "아티클 목록 조회",
+            description = "status/category/q(title LIKE) 모두 optional. Page 기반으로 총 개수가 응답에 포함된다.")
+    public ResponseEntity<Page<CurationArticleSummaryResponse>> list(
+            @Parameter(description = "발행 상태") @RequestParam(required = false) ArticleStatus status,
+            @Parameter(description = "카테고리") @RequestParam(required = false) String category,
+            @Parameter(description = "제목 LIKE 검색어") @RequestParam(required = false) String q,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(articleService.search(status, category, q, pageable));
+    }
+
+    @GetMapping("/{articleId}")
+    @Operation(summary = "아티클 상세 조회")
+    public ResponseEntity<CurationArticleResponse> get(
+            @Parameter(description = "아티클 ID") @PathVariable Long articleId) {
+        return ResponseEntity.ok(articleService.get(articleId));
+    }
+
+    @PutMapping("/{articleId}")
+    @Operation(summary = "아티클 수정",
+            description = "본문/메타데이터 + recipeIds 전체 교체. slug는 변경 불가. 본문이 바뀌면 humanReviewed가 false로 초기화된다.")
+    public ResponseEntity<Map<String, Long>> update(
+            @Parameter(description = "아티클 ID") @PathVariable Long articleId,
+            @RequestBody @Valid CurationArticleUpdateRequest request) {
+        Long updatedId = articleService.update(articleId, request);
+        return ResponseEntity.ok(Map.of("articleId", updatedId));
+    }
+
+    @PostMapping("/{articleId}/publish")
+    @Operation(summary = "아티클 발행",
+            description = "status=PUBLISHED. publishedAt이 null이면 현재 시각으로 채우고 이후 호출에서는 보존된다 (idempotent).")
+    public ResponseEntity<Void> publish(
+            @Parameter(description = "아티클 ID") @PathVariable Long articleId) {
+        articleService.publish(articleId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{articleId}/archive")
+    @Operation(summary = "아티클 아카이브", description = "status=ARCHIVED (idempotent).")
+    public ResponseEntity<Void> archive(
+            @Parameter(description = "아티클 ID") @PathVariable Long articleId) {
+        articleService.archive(articleId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{articleId}/review")
+    @Operation(summary = "사람 검수 완료 표시", description = "humanReviewed=true (idempotent).")
+    public ResponseEntity<Void> review(
+            @Parameter(description = "아티클 ID") @PathVariable Long articleId) {
+        articleService.markReviewed(articleId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{articleId}/images/presigned-urls")
+    @Operation(summary = "아티클 이미지 presigned PUT URL 발급 (articleId 기반)",
+            description = """
+                    articleId path variable이 가리키는 아티클 소속 이미지 업로드 URL을 발급한다.
+                    아티클이 없으면 ARTICLE_NOT_FOUND. DRAFT/PUBLISHED/ARCHIVED 어떤 상태에서도 어드민은 발급 가능하다.
+
+                    image/jpeg, image/png, image/webp만 허용. fileSize 10MB 이하.
+                    uploadKey와 imageKey 모두 서버에서 생성한다 — 프론트가 path를 결정하지 못한다.
+
+                    응답은 uploadKey(원본 업로드 위치) + imageKey(변환 후 .webp 위치) + presignedUrl 3개.
+                    프론트는 presignedUrl로 uploadKey에 PUT하고, DB(coverImageKey) 또는 MDX의 <ArticleImage imageKey="..."/>에는
+                    반드시 imageKey만 저장한다 — uploadKey는 변환 전 원본이라 화면 노출 대상이 아니다.
+
+                    주의(V1): fileSize 10MB 제한은 요청값에 대한 사전 검증일 뿐 presigned PUT 자체가 실제 업로드 크기를
+                    강제하지 않는다. 어드민 전용이라 V1에서 허용하며, 강제가 필요해지면 presigned POST + content-length-range
+                    또는 업로드 후 HEAD/finalize 검증을 별도로 도입한다.
+
+                    Key 패턴:
+                      uploadKey = original/images/articles/{articleId}/{uuid}.{ext}
+                      imageKey  = images/articles/{articleId}/{uuid}.webp""")
+    public ResponseEntity<ArticleImagePresignedUrlResponse> issueImagePresignedUrl(
+            @Parameter(description = "아티클 ID") @PathVariable Long articleId,
+            @RequestBody @Valid ArticleImagePresignedUrlRequest request) {
+        return ResponseEntity.ok(imageUploadService.issuePresignedUrl(articleId, request));
+    }
+
+    @PostMapping("/{articleId}/images/finalize")
+    @Operation(summary = "아티클 이미지 업로드 완료 확인 (S3 HEAD)",
+            description = """
+                    프론트가 S3 PUT을 끝낸 후, 변환된 .webp가 S3에 실제로 존재하는지 확인한다 (Lambda 변환 완료 검증).
+                    DB 상태는 변경하지 않고 단순히 존재 여부만 본다.
+
+                    검증 순서: ① articleId 존재 ② 각 imageKey가 images/articles/{articleId}/ 로 시작 + .webp 종료 ③ S3 HEAD.
+                    모두 존재하면 200 + ready=true.
+                    하나라도 없으면 409 + ARTICLE_IMAGES_NOT_READY (응답에 missingKeys 포함) — 프론트는 짧게 폴링하거나 사용자에게 다시 시도 안내.""")
+    public ResponseEntity<ArticleImageFinalizeResponse> finalizeImages(
+            @Parameter(description = "아티클 ID") @PathVariable Long articleId,
+            @RequestBody @Valid ArticleImageFinalizeRequest request) {
+        return ResponseEntity.ok(imageUploadService.finalizeImages(articleId, request.getImageKeys()));
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImageFinalizeRequest.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImageFinalizeRequest.java
@@ -1,0 +1,26 @@
+package com.jdc.recipe_service.domain.dto.article;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "아티클 이미지 finalize 요청 — S3에 변환 결과(.webp)가 실제로 존재하는지 확인한다.")
+public class ArticleImageFinalizeRequest {
+
+    @NotEmpty(message = "imageKeys는 비어 있을 수 없습니다.")
+    @Size(max = 50, message = "한 번에 finalize 가능한 imageKey 개수는 최대 50개입니다.")
+    @Schema(description = "확인할 imageKey 목록 (.webp). 모두 images/articles/{articleId}/ 형식이어야 한다. 한 번에 최대 50개.",
+            example = "[\"images/articles/42/abc-uuid.webp\", \"images/articles/42/def-uuid.webp\"]")
+    private List<@NotBlank @Size(max = 500) String> imageKeys;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImageFinalizeResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImageFinalizeResponse.java
@@ -1,0 +1,27 @@
+package com.jdc.recipe_service.domain.dto.article;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Finalize 성공 응답. 모든 imageKey가 S3에 존재할 때만 반환된다 (HTTP 200).
+ *
+ * <p>일부라도 누락된 경우는 ArticleImagesNotReadyException → GlobalExceptionHandler가
+ * HTTP 409 + missingKeys를 포함한 별도 shape으로 응답한다.
+ */
+@Getter
+@Builder
+@Schema(description = "아티클 이미지 finalize 성공 응답")
+public class ArticleImageFinalizeResponse {
+
+    @Schema(description = "모든 imageKey가 S3에 존재함을 의미. 항상 true (false 케이스는 409로 응답).",
+            example = "true")
+    private boolean ready;
+
+    @Schema(description = "확인 완료된 imageKey 목록 (요청과 동일).",
+            example = "[\"images/articles/42/abc-uuid.webp\"]")
+    private List<String> imageKeys;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImagePresignedUrlRequest.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImagePresignedUrlRequest.java
@@ -1,0 +1,27 @@
+package com.jdc.recipe_service.domain.dto.article;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "아티클 이미지 presigned URL 발급 요청")
+public class ArticleImagePresignedUrlRequest {
+
+    @NotBlank
+    @Schema(description = "Content-Type. image/jpeg, image/png, image/webp 만 허용", example = "image/webp")
+    private String contentType;
+
+    @NotNull
+    @Positive
+    @Schema(description = "파일 크기(byte). 10MB 이하만 허용", example = "245678")
+    private Long fileSize;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImagePresignedUrlResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImagePresignedUrlResponse.java
@@ -1,0 +1,35 @@
+package com.jdc.recipe_service.domain.dto.article;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 아티클 이미지 presigned URL 응답 (articleId 기반).
+ *
+ * <p>레시피 이미지와 동일하게 원본 → webp 변환 파이프라인을 사용하며 key는 articleId path를 포함한다.
+ * <ul>
+ *   <li>{@code uploadKey} ({@code original/images/articles/{articleId}/{uuid}.{ext}}): 프론트가 PUT 업로드할 위치(원본).</li>
+ *   <li>{@code imageKey} ({@code images/articles/{articleId}/{uuid}.webp}): Lambda 변환 후의 최종 위치. DB(coverImageKey),
+ *       MDX의 {@code <ArticleImage imageKey="..." />}에는 항상 이 키만 저장한다.</li>
+ *   <li>{@code presignedUrl}: {@code uploadKey}에 대한 S3 PUT URL. 발급 후 10분간 유효.</li>
+ * </ul>
+ *
+ * <p>주의: 프론트는 절대 {@code uploadKey}를 DB나 MDX에 저장하지 않는다 — 변환 전 원본 경로이기 때문이다.
+ */
+@Getter
+@Builder
+@Schema(description = "아티클 이미지 presigned URL 발급 응답 (articleId 기반)")
+public class ArticleImagePresignedUrlResponse {
+
+    @Schema(description = "S3 PUT 업로드 대상 키 (원본 위치, ext는 contentType에 따라 jpg/png/webp). articleId path 포함.",
+            example = "original/images/articles/123/4f5b3a3a-1a2b-4c5d-9e6f-1234567890ab.jpg")
+    private String uploadKey;
+
+    @Schema(description = "변환 후 최종 이미지 키 (.webp 고정). coverImageKey 또는 MDX에 저장한다.",
+            example = "images/articles/123/4f5b3a3a-1a2b-4c5d-9e6f-1234567890ab.webp")
+    private String imageKey;
+
+    @Schema(description = "uploadKey에 대한 presigned PUT URL. 10분간 유효.")
+    private String presignedUrl;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleCreateRequest.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleCreateRequest.java
@@ -1,0 +1,59 @@
+package com.jdc.recipe_service.domain.dto.article;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "큐레이션 아티클 생성 요청")
+public class CurationArticleCreateRequest {
+
+    @NotBlank
+    @Pattern(regexp = "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+            message = "slug는 소문자/숫자/하이픈만 허용됩니다.")
+    @Size(max = 200)
+    @Schema(description = "URL slug. 소문자/숫자/하이픈만 허용", example = "summer-diet-cucumber-recipes")
+    private String slug;
+
+    @NotBlank
+    @Size(max = 255)
+    @Schema(description = "제목", example = "여름 다이어트 오이 레시피 모음")
+    private String title;
+
+    @Size(max = 500)
+    @Schema(description = "메타 설명 (목록/SEO description)", example = "수분 95%의 오이로 만드는 가벼운 여름 한 끼")
+    private String description;
+
+    @Size(max = 500)
+    @Schema(description = "커버 이미지 S3 key. presigned URL 응답의 imageKey(.webp)를 저장한다 — uploadKey가 아니다.",
+            example = "images/articles/123/uuid.webp")
+    private String coverImageKey;
+
+    @NotBlank
+    @Schema(description = "본문 MDX 원본")
+    private String contentMdx;
+
+    @Size(max = 50)
+    @Schema(description = "카테고리", example = "diet")
+    private String category;
+
+    @Size(max = 100)
+    @Schema(description = "생성에 사용된 AI 모델 식별자", example = "claude-opus-4.7")
+    private String generatedBy;
+
+    @Schema(description = "참조한 레시피 ID 목록 (audit/soft link). 각 ID는 양의 정수여야 한다.")
+    private List<@NotNull(message = "recipeIds 항목에 null이 포함될 수 없습니다.")
+                 @Positive(message = "recipeIds 항목은 양의 정수여야 합니다.") Long> recipeIds;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleResponse.java
@@ -1,0 +1,77 @@
+package com.jdc.recipe_service.domain.dto.article;
+
+import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "큐레이션 아티클 상세 응답")
+public class CurationArticleResponse {
+
+    @Schema(description = "아티클 ID")
+    private Long id;
+
+    @Schema(description = "URL slug")
+    private String slug;
+
+    @Schema(description = "제목")
+    private String title;
+
+    @Schema(description = "메타 설명")
+    private String description;
+
+    @Schema(description = "커버 이미지 S3 key")
+    private String coverImageKey;
+
+    @Schema(description = "본문 MDX 원본")
+    private String contentMdx;
+
+    @Schema(description = "카테고리")
+    private String category;
+
+    @Schema(description = "발행 상태")
+    private ArticleStatus status;
+
+    @Schema(description = "생성 AI 모델 식별자")
+    private String generatedBy;
+
+    @Schema(description = "사람 검수 완료 여부")
+    private boolean humanReviewed;
+
+    @Schema(description = "최초 발행 시각")
+    private LocalDateTime publishedAt;
+
+    @Schema(description = "생성 시각")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시각")
+    private LocalDateTime updatedAt;
+
+    @Schema(description = "참조한 레시피 ID 목록 (audit)")
+    private List<Long> recipeIds;
+
+    public static CurationArticleResponse of(CurationArticle a, List<Long> recipeIds) {
+        return CurationArticleResponse.builder()
+                .id(a.getId())
+                .slug(a.getSlug())
+                .title(a.getTitle())
+                .description(a.getDescription())
+                .coverImageKey(a.getCoverImageKey())
+                .contentMdx(a.getContentMdx())
+                .category(a.getCategory())
+                .status(a.getStatus())
+                .generatedBy(a.getGeneratedBy())
+                .humanReviewed(a.isHumanReviewed())
+                .publishedAt(a.getPublishedAt())
+                .createdAt(a.getCreatedAt())
+                .updatedAt(a.getUpdatedAt())
+                .recipeIds(recipeIds)
+                .build();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleSummaryResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleSummaryResponse.java
@@ -1,0 +1,46 @@
+package com.jdc.recipe_service.domain.dto.article;
+
+import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 어드민 목록 응답. 본문 MDX는 포함하지 않는다 (목록 트래픽 절감).
+ */
+@Getter
+@Builder
+@Schema(description = "큐레이션 아티클 목록용 요약 응답")
+public class CurationArticleSummaryResponse {
+
+    private Long id;
+    private String slug;
+    private String title;
+    private String description;
+    private String coverImageKey;
+    private String category;
+    private ArticleStatus status;
+    private boolean humanReviewed;
+    private LocalDateTime publishedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static CurationArticleSummaryResponse of(CurationArticle a) {
+        return CurationArticleSummaryResponse.builder()
+                .id(a.getId())
+                .slug(a.getSlug())
+                .title(a.getTitle())
+                .description(a.getDescription())
+                .coverImageKey(a.getCoverImageKey())
+                .category(a.getCategory())
+                .status(a.getStatus())
+                .humanReviewed(a.isHumanReviewed())
+                .publishedAt(a.getPublishedAt())
+                .createdAt(a.getCreatedAt())
+                .updatedAt(a.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleUpdateRequest.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleUpdateRequest.java
@@ -1,0 +1,57 @@
+
+package com.jdc.recipe_service.domain.dto.article;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 큐레이션 아티클 수정 요청.
+ *
+ * <p>slug는 SEO URL 안정성을 위해 생성 후 변경할 수 없다. slug를 바꿔야 하면 archive 후 새로 생성한다.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "큐레이션 아티클 수정 요청 (slug 제외)")
+public class CurationArticleUpdateRequest {
+
+    @NotBlank
+    @Size(max = 255)
+    @Schema(description = "제목")
+    private String title;
+
+    @Size(max = 500)
+    @Schema(description = "메타 설명")
+    private String description;
+
+    @Size(max = 500)
+    @Schema(description = "커버 이미지 S3 key. presigned URL 응답의 imageKey(.webp)를 저장한다 — uploadKey가 아니다.",
+            example = "images/articles/123/uuid.webp")
+    private String coverImageKey;
+
+    @NotBlank
+    @Schema(description = "본문 MDX 원본")
+    private String contentMdx;
+
+    @Size(max = 50)
+    @Schema(description = "카테고리")
+    private String category;
+
+    @Size(max = 100)
+    @Schema(description = "생성에 사용된 AI 모델 식별자 (재생성 시 갱신)")
+    private String generatedBy;
+
+    @Schema(description = "참조한 레시피 ID 목록 — 요청 값으로 전체 교체된다. 각 ID는 양의 정수여야 한다.")
+    private List<@NotNull(message = "recipeIds 항목에 null이 포함될 수 없습니다.")
+                 @Positive(message = "recipeIds 항목은 양의 정수여야 합니다.") Long> recipeIds;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/PublicCurationArticleResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/PublicCurationArticleResponse.java
@@ -1,0 +1,63 @@
+package com.jdc.recipe_service.domain.dto.article;
+
+import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Public 큐레이션 아티클 상세 응답.
+ *
+ * <p>운영 전용 필드(status, generatedBy, humanReviewed, updatedAt)는 의도적으로 제외한다.
+ * 이 DTO는 PUBLISHED 상태 아티클에만 적용되므로 status를 노출할 의미도 없다.
+ * 어드민 UI는 별도의 {@link CurationArticleResponse}를 사용한다.
+ */
+@Getter
+@Builder
+@Schema(description = "Public 큐레이션 아티클 상세 응답")
+public class PublicCurationArticleResponse {
+
+    @Schema(description = "아티클 ID")
+    private Long id;
+
+    @Schema(description = "URL slug")
+    private String slug;
+
+    @Schema(description = "제목")
+    private String title;
+
+    @Schema(description = "메타 설명")
+    private String description;
+
+    @Schema(description = "커버 이미지 S3 imageKey (.webp)")
+    private String coverImageKey;
+
+    @Schema(description = "본문 MDX 원본")
+    private String contentMdx;
+
+    @Schema(description = "카테고리")
+    private String category;
+
+    @Schema(description = "발행 시각")
+    private LocalDateTime publishedAt;
+
+    @Schema(description = "참조한 레시피 ID 목록")
+    private List<Long> recipeIds;
+
+    public static PublicCurationArticleResponse of(CurationArticle a, List<Long> recipeIds) {
+        return PublicCurationArticleResponse.builder()
+                .id(a.getId())
+                .slug(a.getSlug())
+                .title(a.getTitle())
+                .description(a.getDescription())
+                .coverImageKey(a.getCoverImageKey())
+                .contentMdx(a.getContentMdx())
+                .category(a.getCategory())
+                .publishedAt(a.getPublishedAt())
+                .recipeIds(recipeIds)
+                .build();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/PublicCurationArticleSummaryResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/PublicCurationArticleSummaryResponse.java
@@ -1,0 +1,39 @@
+package com.jdc.recipe_service.domain.dto.article;
+
+import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * Public 큐레이션 아티클 목록 응답.
+ *
+ * <p>본문 MDX와 운영 전용 필드(status/generatedBy/humanReviewed)는 의도적으로 제외해 트래픽과 노출 위험을 줄인다.
+ */
+@Getter
+@Builder
+@Schema(description = "Public 큐레이션 아티클 목록 응답")
+public class PublicCurationArticleSummaryResponse {
+
+    private Long id;
+    private String slug;
+    private String title;
+    private String description;
+    private String coverImageKey;
+    private String category;
+    private LocalDateTime publishedAt;
+
+    public static PublicCurationArticleSummaryResponse of(CurationArticle a) {
+        return PublicCurationArticleSummaryResponse.builder()
+                .id(a.getId())
+                .slug(a.getSlug())
+                .title(a.getTitle())
+                .description(a.getDescription())
+                .coverImageKey(a.getCoverImageKey())
+                .category(a.getCategory())
+                .publishedAt(a.getPublishedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/entity/article/CurationArticle.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/article/CurationArticle.java
@@ -1,0 +1,86 @@
+package com.jdc.recipe_service.domain.entity.article;
+
+import com.jdc.recipe_service.domain.entity.common.BaseTimeEntity;
+import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "curation_articles", indexes = {
+        @Index(name = "idx_curation_articles_status_published",
+                columnList = "status, published_at DESC, id DESC"),
+        @Index(name = "idx_curation_articles_category_published",
+                columnList = "category, status, published_at DESC, id DESC")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CurationArticle extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 255)
+    private String slug;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(name = "cover_image_key", length = 500)
+    private String coverImageKey;
+
+    @Column(name = "content_mdx", columnDefinition = "LONGTEXT", nullable = false)
+    private String contentMdx;
+
+    @Column(length = 50)
+    private String category;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private ArticleStatus status = ArticleStatus.DRAFT;
+
+    @Column(name = "generated_by", length = 100)
+    private String generatedBy;
+
+    @Column(name = "human_reviewed", nullable = false)
+    @Builder.Default
+    private boolean humanReviewed = false;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    public void publish() {
+        if (this.publishedAt == null) {
+            this.publishedAt = LocalDateTime.now();
+        }
+        this.status = ArticleStatus.PUBLISHED;
+    }
+
+    public void archive() {
+        this.status = ArticleStatus.ARCHIVED;
+    }
+
+    public void markReviewed() {
+        this.humanReviewed = true;
+    }
+
+    public void updateContent(String title, String description, String contentMdx,
+                              String coverImageKey, String category, String generatedBy) {
+        this.title = title;
+        this.description = description;
+        this.contentMdx = contentMdx;
+        this.coverImageKey = coverImageKey;
+        this.category = category;
+        this.generatedBy = generatedBy;
+        // 본문이 바뀌면 이전 검수 승인은 무효다. 필요하면 다시 markReviewed()를 호출한다.
+        this.humanReviewed = false;
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/entity/article/CurationArticleRecipeRef.java
+++ b/src/main/java/com/jdc/recipe_service/domain/entity/article/CurationArticleRecipeRef.java
@@ -1,0 +1,41 @@
+package com.jdc.recipe_service.domain.entity.article;
+
+import com.jdc.recipe_service.domain.entity.common.BaseCreateTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 큐레이션 아티클이 참고한 레시피의 soft link.
+ *
+ * <p>화면 렌더링용 join 소스가 아니라, 어느 레시피들이 아티클 생성에 참고됐는지 audit하는 용도다.
+ * recipe_id에는 FK를 두지 않는다 — 레시피가 hard delete된 뒤에도 참조 이력을 보존해야 하기 때문이다.
+ * (chat_log.recipeId와 같은 audit 참조 패턴)
+ */
+@Entity
+@Table(name = "curation_article_recipe_refs",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_curation_article_recipe_refs_article_recipe",
+                columnNames = {"article_id", "recipe_id"}),
+        indexes = {
+                @Index(name = "idx_curation_article_recipe_refs_article",
+                        columnList = "article_id, id"),
+                @Index(name = "idx_curation_article_recipe_refs_recipe",
+                        columnList = "recipe_id")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CurationArticleRecipeRef extends BaseCreateTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private CurationArticle article;
+
+    @Column(name = "recipe_id", nullable = false)
+    private Long recipeId;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/repository/article/CurationArticleRecipeRefRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/article/CurationArticleRecipeRefRepository.java
@@ -1,0 +1,32 @@
+package com.jdc.recipe_service.domain.repository.article;
+
+import com.jdc.recipe_service.domain.entity.article.CurationArticleRecipeRef;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CurationArticleRecipeRefRepository extends JpaRepository<CurationArticleRecipeRef, Long> {
+
+    @Query("""
+            SELECT r.recipeId FROM CurationArticleRecipeRef r
+            WHERE r.article.id = :articleId
+            ORDER BY r.id ASC
+            """)
+    List<Long> findRecipeIdsByArticleId(@Param("articleId") Long articleId);
+
+    /**
+     * PUT 시 refs 전체 교체용. delete 후 saveAll 패턴으로 사용한다.
+     * flushAutomatically: 같은 트랜잭션 안에서 saveAll INSERT가 DELETE 이후 실행되도록 보장.
+     * clearAutomatically는 의도적으로 두지 않는다 — service.update()가 보유한 CurationArticle 엔티티가
+     * detach되어 후속 saveAll의 ManyToOne 부모 참조가 stale해질 위험을 만든다.
+     * 삭제된 ref 엔티티는 saveAll에서 새 ID로 INSERT되므로 stale 캐시 충돌 가능성은 없다.
+     */
+    @Modifying(flushAutomatically = true)
+    @Query("DELETE FROM CurationArticleRecipeRef r WHERE r.article.id = :articleId")
+    void deleteByArticleId(@Param("articleId") Long articleId);
+}

--- a/src/main/java/com/jdc/recipe_service/domain/repository/article/CurationArticleRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/article/CurationArticleRepository.java
@@ -1,0 +1,39 @@
+package com.jdc.recipe_service.domain.repository.article;
+
+import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CurationArticleRepository extends JpaRepository<CurationArticle, Long> {
+
+    boolean existsBySlug(String slug);
+
+    /**
+     * public 상세 조회용. PUBLISHED 외 status는 노출 금지이므로 status를 파라미터로 강제한다.
+     * (admin은 raw findById를 쓴다 — 의도 차이를 메서드 시그니처로 분리)
+     */
+    Optional<CurationArticle> findBySlugAndStatus(String slug, ArticleStatus status);
+
+    /**
+     * 어드민 목록: status / category / q(title LIKE) 모두 optional. null이면 조건에서 제외.
+     * Page로 반환해 어드민 화면 총 개수 노출을 지원한다.
+     */
+    @Query("""
+            SELECT a FROM CurationArticle a
+            WHERE (:status IS NULL OR a.status = :status)
+              AND (:category IS NULL OR a.category = :category)
+              AND (:q IS NULL OR a.title LIKE CONCAT('%', :q, '%'))
+            """)
+    Page<CurationArticle> search(@Param("status") ArticleStatus status,
+                                 @Param("category") String category,
+                                 @Param("q") String q,
+                                 Pageable pageable);
+}

--- a/src/main/java/com/jdc/recipe_service/domain/type/article/ArticleStatus.java
+++ b/src/main/java/com/jdc/recipe_service/domain/type/article/ArticleStatus.java
@@ -1,0 +1,7 @@
+package com.jdc.recipe_service.domain.type.article;
+
+public enum ArticleStatus {
+    DRAFT,
+    PUBLISHED,
+    ARCHIVED
+}

--- a/src/main/java/com/jdc/recipe_service/exception/ArticleImagesNotReadyException.java
+++ b/src/main/java/com/jdc/recipe_service/exception/ArticleImagesNotReadyException.java
@@ -1,0 +1,24 @@
+package com.jdc.recipe_service.exception;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Finalize 시점에 일부 imageKey가 S3에 아직 없을 때 던진다.
+ *
+ * <p>ErrorCode {@link ErrorCode#ARTICLE_IMAGES_NOT_READY} (1207, 409)로 매핑되며, GlobalExceptionHandler가
+ * 일반 ErrorResponse가 아닌 별도 shape({@code missingKeys}, {@code presentKeys} 포함)으로 응답한다.
+ */
+@Getter
+public class ArticleImagesNotReadyException extends RuntimeException {
+
+    private final List<String> missingKeys;
+    private final List<String> presentKeys;
+
+    public ArticleImagesNotReadyException(List<String> missingKeys, List<String> presentKeys) {
+        super(ErrorCode.ARTICLE_IMAGES_NOT_READY.getMessage());
+        this.missingKeys = List.copyOf(missingKeys);
+        this.presentKeys = List.copyOf(presentKeys);
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/exception/ErrorCode.java
+++ b/src/main/java/com/jdc/recipe_service/exception/ErrorCode.java
@@ -106,7 +106,16 @@ public enum ErrorCode {
     RECIPE_BOOK_DEFAULT_CANNOT_RENAME(HttpStatus.BAD_REQUEST, "1104", "기본 레시피북은 이름을 변경할 수 없습니다."),
     RECIPE_BOOK_DUPLICATE_ITEM(HttpStatus.CONFLICT, "1105", "이미 해당 레시피북에 추가된 레시피입니다."),
     RECIPE_BOOK_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "1106", "레시피북 생성 한도를 초과했습니다."),
-    RECIPE_BOOK_DUPLICATE_NAME(HttpStatus.CONFLICT, "1107", "이미 같은 이름의 레시피북이 존재합니다.");
+    RECIPE_BOOK_DUPLICATE_NAME(HttpStatus.CONFLICT, "1107", "이미 같은 이름의 레시피북이 존재합니다."),
+
+    // --- Curation Article (1200) ---
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "1201", "요청한 큐레이션 아티클이 존재하지 않습니다."),
+    ARTICLE_SLUG_DUPLICATE(HttpStatus.CONFLICT, "1202", "이미 사용 중인 slug입니다."),
+    ARTICLE_INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "1203", "허용되지 않은 아티클 상태 전이입니다."),
+    ARTICLE_INVALID_RECIPE_REF(HttpStatus.BAD_REQUEST, "1204", "참조한 레시피 중 존재하지 않는 ID가 있습니다."),
+    ARTICLE_IMAGE_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "1205", "지원하지 않는 이미지 형식입니다. (jpeg/png/webp만 허용)"),
+    ARTICLE_IMAGE_TOO_LARGE(HttpStatus.BAD_REQUEST, "1206", "이미지 크기가 허용 한도(10MB)를 초과합니다."),
+    ARTICLE_IMAGES_NOT_READY(HttpStatus.CONFLICT, "1207", "아직 변환되지 않았거나 업로드되지 않은 이미지가 있습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/jdc/recipe_service/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/jdc/recipe_service/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.jdc.recipe_service.handler;
 
+import com.jdc.recipe_service.exception.ArticleImagesNotReadyException;
 import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.exception.ErrorResponse;
@@ -15,6 +16,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -65,6 +67,23 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
                 .body(new ErrorResponse(ErrorCode.USER_NOT_FOUND.getCode(), "존재하지 않는 회원입니다. 다시 로그인해주세요."));
+    }
+
+    /**
+     * @PreAuthorize 등 method security가 던지는 AccessDeniedException을 403으로 매핑한다.
+     *
+     * <p>운영 경로에서는 ExceptionTranslationFilter가 처리하지만, filter chain을 우회한 경로
+     * (예: @WebMvcTest의 addFilters=false, 비표준 invocation)에서도 catch-all 500이 아닌 403이
+     * 나가도록 보강한다. 메시지/코드는 ADMIN_ACCESS_DENIED를 재사용한다 — 이 프로젝트의 @PreAuthorize는
+     * 사실상 admin 게이트 용도로만 쓰인다.
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex) {
+        log.warn("AccessDenied: {}", ex.getMessage());
+        ErrorCode errorCode = ErrorCode.ADMIN_ACCESS_DENIED;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ErrorResponse(errorCode.getCode(), errorCode.getMessage()));
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
@@ -210,6 +229,29 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorResponse("903", "서버 내부 오류가 발생했습니다. 문제가 지속되면 관리자에게 문의해주세요.", errorId));
+    }
+
+    /**
+     * Finalize 시점에 일부 imageKey가 S3에 없을 때 응답한다.
+     *
+     * <p>일반 ErrorResponse({code, message})를 확장해 missingKeys/presentKeys까지 포함한다 — 프론트가
+     * 정확히 어떤 키가 아직 변환 안 됐는지 알아야 폴링/리트라이 UX를 만들 수 있기 때문.
+     * (DailyQuotaExceededException의 retryAfter 패턴과 동일.)
+     */
+    @ExceptionHandler(ArticleImagesNotReadyException.class)
+    public ResponseEntity<Map<String, Object>> handleArticleImagesNotReady(ArticleImagesNotReadyException ex) {
+        ErrorCode errorCode = ErrorCode.ARTICLE_IMAGES_NOT_READY;
+        // 정상 폴링 과정에서 자주 발생하는 409라 debug로 낮춤. 운영 로그 노이즈 방지.
+        log.debug("Article images not ready: missing={}", ex.getMissingKeys());
+
+        Map<String, Object> body = Map.of(
+                "code", errorCode.getCode(),
+                "message", errorCode.getMessage(),
+                "missingKeys", ex.getMissingKeys(),
+                "presentKeys", ex.getPresentKeys()
+        );
+
+        return ResponseEntity.status(errorCode.getStatus()).body(body);
     }
 
     @ExceptionHandler(DailyQuotaService.DailyQuotaExceededException.class)

--- a/src/main/java/com/jdc/recipe_service/service/article/CurationArticleImageUploadService.java
+++ b/src/main/java/com/jdc/recipe_service/service/article/CurationArticleImageUploadService.java
@@ -1,0 +1,157 @@
+package com.jdc.recipe_service.service.article;
+
+import com.jdc.recipe_service.domain.dto.article.ArticleImageFinalizeResponse;
+import com.jdc.recipe_service.domain.dto.article.ArticleImagePresignedUrlRequest;
+import com.jdc.recipe_service.domain.dto.article.ArticleImagePresignedUrlResponse;
+import com.jdc.recipe_service.domain.repository.article.CurationArticleRepository;
+import com.jdc.recipe_service.exception.ArticleImagesNotReadyException;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.util.S3Util;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * 어드민 큐레이션 아티클 이미지 업로드.
+ *
+ * <p>레시피 이미지와 동일한 원본→webp 변환 구조 + articleId 기반 key 정책:
+ * <pre>
+ *   uploadKey  : original/images/articles/{articleId}/{uuid}.{ext}   (프론트 PUT 업로드 대상)
+ *   imageKey   : images/articles/{articleId}/{uuid}.webp             (변환 후 최종, DB/MDX에 저장)
+ * </pre>
+ *
+ * <p>articleId를 path에 박아두는 이유는 운영 추적성 — S3 key만 봐도 어느 글에 속한 이미지인지 알 수 있고,
+ * 글 삭제 시 prefix 단위 정리(`original/images/articles/{id}/`, `images/articles/{id}/`)가 가능해진다.
+ *
+ * <p>fileKey는 서버에서만 생성해 프론트가 S3 path를 결정하지 못하게 한다. DRAFT/PUBLISHED/ARCHIVED 어떤 상태에서도
+ * 어드민은 이미지 업로드 URL을 받을 수 있다 — 발행 후 본문 수정 중 이미지 추가 시나리오를 막지 않기 위함.
+ *
+ * <p><b>fileSize 검증의 한계 (V1)</b>: 요청 DTO의 fileSize ≤ 10MB는 <em>요청값에 대한 사전 검증</em>일 뿐
+ * presigned PUT URL 자체가 실제 업로드 크기를 강제하지 않는다. 클라이언트가 fileSize 245678로 신청하고 실제로는
+ * 50MB를 PUT해도 S3는 받아준다. 어드민 전용 + 운영자 신뢰 가정하에 V1에서는 사전 검증만 둔다.
+ *
+ * <p>참고: 본 서비스의 {@link #finalizeImages} 는 <strong>변환 결과 .webp 객체의 존재 여부만 확인</strong>하며
+ * ContentLength(실제 업로드 크기) 검사는 하지 않는다. 따라서 fileSize 강제는 finalize로 해결되지 않는다.
+ * 강제가 필요해지면 별도 작업이 필요하다:
+ * <ul>
+ *   <li>presigned <em>POST</em> + content-length-range 정책으로 전환, 또는</li>
+ *   <li>finalize에서 HeadObjectResponse.contentLength()까지 검사하도록 확장 (단, 변환 후 webp의 크기는 원본과 다름)</li>
+ * </ul>
+ *
+ * <p>TODO(image-pipeline): Lambda recipe-image-resizer가 articles 분기에서 다음 입출력을 처리해야 한다.
+ * <pre>
+ *   입력: original/images/articles/{articleId}/{uuid}.{ext}
+ *   출력: images/articles/{articleId}/{uuid}.webp
+ *   변환: width 1024, withoutEnlargement true, webp quality 85
+ * </pre>
+ * recipes 라우팅({@code original/images/recipes/} → {@code images/recipes/})은 이미 잡혀 있고, 여기에
+ * articles 분기가 추가되어야 한다. 인프라/Lambda 갱신은 별도 배포 항목.
+ */
+@Service
+@RequiredArgsConstructor
+public class CurationArticleImageUploadService {
+
+    private static final Set<String> ALLOWED_CONTENT_TYPES =
+            Set.of("image/jpeg", "image/png", "image/webp");
+
+    private static final Map<String, String> EXTENSION_BY_CONTENT_TYPE = Map.of(
+            "image/jpeg", "jpg",
+            "image/png", "png",
+            "image/webp", "webp"
+    );
+
+    private static final long MAX_FILE_SIZE_BYTES = 10L * 1024 * 1024;
+
+    private static final String IMAGE_KEY_PREFIX = "images/articles";
+    private static final String UPLOAD_KEY_PREFIX = "original/" + IMAGE_KEY_PREFIX;
+    private static final String CONVERTED_EXTENSION = "webp";
+
+    private final S3Util s3Util;
+    private final CurationArticleRepository articleRepo;
+
+    public ArticleImagePresignedUrlResponse issuePresignedUrl(Long articleId,
+                                                              ArticleImagePresignedUrlRequest req) {
+        if (!articleRepo.existsById(articleId)) {
+            throw new CustomException(ErrorCode.ARTICLE_NOT_FOUND);
+        }
+
+        String contentType = req.getContentType();
+        if (!ALLOWED_CONTENT_TYPES.contains(contentType)) {
+            throw new CustomException(ErrorCode.ARTICLE_IMAGE_INVALID_CONTENT_TYPE);
+        }
+        if (req.getFileSize() > MAX_FILE_SIZE_BYTES) {
+            throw new CustomException(ErrorCode.ARTICLE_IMAGE_TOO_LARGE);
+        }
+
+        String uuid = UUID.randomUUID().toString();
+        String uploadKey = String.format("%s/%d/%s.%s",
+                UPLOAD_KEY_PREFIX, articleId, uuid, EXTENSION_BY_CONTENT_TYPE.get(contentType));
+        String imageKey = String.format("%s/%d/%s.%s",
+                IMAGE_KEY_PREFIX, articleId, uuid, CONVERTED_EXTENSION);
+
+        String presignedUrl = s3Util.createPresignedUrl(uploadKey, contentType);
+
+        return ArticleImagePresignedUrlResponse.builder()
+                .uploadKey(uploadKey)
+                .imageKey(imageKey)
+                .presignedUrl(presignedUrl)
+                .build();
+    }
+
+    /**
+     * 프론트가 PUT을 끝낸 imageKey들이 S3에 실제로 존재하는지(=Lambda 변환 완료) 확인한다.
+     *
+     * <p>검증 순서:
+     * <ol>
+     *   <li>articleId 존재</li>
+     *   <li>각 key가 {@code images/articles/{articleId}/}로 시작하고 {@code .webp}로 끝나는지 (다른 글의 키 사칭 방지)</li>
+     *   <li>S3 HEAD로 객체 존재 여부 확인</li>
+     * </ol>
+     *
+     * <p>모든 키가 존재하면 ready=true 응답. 하나라도 누락되면 {@link ArticleImagesNotReadyException}을 던져
+     * 409 + missingKeys 응답으로 매핑된다.
+     */
+    public ArticleImageFinalizeResponse finalizeImages(Long articleId, List<String> imageKeys) {
+        if (!articleRepo.existsById(articleId)) {
+            throw new CustomException(ErrorCode.ARTICLE_NOT_FOUND);
+        }
+
+        String requiredPrefix = String.format("%s/%d/", IMAGE_KEY_PREFIX, articleId);
+        List<String> distinct = imageKeys.stream().distinct().toList();
+
+        for (String key : distinct) {
+            if (key == null || !key.startsWith(requiredPrefix) || !key.endsWith("." + CONVERTED_EXTENSION)) {
+                // 다른 article의 키 사칭 방지 + 변환 결과(.webp)만 허용
+                throw new CustomException(ErrorCode.INVALID_INPUT_VALUE,
+                        "imageKey 형식이 잘못되었습니다: " + key);
+            }
+        }
+
+        List<String> missing = new ArrayList<>();
+        List<String> present = new ArrayList<>();
+        for (String key : distinct) {
+            // isObjectPresent는 404만 false. 권한/네트워크 문제는 예외로 propagate되어 catch-all 500이 되며,
+            // 프론트가 "아직 변환 안 됨"으로 오해하고 무한 폴링하는 것을 막는다.
+            if (s3Util.isObjectPresent(key)) {
+                present.add(key);
+            } else {
+                missing.add(key);
+            }
+        }
+
+        if (!missing.isEmpty()) {
+            throw new ArticleImagesNotReadyException(missing, present);
+        }
+
+        return ArticleImageFinalizeResponse.builder()
+                .ready(true)
+                .imageKeys(present)
+                .build();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/service/article/CurationArticleService.java
+++ b/src/main/java/com/jdc/recipe_service/service/article/CurationArticleService.java
@@ -1,0 +1,152 @@
+package com.jdc.recipe_service.service.article;
+
+import com.jdc.recipe_service.domain.dto.article.CurationArticleCreateRequest;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleResponse;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleSummaryResponse;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleUpdateRequest;
+import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.entity.article.CurationArticleRecipeRef;
+import com.jdc.recipe_service.domain.repository.RecipeRepository;
+import com.jdc.recipe_service.domain.repository.article.CurationArticleRecipeRefRepository;
+import com.jdc.recipe_service.domain.repository.article.CurationArticleRepository;
+import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 큐레이션 아티클 어드민 유스케이스.
+ *
+ * <p>V1에서는 status 전이 제약을 두지 않는다 (publish/archive 모두 idempotent). 향후 더 엄격한 정책이 필요해지면
+ * ARTICLE_INVALID_STATUS_TRANSITION을 사용해 게이트한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CurationArticleService {
+
+    private final CurationArticleRepository articleRepo;
+    private final CurationArticleRecipeRefRepository refRepo;
+    private final RecipeRepository recipeRepo;
+
+    // ── Read ──
+
+    public CurationArticleResponse get(Long articleId) {
+        CurationArticle article = loadArticle(articleId);
+        List<Long> refs = refRepo.findRecipeIdsByArticleId(articleId);
+        return CurationArticleResponse.of(article, refs);
+    }
+
+    public Page<CurationArticleSummaryResponse> search(ArticleStatus status,
+                                                       String category,
+                                                       String q,
+                                                       Pageable pageable) {
+        return articleRepo.search(status, nullIfBlank(category), nullIfBlank(q), pageable)
+                .map(CurationArticleSummaryResponse::of);
+    }
+
+    // ── Write ──
+
+    @Transactional
+    public Long create(CurationArticleCreateRequest req) {
+        if (articleRepo.existsBySlug(req.getSlug())) {
+            throw new CustomException(ErrorCode.ARTICLE_SLUG_DUPLICATE);
+        }
+        validateRecipeIds(req.getRecipeIds());
+
+        CurationArticle article = CurationArticle.builder()
+                .slug(req.getSlug())
+                .title(req.getTitle())
+                .description(req.getDescription())
+                .coverImageKey(req.getCoverImageKey())
+                .contentMdx(req.getContentMdx())
+                .category(req.getCategory())
+                .generatedBy(req.getGeneratedBy())
+                .build();
+        CurationArticle saved = articleRepo.save(article);
+
+        saveRefs(saved, req.getRecipeIds());
+        return saved.getId();
+    }
+
+    @Transactional
+    public Long update(Long articleId, CurationArticleUpdateRequest req) {
+        CurationArticle article = loadArticle(articleId);
+        validateRecipeIds(req.getRecipeIds());
+
+        article.updateContent(
+                req.getTitle(),
+                req.getDescription(),
+                req.getContentMdx(),
+                req.getCoverImageKey(),
+                req.getCategory(),
+                req.getGeneratedBy()
+        );
+
+        refRepo.deleteByArticleId(articleId);
+        saveRefs(article, req.getRecipeIds());
+
+        return article.getId();
+    }
+
+    @Transactional
+    public void publish(Long articleId) {
+        loadArticle(articleId).publish();
+    }
+
+    @Transactional
+    public void archive(Long articleId) {
+        loadArticle(articleId).archive();
+    }
+
+    @Transactional
+    public void markReviewed(Long articleId) {
+        loadArticle(articleId).markReviewed();
+    }
+
+    // ── helpers ──
+
+    private CurationArticle loadArticle(Long articleId) {
+        return articleRepo.findById(articleId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
+    }
+
+    private void validateRecipeIds(List<Long> recipeIds) {
+        if (recipeIds == null || recipeIds.isEmpty()) return;
+
+        // DTO에 element-level @NotNull/@Positive가 있지만, service 단독 호출(향후 internal caller / batch)
+        // 경로도 안전해야 한다. recipeRepo.findAllById가 null element를 받으면 IllegalArgumentException으로
+        // 터지면서 catch-all 500이 나갈 수 있어 여기서 명시적 4xx로 차단한다.
+        if (recipeIds.stream().anyMatch(id -> id == null || id <= 0)) {
+            throw new CustomException(ErrorCode.ARTICLE_INVALID_RECIPE_REF);
+        }
+
+        List<Long> distinct = recipeIds.stream().distinct().toList();
+        long foundCount = recipeRepo.findAllById(distinct).size();
+        if (foundCount != distinct.size()) {
+            throw new CustomException(ErrorCode.ARTICLE_INVALID_RECIPE_REF);
+        }
+    }
+
+    private void saveRefs(CurationArticle article, List<Long> recipeIds) {
+        if (recipeIds == null || recipeIds.isEmpty()) return;
+        List<CurationArticleRecipeRef> refs = recipeIds.stream()
+                .distinct()
+                .map(rid -> CurationArticleRecipeRef.builder()
+                        .article(article)
+                        .recipeId(rid)
+                        .build())
+                .toList();
+        refRepo.saveAll(refs);
+    }
+
+    private static String nullIfBlank(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/service/article/PublicCurationArticleService.java
+++ b/src/main/java/com/jdc/recipe_service/service/article/PublicCurationArticleService.java
@@ -1,0 +1,65 @@
+package com.jdc.recipe_service.service.article;
+
+import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleResponse;
+import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleSummaryResponse;
+import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.repository.article.CurationArticleRecipeRefRepository;
+import com.jdc.recipe_service.domain.repository.article.CurationArticleRepository;
+import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Public 큐레이션 아티클 조회 유스케이스.
+ *
+ * <p>admin {@link CurationArticleService}와 클래스를 분리해 PUBLISHED 외 상태가 절대 노출되지 않도록 한다 —
+ * 단일 service에서 분기를 두면 향후 메서드 추가 시 PUBLISHED 필터를 빠뜨릴 위험이 있다.
+ *
+ * <p>정렬은 service 레이어에서 publishedAt DESC, id DESC로 강제한다 — 외부에서 sort 파라미터를 조작해
+ * 다른 정렬을 받아갈 수 없게 한다 (캐시/CDN 키 안정성에도 도움).
+ *
+ * <p>page size는 public API 특성상 임의의 큰 값(예: size=100000)으로 인한 서버 부담을 막기 위해 service에서
+ * {@link #MAX_PAGE_SIZE}로 clamp한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PublicCurationArticleService {
+
+    static final int MAX_PAGE_SIZE = 50;
+
+    private final CurationArticleRepository articleRepo;
+    private final CurationArticleRecipeRefRepository refRepo;
+
+    public Page<PublicCurationArticleSummaryResponse> listPublished(String category, Pageable pageable) {
+        int clampedSize = Math.min(Math.max(pageable.getPageSize(), 1), MAX_PAGE_SIZE);
+        Pageable enforced = PageRequest.of(
+                pageable.getPageNumber(),
+                clampedSize,
+                Sort.by(Sort.Order.desc("publishedAt"), Sort.Order.desc("id"))
+        );
+        return articleRepo
+                .search(ArticleStatus.PUBLISHED, nullIfBlank(category), null, enforced)
+                .map(PublicCurationArticleSummaryResponse::of);
+    }
+
+    public PublicCurationArticleResponse getBySlug(String slug) {
+        CurationArticle article = articleRepo.findBySlugAndStatus(slug, ArticleStatus.PUBLISHED)
+                .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
+        List<Long> recipeIds = refRepo.findRecipeIdsByArticleId(article.getId());
+        return PublicCurationArticleResponse.of(article, recipeIds);
+    }
+
+    private static String nullIfBlank(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/util/S3Util.java
+++ b/src/main/java/com/jdc/recipe_service/util/S3Util.java
@@ -70,6 +70,28 @@ public class S3Util {
         }
     }
 
+    /**
+     * doesObjectExist의 엄격 버전. <strong>404/NoSuchKey만 false</strong>를 반환하고, 그 외 S3Exception
+     * (403 권한 문제, 5xx, 네트워크 등)은 그대로 propagate해서 catch-all 500으로 매핑되게 한다.
+     *
+     * <p>finalize 같은 "객체 존재 검증" 호출자는 권한/리전 오설정 같은 환경 문제가 "아직 변환 안 됨"으로
+     * 잘못 보고되어 프론트가 무한 폴링하는 것을 막기 위해 이 메서드를 사용한다.
+     */
+    public boolean isObjectPresent(String fileKey) {
+        try {
+            s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(fileKey)
+                    .build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) return false;
+            throw e;
+        }
+    }
+
     public void deleteFiles(List<String> fileKeys) {
         if (fileKeys.isEmpty()) return;
         List<ObjectIdentifier> objects = fileKeys.stream()

--- a/src/main/resources/db/migration/V20260504_001__create_curation_articles.sql
+++ b/src/main/resources/db/migration/V20260504_001__create_curation_articles.sql
@@ -1,0 +1,58 @@
+-- 큐레이션 아티클: 운영자가 직접 올리는 MDX 기반 매거진형 글.
+-- 일반 유저 CRUD가 아니라 내부 운영 툴에서만 쓰는 어드민 전용 도메인이다.
+-- 검색은 OpenSearch에 위임하므로 MySQL FULLTEXT 및 content_text 캐시는 두지 않는다.
+-- v1에서는 다중 태그 대신 category 단일값으로 시작한다. 필요해지면 additive로 curation_article_tags를 추가한다.
+
+-- =========================================================================
+-- 1. curation_articles - 본문 (MDX 통째로 저장)
+-- =========================================================================
+CREATE TABLE curation_articles (
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
+    slug            VARCHAR(255) NOT NULL,
+    title           VARCHAR(255) NOT NULL,
+    description     VARCHAR(500) NULL,
+    cover_image_key VARCHAR(500) NULL,
+
+    content_mdx     LONGTEXT     NOT NULL,
+
+    category        VARCHAR(50)  NULL,
+    -- DRAFT / PUBLISHED / ARCHIVED. Java enum + @Enumerated(STRING).
+    status          VARCHAR(20)  NOT NULL DEFAULT 'DRAFT',
+
+    generated_by    VARCHAR(100) NULL,
+    human_reviewed  TINYINT(1)   NOT NULL DEFAULT 0,
+
+    published_at    DATETIME(6)  NULL,
+    created_at      DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_curation_articles_slug (slug),
+    KEY idx_curation_articles_status_published   (status, published_at DESC, id DESC),
+    KEY idx_curation_articles_category_published (category, status, published_at DESC, id DESC)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+-- =========================================================================
+-- 2. curation_article_recipe_refs - 아티클 ↔ 레시피 soft link (audit/reference)
+-- =========================================================================
+-- 화면 렌더링용 join 소스가 아니라, "이 아티클이 어떤 레시피를 참고해 만들어졌는지"
+-- 추적용 테이블이다. 본문 자체는 self-contained MDX이므로 ref가 비어 있어도 글은 그대로 렌더된다.
+--
+-- recipe_id FK 미설정: 레시피 hard delete 후에도 아티클 생성 참고 이력을 보존한다.
+-- chat_log처럼 audit/reference 성격의 느슨한 참조로 관리한다.
+CREATE TABLE curation_article_recipe_refs (
+    id         BIGINT      NOT NULL AUTO_INCREMENT,
+    article_id BIGINT      NOT NULL,
+    recipe_id  BIGINT      NOT NULL,
+
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+
+    PRIMARY KEY (id),
+    CONSTRAINT fk_curation_article_recipe_refs_article
+        FOREIGN KEY (article_id) REFERENCES curation_articles (id) ON DELETE CASCADE,
+    CONSTRAINT uk_curation_article_recipe_refs_article_recipe
+        UNIQUE (article_id, recipe_id),
+    KEY idx_curation_article_recipe_refs_article (article_id, id),
+    KEY idx_curation_article_recipe_refs_recipe  (recipe_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/test/java/com/jdc/recipe_service/controller/CurationArticleControllerWebMvcTest.java
+++ b/src/test/java/com/jdc/recipe_service/controller/CurationArticleControllerWebMvcTest.java
@@ -1,0 +1,148 @@
+package com.jdc.recipe_service.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleResponse;
+import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleSummaryResponse;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.handler.GlobalExceptionHandler;
+import com.jdc.recipe_service.jwt.JwtTokenProvider;
+import com.jdc.recipe_service.security.CustomAuthenticationEntryPoint;
+import com.jdc.recipe_service.service.article.PublicCurationArticleService;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@link CurationArticleController} @WebMvcTest. (이 프로젝트는 일반 유저용 컨트롤러에 prefix를 붙이지 않는다.)
+ *
+ * <p>인증 불필요. service가 PUBLISHED 필터를 강제하므로 controller는 단순히 service를 위임한다 —
+ * 컨트롤러 테스트는 (1) 라우팅 정확성 (2) status 매핑 (3) 응답 shape의 unpublished 필드 미노출에 집중한다.
+ */
+@WebMvcTest(controllers = CurationArticleController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({GlobalExceptionHandler.class,
+        CurationArticleControllerWebMvcTest.MeterRegistryTestConfig.class})
+class CurationArticleControllerWebMvcTest {
+
+    @TestConfiguration
+    static class MeterRegistryTestConfig {
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockBean PublicCurationArticleService publicArticleService;
+    @MockBean JwtTokenProvider jwtTokenProvider;
+    @MockBean UserDetailsService userDetailsService;
+    @MockBean CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Test
+    @DisplayName("GET /api/curation-articles: 200 + Page 응답 + 운영 전용 필드(status/generatedBy/humanReviewed) 미노출")
+    void list_ok() throws Exception {
+        PublicCurationArticleSummaryResponse item = PublicCurationArticleSummaryResponse.builder()
+                .id(7L)
+                .slug("summer-diet")
+                .title("여름 다이어트")
+                .description("desc")
+                .coverImageKey("images/articles/7/uuid.webp")
+                .category("diet")
+                .publishedAt(LocalDateTime.of(2026, 5, 1, 10, 0))
+                .build();
+        given(publicArticleService.listPublished(eq("diet"), any()))
+                .willReturn(new PageImpl<>(List.of(item), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/curation-articles")
+                        .param("category", "diet"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(7))
+                .andExpect(jsonPath("$.content[0].slug").value("summer-diet"))
+                .andExpect(jsonPath("$.content[0].title").value("여름 다이어트"))
+                .andExpect(jsonPath("$.content[0].coverImageKey").value("images/articles/7/uuid.webp"))
+                // 운영 전용 필드는 응답 schema에 존재하지 않아야 한다
+                .andExpect(jsonPath("$.content[0].status").doesNotExist())
+                .andExpect(jsonPath("$.content[0].generatedBy").doesNotExist())
+                .andExpect(jsonPath("$.content[0].humanReviewed").doesNotExist())
+                .andExpect(jsonPath("$.content[0].contentMdx").doesNotExist())
+                // 메타데이터는 $.page 하위에 nested. WebConfig의 @EnableSpringDataWebSupport(VIA_DTO)로
+                // 명시 고정된 wire shape이라 환경/버전과 무관하게 안정적이다 — 프론트 계약으로 회귀 잡는다.
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$.page.size").value(20))
+                .andExpect(jsonPath("$.page.number").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /api/curation-articles/{slug}: 200 + 본문/recipeIds 포함 + 운영 필드 미노출")
+    void getBySlug_ok() throws Exception {
+        PublicCurationArticleResponse resp = PublicCurationArticleResponse.builder()
+                .id(7L)
+                .slug("summer-diet")
+                .title("여름 다이어트")
+                .contentMdx("# body")
+                .coverImageKey("images/articles/7/uuid.webp")
+                .recipeIds(List.of(11L, 12L))
+                .publishedAt(LocalDateTime.of(2026, 5, 1, 10, 0))
+                .build();
+        given(publicArticleService.getBySlug("summer-diet")).willReturn(resp);
+
+        mockMvc.perform(get("/api/curation-articles/{slug}", "summer-diet"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(7))
+                .andExpect(jsonPath("$.slug").value("summer-diet"))
+                .andExpect(jsonPath("$.contentMdx").value("# body"))
+                .andExpect(jsonPath("$.recipeIds[0]").value(11))
+                .andExpect(jsonPath("$.recipeIds[1]").value(12))
+                .andExpect(jsonPath("$.status").doesNotExist())
+                .andExpect(jsonPath("$.generatedBy").doesNotExist())
+                .andExpect(jsonPath("$.humanReviewed").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /api/curation-articles/{slug}: DRAFT 상태 slug는 service에서 ARTICLE_NOT_FOUND 던지고 404 + code=1201로 응답")
+    void getBySlug_draft_returns404() throws Exception {
+        given(publicArticleService.getBySlug("draft-slug"))
+                .willThrow(new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
+
+        mockMvc.perform(get("/api/curation-articles/{slug}", "draft-slug"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("1201"));
+    }
+
+    @Test
+    @DisplayName("GET /api/curation-articles/{slug}: ARCHIVED 상태도 동일하게 404 + ARTICLE_NOT_FOUND")
+    void getBySlug_archived_returns404() throws Exception {
+        // service 레이어에서 ARCHIVED는 PUBLISHED 필터에 걸러져 동일하게 ARTICLE_NOT_FOUND.
+        given(publicArticleService.getBySlug("archived-slug"))
+                .willThrow(new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
+
+        mockMvc.perform(get("/api/curation-articles/{slug}", "archived-slug"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("1201"));
+    }
+}

--- a/src/test/java/com/jdc/recipe_service/controller/admin/AdminCurationArticleControllerWebMvcTest.java
+++ b/src/test/java/com/jdc/recipe_service/controller/admin/AdminCurationArticleControllerWebMvcTest.java
@@ -1,0 +1,290 @@
+package com.jdc.recipe_service.controller.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jdc.recipe_service.domain.dto.article.ArticleImageFinalizeRequest;
+import com.jdc.recipe_service.domain.dto.article.ArticleImageFinalizeResponse;
+import com.jdc.recipe_service.domain.dto.article.ArticleImagePresignedUrlRequest;
+import com.jdc.recipe_service.domain.dto.article.ArticleImagePresignedUrlResponse;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleCreateRequest;
+import com.jdc.recipe_service.exception.ArticleImagesNotReadyException;
+import com.jdc.recipe_service.handler.GlobalExceptionHandler;
+import com.jdc.recipe_service.domain.entity.User;
+import com.jdc.recipe_service.domain.type.Role;
+import com.jdc.recipe_service.jwt.JwtTokenProvider;
+import com.jdc.recipe_service.security.CustomAuthenticationEntryPoint;
+import com.jdc.recipe_service.security.CustomUserDetails;
+import com.jdc.recipe_service.service.article.CurationArticleImageUploadService;
+import com.jdc.recipe_service.service.article.CurationArticleService;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * AdminCurationArticleController @WebMvcTest.
+ *
+ * <p>@EnableMethodSecurity를 TestConfiguration에 명시해 클래스 레벨 @PreAuthorize가 실제로 enforced되도록
+ * 한다 (WebMvcTest는 SecurityConfig를 로드하지 않으므로 method security가 자동 활성화되지 않는다).
+ * URL 패턴 매처 기반 보안 (/api/admin/** ROLE_ADMIN)은 SecurityConfig 정합성 회귀로 별도 통합 테스트가 다룬다.
+ */
+@WebMvcTest(controllers = AdminCurationArticleController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({GlobalExceptionHandler.class, AdminCurationArticleControllerWebMvcTest.MethodSecurityTestConfig.class})
+class AdminCurationArticleControllerWebMvcTest {
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class MethodSecurityTestConfig {
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockBean CurationArticleService articleService;
+    @MockBean CurationArticleImageUploadService imageUploadService;
+    @MockBean JwtTokenProvider jwtTokenProvider;
+    @MockBean UserDetailsService userDetailsService;
+    @MockBean CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @BeforeEach
+    void setUpAdminAuth() {
+        User admin = User.builder()
+                .nickname("admin")
+                .provider("test")
+                .oauthId("admin-oid")
+                .role(Role.ADMIN)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", 1L);
+        CustomUserDetails principal = new CustomUserDetails(admin);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @AfterEach
+    void clearAuth() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/curation-articles: 정상 요청 → 201 + articleId 응답")
+    void create_ok() throws Exception {
+        CurationArticleCreateRequest req = CurationArticleCreateRequest.builder()
+                .slug("summer-diet")
+                .title("여름 다이어트")
+                .contentMdx("# body")
+                .build();
+        given(articleService.create(any(CurationArticleCreateRequest.class))).willReturn(42L);
+
+        mockMvc.perform(post("/api/admin/curation-articles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.articleId").value(42));
+
+        verify(articleService).create(any(CurationArticleCreateRequest.class));
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/curation-articles: slug 패턴 위반 → 400 (service 호출 안 됨)")
+    void create_invalidSlugPattern_returns400() throws Exception {
+        // slug에 대문자 포함 — 패턴 위반
+        CurationArticleCreateRequest req = CurationArticleCreateRequest.builder()
+                .slug("Summer-Diet")
+                .title("t")
+                .contentMdx("c")
+                .build();
+
+        mockMvc.perform(post("/api/admin/curation-articles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+
+        verify(articleService, never()).create(any());
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/curation-articles: 필수 필드 누락(contentMdx 빈 값) → 400")
+    void create_blankContentMdx_returns400() throws Exception {
+        CurationArticleCreateRequest req = CurationArticleCreateRequest.builder()
+                .slug("ok-slug")
+                .title("t")
+                .contentMdx("")
+                .build();
+
+        mockMvc.perform(post("/api/admin/curation-articles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+
+        verify(articleService, never()).create(any());
+    }
+
+    @Test
+    @DisplayName("POST /{articleId}/images/presigned-urls: articleId path가 service로 전달되고 응답 3-필드가 그대로 내려간다")
+    void issuePresignedUrl_ok() throws Exception {
+        long articleId = 123L;
+        ArticleImagePresignedUrlRequest req = ArticleImagePresignedUrlRequest.builder()
+                .contentType("image/jpeg")
+                .fileSize(123_456L)
+                .build();
+        given(imageUploadService.issuePresignedUrl(eq(articleId), any(ArticleImagePresignedUrlRequest.class)))
+                .willReturn(ArticleImagePresignedUrlResponse.builder()
+                        .uploadKey("original/images/articles/123/uuid.jpg")
+                        .imageKey("images/articles/123/uuid.webp")
+                        .presignedUrl("https://s3.test/uuid")
+                        .build());
+
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/presigned-urls", articleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.uploadKey").value("original/images/articles/123/uuid.jpg"))
+                .andExpect(jsonPath("$.imageKey").value("images/articles/123/uuid.webp"))
+                .andExpect(jsonPath("$.presignedUrl").value("https://s3.test/uuid"));
+
+        verify(imageUploadService).issuePresignedUrl(eq(articleId), any(ArticleImagePresignedUrlRequest.class));
+    }
+
+    @Test
+    @DisplayName("POST /{articleId}/images/presigned-urls: fileSize 누락 → 400 (service 미호출)")
+    void issuePresignedUrl_missingFileSize_returns400() throws Exception {
+        // fileSize 없이 contentType만
+        String body = "{\"contentType\":\"image/webp\"}";
+
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/presigned-urls", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+
+        verify(imageUploadService, never()).issuePresignedUrl(any(), any());
+    }
+
+    @Test
+    @DisplayName("POST /{articleId}/publish: path variable로 service에 raw Long 전달")
+    void publish_callsService() throws Exception {
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/publish", 42L))
+                .andExpect(status().isOk());
+
+        verify(articleService).publish(eq(42L));
+    }
+
+    @Test
+    @DisplayName("POST /{articleId}/images/finalize: 모든 imageKey가 ready면 200 + ready=true 응답 + service 호출 인자 검증")
+    void finalize_ok() throws Exception {
+        long articleId = 42L;
+        ArticleImageFinalizeRequest req = ArticleImageFinalizeRequest.builder()
+                .imageKeys(java.util.List.of("images/articles/42/abc.webp"))
+                .build();
+        given(imageUploadService.finalizeImages(eq(articleId), any()))
+                .willReturn(ArticleImageFinalizeResponse.builder()
+                        .ready(true)
+                        .imageKeys(java.util.List.of("images/articles/42/abc.webp"))
+                        .build());
+
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/finalize", articleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ready").value(true))
+                .andExpect(jsonPath("$.imageKeys[0]").value("images/articles/42/abc.webp"));
+
+        verify(imageUploadService).finalizeImages(eq(articleId), any());
+    }
+
+    @Test
+    @DisplayName("POST /{articleId}/images/finalize: 일부 imageKey가 누락되면 409 + code=1207 + missingKeys/presentKeys 포함")
+    void finalize_notReady_returns409WithMissingKeys() throws Exception {
+        long articleId = 42L;
+        ArticleImageFinalizeRequest req = ArticleImageFinalizeRequest.builder()
+                .imageKeys(java.util.List.of("images/articles/42/abc.webp", "images/articles/42/def.webp"))
+                .build();
+        given(imageUploadService.finalizeImages(eq(articleId), any()))
+                .willThrow(new ArticleImagesNotReadyException(
+                        java.util.List.of("images/articles/42/def.webp"),
+                        java.util.List.of("images/articles/42/abc.webp")));
+
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/finalize", articleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("1207"))
+                .andExpect(jsonPath("$.missingKeys[0]").value("images/articles/42/def.webp"))
+                .andExpect(jsonPath("$.presentKeys[0]").value("images/articles/42/abc.webp"));
+    }
+
+    @Test
+    @DisplayName("POST /{articleId}/images/finalize: imageKeys 누락 → 400 (service 미호출)")
+    void finalize_emptyImageKeys_returns400() throws Exception {
+        // imageKeys 배열 자체가 비어 있음
+        String body = "{\"imageKeys\":[]}";
+
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/finalize", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+
+        verify(imageUploadService, never()).finalizeImages(any(), any());
+    }
+
+    @Test
+    @DisplayName("ROLE_USER가 호출하면 클래스 레벨 @PreAuthorize가 막아 403 + ADMIN_ACCESS_DENIED 응답을 내려준다")
+    void create_nonAdmin_returns403() throws Exception {
+        // override @BeforeEach: USER role로 다시 세팅
+        SecurityContextHolder.clearContext();
+        User user = User.builder()
+                .nickname("user")
+                .provider("test")
+                .oauthId("user-oid")
+                .role(Role.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 99L);
+        CustomUserDetails principal = new CustomUserDetails(user);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        CurationArticleCreateRequest req = CurationArticleCreateRequest.builder()
+                .slug("ok-slug")
+                .title("t")
+                .contentMdx("c")
+                .build();
+
+        mockMvc.perform(post("/api/admin/curation-articles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("605"));
+
+        verify(articleService, never()).create(any());
+    }
+}

--- a/src/test/java/com/jdc/recipe_service/repository/article/CurationArticleRepositoryTest.java
+++ b/src/test/java/com/jdc/recipe_service/repository/article/CurationArticleRepositoryTest.java
@@ -1,0 +1,115 @@
+package com.jdc.recipe_service.repository.article;
+
+import com.jdc.recipe_service.config.JpaAuditingConfig;
+import com.jdc.recipe_service.config.QuerydslConfig;
+import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.repository.article.CurationArticleRepository;
+import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Import({QuerydslConfig.class, JpaAuditingConfig.class})
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "app.s3.bucket-name=test-bucket",
+        "cloud.aws.region.static=ap-northeast-2"
+})
+class CurationArticleRepositoryTest {
+
+    @Container
+    @ServiceConnection
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.33");
+
+    @Autowired private EntityManager em;
+    @Autowired private CurationArticleRepository articleRepo;
+
+    @Test
+    @DisplayName("동일 slug 두 번 저장 시 unique 제약으로 실패한다")
+    void slugIsUnique() {
+        articleRepo.save(buildArticle("dup-slug", "첫 글", ArticleStatus.DRAFT, "diet"));
+        em.flush();
+
+        assertThatThrownBy(() -> {
+                    articleRepo.save(buildArticle("dup-slug", "두번째 글", ArticleStatus.DRAFT, "diet"));
+                    em.flush();
+                })
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("status + category + q(title LIKE) 모두 적용된 검색이 일치하는 행만 반환한다")
+    void searchAppliesAllFilters() {
+        articleRepo.save(buildArticle("a-1", "여름 다이어트 한식", ArticleStatus.PUBLISHED, "diet"));
+        articleRepo.save(buildArticle("a-2", "겨울 양식 추천",   ArticleStatus.PUBLISHED, "winter"));
+        articleRepo.save(buildArticle("a-3", "여름 다이어트 양식", ArticleStatus.DRAFT,     "diet"));
+        em.flush();
+        em.clear();
+
+        Page<CurationArticle> page = articleRepo.search(
+                ArticleStatus.PUBLISHED,
+                "diet",
+                "여름",
+                PageRequest.of(0, 20)
+        );
+
+        assertThat(page.getTotalElements()).isEqualTo(1L);
+        assertThat(page.getContent())
+                .extracting(CurationArticle::getSlug)
+                .containsExactly("a-1");
+    }
+
+    @Test
+    @DisplayName("필터가 모두 null이면 전체가 반환된다 (Page 총 개수 포함)")
+    void searchWithAllNullFiltersReturnsAll() {
+        articleRepo.save(buildArticle("b-1", "글 A", ArticleStatus.DRAFT, null));
+        articleRepo.save(buildArticle("b-2", "글 B", ArticleStatus.PUBLISHED, "diet"));
+        articleRepo.save(buildArticle("b-3", "글 C", ArticleStatus.ARCHIVED, "winter"));
+        em.flush();
+        em.clear();
+
+        Page<CurationArticle> page = articleRepo.search(null, null, null, PageRequest.of(0, 20));
+
+        assertThat(page.getTotalElements()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("existsBySlug는 등록된 slug에만 true를 반환한다")
+    void existsBySlug() {
+        articleRepo.save(buildArticle("exists-slug", "t", ArticleStatus.DRAFT, null));
+        em.flush();
+
+        assertThat(articleRepo.existsBySlug("exists-slug")).isTrue();
+        assertThat(articleRepo.existsBySlug("missing-slug")).isFalse();
+    }
+
+    private CurationArticle buildArticle(String slug, String title, ArticleStatus status, String category) {
+        return CurationArticle.builder()
+                .slug(slug)
+                .title(title)
+                .contentMdx("# body")
+                .category(category)
+                .status(status)
+                .humanReviewed(false)
+                .build();
+    }
+}

--- a/src/test/java/com/jdc/recipe_service/service/article/CurationArticleImageUploadServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/article/CurationArticleImageUploadServiceTest.java
@@ -1,0 +1,207 @@
+package com.jdc.recipe_service.service.article;
+
+import com.jdc.recipe_service.domain.dto.article.ArticleImageFinalizeResponse;
+import com.jdc.recipe_service.domain.dto.article.ArticleImagePresignedUrlRequest;
+import com.jdc.recipe_service.domain.dto.article.ArticleImagePresignedUrlResponse;
+import com.jdc.recipe_service.domain.repository.article.CurationArticleRepository;
+import com.jdc.recipe_service.exception.ArticleImagesNotReadyException;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import com.jdc.recipe_service.util.S3Util;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CurationArticleImageUploadServiceTest {
+
+    @Mock private S3Util s3Util;
+    @Mock private CurationArticleRepository articleRepo;
+
+    @InjectMocks private CurationArticleImageUploadService imageUploadService;
+
+    @Test
+    @DisplayName("article이 존재하면 articleId path를 포함한 uploadKey/imageKey가 생성되고 S3 presigned URL이 uploadKey에 발급된다")
+    void issuesPresignedUrlWithArticleIdPath() {
+        long articleId = 42L;
+        given(articleRepo.existsById(articleId)).willReturn(true);
+        given(s3Util.createPresignedUrl(anyString(), anyString())).willReturn("https://s3.test/upload");
+
+        ArticleImagePresignedUrlRequest req = ArticleImagePresignedUrlRequest.builder()
+                .contentType("image/jpeg")
+                .fileSize(245_678L)
+                .build();
+
+        ArticleImagePresignedUrlResponse resp = imageUploadService.issuePresignedUrl(articleId, req);
+
+        // path에 articleId가 박힘 + ext가 contentType 매핑(jpeg→jpg) + 변환 결과는 webp 고정
+        assertThat(resp.getUploadKey())
+                .startsWith("original/images/articles/42/")
+                .endsWith(".jpg");
+        assertThat(resp.getImageKey())
+                .startsWith("images/articles/42/")
+                .endsWith(".webp");
+        // upload/image key UUID 동일성 — 서로 prefix만 다른 같은 자원이어야 한다
+        String uploadUuid = resp.getUploadKey().substring(
+                "original/images/articles/42/".length(),
+                resp.getUploadKey().length() - ".jpg".length());
+        String imageUuid = resp.getImageKey().substring(
+                "images/articles/42/".length(),
+                resp.getImageKey().length() - ".webp".length());
+        assertThat(uploadUuid).isEqualTo(imageUuid);
+
+        // S3 presigned URL은 uploadKey에 대해 contentType과 함께 호출되어야 한다
+        ArgumentCaptor<String> keyCap = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> ctCap = ArgumentCaptor.forClass(String.class);
+        verify(s3Util).createPresignedUrl(keyCap.capture(), ctCap.capture());
+        assertThat(keyCap.getValue()).isEqualTo(resp.getUploadKey());
+        assertThat(ctCap.getValue()).isEqualTo("image/jpeg");
+        assertThat(resp.getPresignedUrl()).isEqualTo("https://s3.test/upload");
+    }
+
+    @Test
+    @DisplayName("article이 없으면 ARTICLE_NOT_FOUND. S3 호출은 일어나지 않는다")
+    void throwsWhenArticleMissing() {
+        given(articleRepo.existsById(999L)).willReturn(false);
+
+        ArticleImagePresignedUrlRequest req = ArticleImagePresignedUrlRequest.builder()
+                .contentType("image/jpeg").fileSize(1L).build();
+
+        assertThatThrownBy(() -> imageUploadService.issuePresignedUrl(999L, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ARTICLE_NOT_FOUND);
+
+        verify(s3Util, never()).createPresignedUrl(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 contentType이면 ARTICLE_IMAGE_INVALID_CONTENT_TYPE")
+    void throwsWhenContentTypeInvalid() {
+        given(articleRepo.existsById(1L)).willReturn(true);
+
+        ArticleImagePresignedUrlRequest req = ArticleImagePresignedUrlRequest.builder()
+                .contentType("image/gif")
+                .fileSize(1L)
+                .build();
+
+        assertThatThrownBy(() -> imageUploadService.issuePresignedUrl(1L, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ARTICLE_IMAGE_INVALID_CONTENT_TYPE);
+
+        verify(s3Util, never()).createPresignedUrl(anyString(), anyString());
+    }
+
+    // ── finalizeImages ──
+
+    @Test
+    @DisplayName("finalize: 모든 imageKey가 S3에 존재하면 ready=true 응답")
+    void finalize_allReady() {
+        long articleId = 42L;
+        given(articleRepo.existsById(articleId)).willReturn(true);
+        given(s3Util.isObjectPresent("images/articles/42/abc.webp")).willReturn(true);
+        given(s3Util.isObjectPresent("images/articles/42/def.webp")).willReturn(true);
+
+        ArticleImageFinalizeResponse resp = imageUploadService.finalizeImages(
+                articleId, List.of("images/articles/42/abc.webp", "images/articles/42/def.webp"));
+
+        assertThat(resp.isReady()).isTrue();
+        assertThat(resp.getImageKeys())
+                .containsExactlyInAnyOrder("images/articles/42/abc.webp", "images/articles/42/def.webp");
+    }
+
+    @Test
+    @DisplayName("finalize: 일부 imageKey가 S3에 없으면 ArticleImagesNotReadyException(missing/present 분리)")
+    void finalize_partialMissingThrows() {
+        long articleId = 42L;
+        given(articleRepo.existsById(articleId)).willReturn(true);
+        given(s3Util.isObjectPresent("images/articles/42/abc.webp")).willReturn(true);
+        given(s3Util.isObjectPresent("images/articles/42/def.webp")).willReturn(false);
+
+        assertThatThrownBy(() -> imageUploadService.finalizeImages(
+                articleId, List.of("images/articles/42/abc.webp", "images/articles/42/def.webp")))
+                .isInstanceOf(ArticleImagesNotReadyException.class)
+                .satisfies(ex -> {
+                    ArticleImagesNotReadyException notReady = (ArticleImagesNotReadyException) ex;
+                    assertThat(notReady.getMissingKeys()).containsExactly("images/articles/42/def.webp");
+                    assertThat(notReady.getPresentKeys()).containsExactly("images/articles/42/abc.webp");
+                });
+    }
+
+    @Test
+    @DisplayName("finalize: imageKey가 다른 article prefix를 갖고 있으면 INVALID_INPUT_VALUE — S3 HEAD 호출되지 않음")
+    void finalize_wrongPrefixThrows() {
+        long articleId = 42L;
+        given(articleRepo.existsById(articleId)).willReturn(true);
+
+        // articleId=42인데 키는 articleId=99의 것
+        assertThatThrownBy(() -> imageUploadService.finalizeImages(
+                articleId, List.of("images/articles/99/abc.webp")))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+
+        verify(s3Util, never()).isObjectPresent(anyString());
+    }
+
+    @Test
+    @DisplayName("finalize: imageKey가 .webp가 아니면 INVALID_INPUT_VALUE")
+    void finalize_nonWebpExtensionThrows() {
+        long articleId = 42L;
+        given(articleRepo.existsById(articleId)).willReturn(true);
+
+        assertThatThrownBy(() -> imageUploadService.finalizeImages(
+                articleId, List.of("images/articles/42/abc.jpg")))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+
+        verify(s3Util, never()).isObjectPresent(anyString());
+    }
+
+    @Test
+    @DisplayName("finalize: article이 없으면 ARTICLE_NOT_FOUND. 형식 검증/S3 호출은 일어나지 않는다")
+    void finalize_articleMissingThrows() {
+        given(articleRepo.existsById(999L)).willReturn(false);
+
+        assertThatThrownBy(() -> imageUploadService.finalizeImages(
+                999L, List.of("images/articles/999/abc.webp")))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ARTICLE_NOT_FOUND);
+
+        verify(s3Util, never()).isObjectPresent(anyString());
+    }
+
+    @Test
+    @DisplayName("fileSize가 10MB를 초과하면 ARTICLE_IMAGE_TOO_LARGE")
+    void throwsWhenFileSizeTooLarge() {
+        given(articleRepo.existsById(1L)).willReturn(true);
+
+        ArticleImagePresignedUrlRequest req = ArticleImagePresignedUrlRequest.builder()
+                .contentType("image/jpeg")
+                .fileSize(10L * 1024 * 1024 + 1)  // 10MB + 1 byte
+                .build();
+
+        assertThatThrownBy(() -> imageUploadService.issuePresignedUrl(1L, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ARTICLE_IMAGE_TOO_LARGE);
+
+        verify(s3Util, never()).createPresignedUrl(anyString(), anyString());
+    }
+}

--- a/src/test/java/com/jdc/recipe_service/service/article/CurationArticleServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/article/CurationArticleServiceTest.java
@@ -1,0 +1,276 @@
+package com.jdc.recipe_service.service.article;
+
+import com.jdc.recipe_service.domain.dto.article.CurationArticleCreateRequest;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleUpdateRequest;
+import com.jdc.recipe_service.domain.entity.Recipe;
+import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.entity.article.CurationArticleRecipeRef;
+import com.jdc.recipe_service.domain.repository.RecipeRepository;
+import com.jdc.recipe_service.domain.repository.article.CurationArticleRecipeRefRepository;
+import com.jdc.recipe_service.domain.repository.article.CurationArticleRepository;
+import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CurationArticleServiceTest {
+
+    @Mock private CurationArticleRepository articleRepo;
+    @Mock private CurationArticleRecipeRefRepository refRepo;
+    @Mock private RecipeRepository recipeRepo;
+
+    @InjectMocks private CurationArticleService articleService;
+
+    private CurationArticle draftArticle;
+
+    @BeforeEach
+    void setUp() {
+        draftArticle = CurationArticle.builder()
+                .slug("summer-diet")
+                .title("여름 다이어트")
+                .contentMdx("# body")
+                .status(ArticleStatus.DRAFT)
+                .humanReviewed(false)
+                .build();
+        ReflectionTestUtils.setField(draftArticle, "id", 100L);
+    }
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        @DisplayName("slug이 이미 존재하면 ARTICLE_SLUG_DUPLICATE 예외를 던진다")
+        void throwsWhenSlugDuplicate() {
+            given(articleRepo.existsBySlug("summer-diet")).willReturn(true);
+
+            CurationArticleCreateRequest req = CurationArticleCreateRequest.builder()
+                    .slug("summer-diet")
+                    .title("t")
+                    .contentMdx("c")
+                    .build();
+
+            assertThatThrownBy(() -> articleService.create(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.ARTICLE_SLUG_DUPLICATE);
+
+            verify(articleRepo, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("recipeIds 중 존재하지 않는 ID가 있으면 ARTICLE_INVALID_RECIPE_REF 예외를 던진다")
+        void throwsWhenRecipeRefInvalid() {
+            given(articleRepo.existsBySlug("summer-diet")).willReturn(false);
+            // 요청은 [1, 2]지만 1만 존재
+            given(recipeRepo.findAllById(List.of(1L, 2L)))
+                    .willReturn(List.of(Recipe.builder().build()));
+
+            CurationArticleCreateRequest req = CurationArticleCreateRequest.builder()
+                    .slug("summer-diet")
+                    .title("t")
+                    .contentMdx("c")
+                    .recipeIds(List.of(1L, 2L))
+                    .build();
+
+            assertThatThrownBy(() -> articleService.create(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.ARTICLE_INVALID_RECIPE_REF);
+
+            verify(articleRepo, never()).save(any());
+            verify(refRepo, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("recipeIds에 null이 섞이면 findAllById를 부르지 않고 ARTICLE_INVALID_RECIPE_REF로 차단된다")
+        void throwsWhenRecipeIdContainsNull() {
+            given(articleRepo.existsBySlug("summer-diet")).willReturn(false);
+
+            CurationArticleCreateRequest req = CurationArticleCreateRequest.builder()
+                    .slug("summer-diet")
+                    .title("t")
+                    .contentMdx("c")
+                    // List.of는 null을 거부하므로 Arrays.asList 사용
+                    .recipeIds(Arrays.asList(1L, null))
+                    .build();
+
+            assertThatThrownBy(() -> articleService.create(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.ARTICLE_INVALID_RECIPE_REF);
+
+            verify(recipeRepo, never()).findAllById(any());
+            verify(articleRepo, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("recipeIds에 비양수(0/음수)가 섞이면 ARTICLE_INVALID_RECIPE_REF로 차단된다")
+        void throwsWhenRecipeIdNonPositive() {
+            given(articleRepo.existsBySlug("summer-diet")).willReturn(false);
+
+            CurationArticleCreateRequest req = CurationArticleCreateRequest.builder()
+                    .slug("summer-diet")
+                    .title("t")
+                    .contentMdx("c")
+                    .recipeIds(List.of(1L, 0L, -3L))
+                    .build();
+
+            assertThatThrownBy(() -> articleService.create(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.ARTICLE_INVALID_RECIPE_REF);
+
+            verify(recipeRepo, never()).findAllById(any());
+            verify(articleRepo, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("정상 생성 시 article 저장 + refs도 저장한다")
+        void savesArticleAndRefs() {
+            given(articleRepo.existsBySlug("summer-diet")).willReturn(false);
+            given(recipeRepo.findAllById(List.of(1L, 2L)))
+                    .willReturn(List.of(Recipe.builder().build(), Recipe.builder().build()));
+            given(articleRepo.save(any(CurationArticle.class))).willReturn(draftArticle);
+
+            CurationArticleCreateRequest req = CurationArticleCreateRequest.builder()
+                    .slug("summer-diet")
+                    .title("여름 다이어트")
+                    .contentMdx("# body")
+                    .recipeIds(List.of(1L, 2L))
+                    .build();
+
+            Long id = articleService.create(req);
+
+            assertThat(id).isEqualTo(100L);
+            ArgumentCaptor<List<CurationArticleRecipeRef>> captor =
+                    ArgumentCaptor.forClass(List.class);
+            verify(refRepo).saveAll(captor.capture());
+            assertThat(captor.getValue()).hasSize(2);
+            assertThat(captor.getValue())
+                    .extracting(CurationArticleRecipeRef::getRecipeId)
+                    .containsExactlyInAnyOrder(1L, 2L);
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        @DisplayName("본문이 바뀌면 humanReviewed가 false로 리셋된다")
+        void resetsHumanReviewed() {
+            // given humanReviewed가 true인 article
+            draftArticle.markReviewed();
+            assertThat(draftArticle.isHumanReviewed()).isTrue();
+            given(articleRepo.findById(100L)).willReturn(Optional.of(draftArticle));
+
+            CurationArticleUpdateRequest req = CurationArticleUpdateRequest.builder()
+                    .title("새 제목")
+                    .contentMdx("# new body")
+                    .build();
+
+            articleService.update(100L, req);
+
+            assertThat(draftArticle.isHumanReviewed()).isFalse();
+            assertThat(draftArticle.getTitle()).isEqualTo("새 제목");
+        }
+
+        @Test
+        @DisplayName("recipeIds가 바뀌면 기존 refs를 모두 삭제한 뒤 새 refs를 저장한다")
+        void replacesRecipeRefs() {
+            given(articleRepo.findById(100L)).willReturn(Optional.of(draftArticle));
+            given(recipeRepo.findAllById(List.of(7L, 8L)))
+                    .willReturn(List.of(Recipe.builder().build(), Recipe.builder().build()));
+
+            CurationArticleUpdateRequest req = CurationArticleUpdateRequest.builder()
+                    .title("t")
+                    .contentMdx("c")
+                    .recipeIds(List.of(7L, 8L))
+                    .build();
+
+            articleService.update(100L, req);
+
+            verify(refRepo).deleteByArticleId(100L);
+            ArgumentCaptor<List<CurationArticleRecipeRef>> captor =
+                    ArgumentCaptor.forClass(List.class);
+            verify(refRepo).saveAll(captor.capture());
+            assertThat(captor.getValue())
+                    .extracting(CurationArticleRecipeRef::getRecipeId)
+                    .containsExactlyInAnyOrder(7L, 8L);
+        }
+
+        @Test
+        @DisplayName("아티클이 없으면 ARTICLE_NOT_FOUND")
+        void throwsWhenArticleMissing() {
+            given(articleRepo.findById(999L)).willReturn(Optional.empty());
+
+            CurationArticleUpdateRequest req = CurationArticleUpdateRequest.builder()
+                    .title("t").contentMdx("c").build();
+
+            assertThatThrownBy(() -> articleService.update(999L, req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.ARTICLE_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("publish")
+    class Publish {
+
+        @Test
+        @DisplayName("DRAFT에서 publish 호출 시 status=PUBLISHED + publishedAt이 채워진다")
+        void firstPublishSetsPublishedAt() {
+            given(articleRepo.findById(100L)).willReturn(Optional.of(draftArticle));
+
+            articleService.publish(100L);
+
+            assertThat(draftArticle.getStatus()).isEqualTo(ArticleStatus.PUBLISHED);
+            assertThat(draftArticle.getPublishedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("이미 PUBLISHED 상태에서 publish 재호출해도 publishedAt이 보존된다 (idempotent)")
+        void repeatedPublishPreservesPublishedAt() {
+            // 첫 발행
+            given(articleRepo.findById(100L)).willReturn(Optional.of(draftArticle));
+            articleService.publish(100L);
+            LocalDateTime firstPublishedAt = draftArticle.getPublishedAt();
+            assertThat(firstPublishedAt).isNotNull();
+
+            // 재발행 — 시간이 다르게 흐르도록 미세 대기 대신 직접 검증
+            articleService.publish(100L);
+
+            assertThat(draftArticle.getStatus()).isEqualTo(ArticleStatus.PUBLISHED);
+            assertThat(draftArticle.getPublishedAt())
+                    .as("두 번째 publish는 publishedAt을 덮어쓰지 않는다")
+                    .isEqualTo(firstPublishedAt);
+
+            verify(articleRepo, times(2)).findById(100L);
+        }
+    }
+}

--- a/src/test/java/com/jdc/recipe_service/service/article/PublicCurationArticleServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/article/PublicCurationArticleServiceTest.java
@@ -1,0 +1,130 @@
+package com.jdc.recipe_service.service.article;
+
+import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleResponse;
+import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleSummaryResponse;
+import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.repository.article.CurationArticleRecipeRefRepository;
+import com.jdc.recipe_service.domain.repository.article.CurationArticleRepository;
+import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PublicCurationArticleServiceTest {
+
+    @Mock private CurationArticleRepository articleRepo;
+    @Mock private CurationArticleRecipeRefRepository refRepo;
+
+    @InjectMocks private PublicCurationArticleService publicService;
+
+    @Test
+    @DisplayName("listPublished는 status=PUBLISHED + q=null로 search를 부르고, sort를 publishedAt DESC, id DESC로 강제한다")
+    void listPublished_enforcesPublishedAndSort() {
+        Pageable userProvided = PageRequest.of(2, 10, Sort.by(Sort.Order.asc("title")));
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        given(articleRepo.search(eq(ArticleStatus.PUBLISHED), eq("diet"), isNull(), pageableCaptor.capture()))
+                .willReturn(new PageImpl<>(List.of()));
+
+        Page<PublicCurationArticleSummaryResponse> result =
+                publicService.listPublished("diet", userProvided);
+
+        assertThat(result).isEmpty();
+        Pageable used = pageableCaptor.getValue();
+        // 페이지/사이즈는 그대로 유지
+        assertThat(used.getPageNumber()).isEqualTo(2);
+        assertThat(used.getPageSize()).isEqualTo(10);
+        // 사용자가 보낸 title ASC 정렬은 무시되고 publishedAt DESC, id DESC가 강제된다
+        Sort sort = used.getSort();
+        assertThat(sort.getOrderFor("publishedAt"))
+                .isNotNull()
+                .extracting(Sort.Order::getDirection)
+                .isEqualTo(Sort.Direction.DESC);
+        assertThat(sort.getOrderFor("id"))
+                .isNotNull()
+                .extracting(Sort.Order::getDirection)
+                .isEqualTo(Sort.Direction.DESC);
+        assertThat(sort.getOrderFor("title")).isNull();
+    }
+
+    @Test
+    @DisplayName("listPublished의 category가 빈 문자열이면 null로 변환되어 search에 전달된다")
+    void listPublished_blankCategoryBecomesNull() {
+        given(articleRepo.search(eq(ArticleStatus.PUBLISHED), isNull(), isNull(), org.mockito.ArgumentMatchers.any()))
+                .willReturn(new PageImpl<>(List.of()));
+
+        publicService.listPublished("   ", PageRequest.of(0, 20));
+        // mock matcher가 null category를 만족하면 통과 (설정한 stub이 매칭됨)
+    }
+
+    @Test
+    @DisplayName("getBySlug는 PUBLISHED 상태만 조회 — DRAFT/ARCHIVED slug는 ARTICLE_NOT_FOUND")
+    void getBySlug_unpublishedReturns404() {
+        // findBySlugAndStatus(slug, PUBLISHED)는 DRAFT/ARCHIVED인 글을 못 찾는다 → empty Optional
+        given(articleRepo.findBySlugAndStatus("hidden-glug", ArticleStatus.PUBLISHED))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> publicService.getBySlug("hidden-glug"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ARTICLE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("listPublished는 size를 50으로 clamp한다 (public API 부담 방지)")
+    void listPublished_clampsPageSizeTo50() {
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        given(articleRepo.search(eq(ArticleStatus.PUBLISHED), isNull(), isNull(), pageableCaptor.capture()))
+                .willReturn(new PageImpl<>(List.of()));
+
+        // 1000을 요청해도 service에서 50으로 자른다
+        publicService.listPublished(null, PageRequest.of(0, 1000));
+
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(50);
+    }
+
+    @Test
+    @DisplayName("getBySlug는 PUBLISHED 글에 대해 본문/recipeIds를 함께 응답한다")
+    void getBySlug_returnsArticleWithRecipeIds() {
+        CurationArticle article = CurationArticle.builder()
+                .slug("summer-diet")
+                .title("여름 다이어트")
+                .contentMdx("# body")
+                .status(ArticleStatus.PUBLISHED)
+                .build();
+        ReflectionTestUtils.setField(article, "id", 7L);
+
+        given(articleRepo.findBySlugAndStatus("summer-diet", ArticleStatus.PUBLISHED))
+                .willReturn(Optional.of(article));
+        given(refRepo.findRecipeIdsByArticleId(7L)).willReturn(List.of(11L, 12L));
+
+        PublicCurationArticleResponse resp = publicService.getBySlug("summer-diet");
+
+        assertThat(resp.getId()).isEqualTo(7L);
+        assertThat(resp.getSlug()).isEqualTo("summer-diet");
+        assertThat(resp.getTitle()).isEqualTo("여름 다이어트");
+        assertThat(resp.getContentMdx()).isEqualTo("# body");
+        assertThat(resp.getRecipeIds()).containsExactly(11L, 12L);
+    }
+}


### PR DESCRIPTION
  ## 해결하려는 문제가 무엇인가요?

  운영자가 직접 작성하는 매거진형 글(다이어트 모음집, 시즌별 큐레이션 등)이 없어 SEO/콘텐츠 마케팅 통로가 부재했다. AI로
   본문을 생성하고 운영자가 검토만 거쳐 발행할 수 있는 가벼운 도구가 필요했다.

  ## 어떻게 해결했나요?

  - **AS-IS:** 큐레이션 콘텐츠 미존재. 글을 쓰려면 별도 CMS 도입 필요.
  - **TO-BE:** 큐레이션 아티클 도메인 신규 추가. 운영자는 MDX 본문 + 레시피 묶음으로 작성/발행, 일반 유저는 PUBLISHED
  상태 글만 slug로 조회.

  **커밋 분리**

  - `e719ad0` `build(deps)` — Testcontainers BOM 1.21.4. Repository 테스트가 Docker Desktop 4.69를 안정 감지하기 위함.
  이 커밋만 단독 revert 가능.
  - `24ef813` `feat(curation-articles)` — 도메인 전체 (33 files).

  **리뷰어가 먼저 봐야 할 영역**

  1. `V20260504_001__create_curation_articles.sql` — 테이블 2개. `curation_article_recipe_refs.recipe_id`는 **FK
  미설정** (`chat_log` 같은 audit/soft link 패턴, 의도된 비대칭).
  2. `CurationArticleService` / `PublicCurationArticleService` — admin/public 분리. **PUBLISHED 강제는 service 레이어가
  책임** (단일 service에서 분기 시 미래에 필터 누락 위험).
  3. `CurationArticleImageUploadService.finalizeImages` — S3 HEAD로 변환 결과(.webp) 객체 존재만 검증. **DB 상태는
  변경하지 않음**.
  4. `S3Util.isObjectPresent` — `doesObjectExist`의 strict 버전 (404/NoSuchKey만 false, 그 외 propagate). 권한/네트워크
  문제가 "아직 변환 안 됨"으로 잘못 보고되어 프론트가 무한 폴링하는 silent failure 차단.
  5. `GlobalExceptionHandler` — `AccessDeniedException` 글로벌 매핑 추가 (method security가 필터 체인 우회할 때
  catch-all 500 방지). `ArticleImagesNotReadyException` → 409 + `missingKeys`/`presentKeys` 응답.

  ## Test plan

  - [x] `./gradlew compileJava compileTestJava` 통과
  - [x] `./gradlew test --tests "*CurationArticle*" --rerun-tasks` **42/42 통과** (Service unit / WebMvc / @DataJpaTest
  with Testcontainers)
  - [x] @PreAuthorize 회귀: ROLE_USER 호출 시 403 + code 605 응답 검증 (WebMvc test 추가)
  - [ ] **수동 검증 (스테이징 배포 후)**: 어드민에서 글 1건 작성 → 이미지 업로드 → finalize → 발행 → public slug 조회
  end-to-end
  - [ ] **수동 검증 (Lambda 배포 후)**: finalize 200 응답 확인. Lambda articles 분기 배포 전엔 finalize 영구 409이 정상
  동작.

  ## Rollout / DB / API impact

  ### DB

  - V20260504_001 — `curation_articles`, `curation_article_recipe_refs` 신규 테이블 추가. 기존 테이블 영향 0.
  - expand-contract 불필요 (신규 도메인이라 backfill/dual-write 없음).

  ### API

  - 신규 엔드포인트만 추가 — **breaking change 없음**.
  - Public 2개: `GET /api/curation-articles`, `GET /api/curation-articles/{slug}`
  - Admin 9개: `POST` 생성 / `GET` 목록·상세 / `PUT` 수정 / `POST`
  publish·archive·review·images/presigned-urls·images/finalize
  - ErrorCode 1201~1207 신규 (1200 대역 — 1100 RecipeBook과 분리)
  - Public 노출 게이트는 `status = PUBLISHED` 만. `humanReviewed`는 노출 게이트가 아님 (AI 자동 발행 시 `humanReviewed =
   false` 가능).
  - Public 목록 size cap = 50 (service clamp). sort는 `publishedAt DESC, id DESC`로 강제 (sort param 무시).

  ### 인프라 (별도 작업 필요)

  Lambda `recipe-image-resizer`에 `articles` 분기 추가 필요:

  ```
  입력: original/images/articles/{articleId}/{uuid}.{ext}
  출력: images/articles/{articleId}/{uuid}.webp
  변환: width 1024, withoutEnlargement true, webp quality 85
  ```

  기존 `recipes` 라우팅은 변경 없음. **Lambda 배포 전엔 finalize endpoint가 영구 409**로 응답하지만 운영자가 인지 가능한
   상태.

  ### 프론트

  - 핸드오프 문서: `docs/handoff/frontend-api-changes-2026-05-04.md/html` (gitignored — Slack/직접 공유). MDX 렌더러
  도입 필요. `<ArticleImage imageKey="..." />` 컴포넌트 + `<RecipeCard slug="..." />`(선택) 약속됨.
  - 인증: 기존 `accessToken` 쿠키 재사용. `Authorization` 헤더 추가 작업 없음.

  ### feature flag

  없음. 관리자만 접근하는 admin API + 발행 안 한 글은 public에 안 뜨므로 점진 노출 무관.

  ## Risks and rollback

  | 위험 | 영향 | 대응 |
  |---|---|---|
  | Lambda articles 분기 미배포 상태에서 이미지 업로드 | finalize 영구 409 | 운영자가 발행 보류 가능. Lambda 배포 후 정상화 |
  | IAM/네트워크 등 환경 문제로 S3 HEAD 실패 | 401/403/5xx 직접 propagate (catch-all 500) | `isObjectPresent`로 silent failure(가짜 폴링) 차단 — 알람으로 감지 가능 |
  | MDX 안에 잘못된 imageKey가 들어감 | 화면에 깨진 이미지 노출 | 어드민 미리보기 + finalize 권장 흐름. 실제 강제는 안 함 |
  | status 전이 충돌 (동시 publish/archive) | 마지막 호출 win | 모든 상태 전이 idempotent라 데이터 손상 없음 |

  **롤백**:
  - revert PR (e719ad0, 24ef813 둘 다 revert) → 코드 원복
  - DB: `DROP TABLE curation_article_recipe_refs; DROP TABLE curation_articles;` (외부 트래픽 0이라 데이터 손실 무관)
  - 외부 사용자 영향 없음 (admin API는 운영자만, public API는 PUBLISHED 글이 0건이면 빈 응답)

  ## Related

  - 핸드오프 문서: `docs/handoff/frontend-api-changes-2026-05-04.md/html` (gitignored)
  - ErrorCode 도메인 표 갱신: `.claude/rules/error-handling.md` (1100 RecipeBook + 1200 Article 명시 추가)
  - 관련 skill: `api-contract-docs`, `db-migration`, `external-api`
  - 후속 작업 (별도 PR/티켓):
    - Lambda `recipe-image-resizer` articles 분기 배포
    - V2 후보: presigned POST + content-length-range 또는 finalize ContentLength 검증 (fileSize 강제가 필요해지면)