### PR TITLE
refactor(curation-articles): public 응답 id/recipeIds를 HashID 문자열로 직렬화

### DIFF
--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/PublicCurationArticleResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/PublicCurationArticleResponse.java
@@ -1,6 +1,9 @@
 package com.jdc.recipe_service.domain.dto.article;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.jdc.recipe_service.config.HashIdConfig;
 import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +23,11 @@ import java.util.List;
 @Schema(description = "Public 큐레이션 아티클 상세 응답")
 public class PublicCurationArticleResponse {
 
-    @Schema(description = "아티클 ID")
+    /**
+     * Public 응답에서는 HashID 문자열로 직렬화된다 (raw Long 노출 금지).
+     */
+    @JsonSerialize(using = HashIdConfig.HashIdSerializer.class)
+    @Schema(description = "아티클 ID (HashID 문자열)", example = "xJvY7aBp", type = "string")
     private Long id;
 
     @Schema(description = "URL slug")
@@ -44,7 +51,18 @@ public class PublicCurationArticleResponse {
     @Schema(description = "발행 시각")
     private LocalDateTime publishedAt;
 
-    @Schema(description = "참조한 레시피 ID 목록")
+    /**
+     * Public 응답에서는 각 element가 HashID 문자열로 직렬화된다.
+     *
+     * <p>OpenAPI/Swagger 스펙에서 item type을 정확히 string으로 표시하기 위해 {@code @ArraySchema} +
+     * {@code schema = @Schema(type = "string")} 조합을 사용한다. 단순 {@code @Schema(type = "array")}만
+     * 쓰면 필드 정적 타입이 {@code List<Long>}이라 item type이 number로 잡혀 프론트 문서와 어긋난다.
+     */
+    @JsonSerialize(contentUsing = HashIdConfig.HashIdSerializer.class)
+    @ArraySchema(
+            schema = @Schema(type = "string", example = "vK9mP2Qa", description = "레시피 ID (HashID 문자열)"),
+            arraySchema = @Schema(description = "참조한 레시피 ID 목록 (HashID 문자열 배열)")
+    )
     private List<Long> recipeIds;
 
     public static PublicCurationArticleResponse of(CurationArticle a, List<Long> recipeIds) {

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/PublicCurationArticleSummaryResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/PublicCurationArticleSummaryResponse.java
@@ -1,5 +1,7 @@
 package com.jdc.recipe_service.domain.dto.article;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.jdc.recipe_service.config.HashIdConfig;
 import com.jdc.recipe_service.domain.entity.article.CurationArticle;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -17,7 +19,14 @@ import java.time.LocalDateTime;
 @Schema(description = "Public 큐레이션 아티클 목록 응답")
 public class PublicCurationArticleSummaryResponse {
 
+    /**
+     * Public 응답에서는 HashID 문자열로 직렬화된다 (raw Long 노출 금지).
+     * 직렬화는 HashIdConfig의 정적 Hashids 인스턴스를 사용한다.
+     */
+    @JsonSerialize(using = HashIdConfig.HashIdSerializer.class)
+    @Schema(description = "아티클 ID (HashID 문자열)", example = "xJvY7aBp", type = "string")
     private Long id;
+
     private String slug;
     private String title;
     private String description;

--- a/src/test/java/com/jdc/recipe_service/controller/CurationArticleControllerWebMvcTest.java
+++ b/src/test/java/com/jdc/recipe_service/controller/CurationArticleControllerWebMvcTest.java
@@ -1,6 +1,6 @@
 package com.jdc.recipe_service.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jdc.recipe_service.config.HashIdConfig;
 import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleResponse;
 import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleSummaryResponse;
 import com.jdc.recipe_service.exception.CustomException;
@@ -11,6 +11,7 @@ import com.jdc.recipe_service.security.CustomAuthenticationEntryPoint;
 import com.jdc.recipe_service.service.article.PublicCurationArticleService;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.hashids.Hashids;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -43,8 +45,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @WebMvcTest(controllers = CurationArticleController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@Import({GlobalExceptionHandler.class,
+@Import({GlobalExceptionHandler.class, HashIdConfig.class,
         CurationArticleControllerWebMvcTest.MeterRegistryTestConfig.class})
+@TestPropertySource(properties = {
+        "app.hashids.salt=TEST_SALT_FOR_PUBLIC_CURATION_ARTICLE_CONTROLLER",
+        "app.hashids.min-length=8"
+})
 class CurationArticleControllerWebMvcTest {
 
     @TestConfiguration
@@ -56,7 +62,7 @@ class CurationArticleControllerWebMvcTest {
     }
 
     @Autowired MockMvc mockMvc;
-    @Autowired ObjectMapper objectMapper;
+    @Autowired Hashids hashids;
 
     @MockBean PublicCurationArticleService publicArticleService;
     @MockBean JwtTokenProvider jwtTokenProvider;
@@ -64,7 +70,7 @@ class CurationArticleControllerWebMvcTest {
     @MockBean CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Test
-    @DisplayName("GET /api/curation-articles: 200 + Page 응답 + 운영 전용 필드(status/generatedBy/humanReviewed) 미노출")
+    @DisplayName("GET /api/curation-articles: 200 + Page 응답. id는 HashID 문자열, 운영 전용 필드 미노출")
     void list_ok() throws Exception {
         PublicCurationArticleSummaryResponse item = PublicCurationArticleSummaryResponse.builder()
                 .id(7L)
@@ -78,10 +84,15 @@ class CurationArticleControllerWebMvcTest {
         given(publicArticleService.listPublished(eq("diet"), any()))
                 .willReturn(new PageImpl<>(List.of(item), PageRequest.of(0, 20), 1));
 
+        // 기대값은 같은 Hashids 인스턴스로 동적 생성 — salt/minLength 변경되어도 회귀 안 깨짐
+        String expectedArticleId = hashids.encode(7L);
+
         mockMvc.perform(get("/api/curation-articles")
                         .param("category", "diet"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].id").value(7))
+                // raw Long 7이 아니라 HashID 문자열로 내려가야 한다
+                .andExpect(jsonPath("$.content[0].id").value(expectedArticleId))
+                .andExpect(jsonPath("$.content[0].id").isString())
                 .andExpect(jsonPath("$.content[0].slug").value("summer-diet"))
                 .andExpect(jsonPath("$.content[0].title").value("여름 다이어트"))
                 .andExpect(jsonPath("$.content[0].coverImageKey").value("images/articles/7/uuid.webp"))
@@ -98,7 +109,7 @@ class CurationArticleControllerWebMvcTest {
     }
 
     @Test
-    @DisplayName("GET /api/curation-articles/{slug}: 200 + 본문/recipeIds 포함 + 운영 필드 미노출")
+    @DisplayName("GET /api/curation-articles/{slug}: 200 + id/recipeIds가 HashID 문자열, 본문 포함, 운영 필드 미노출")
     void getBySlug_ok() throws Exception {
         PublicCurationArticleResponse resp = PublicCurationArticleResponse.builder()
                 .id(7L)
@@ -111,13 +122,21 @@ class CurationArticleControllerWebMvcTest {
                 .build();
         given(publicArticleService.getBySlug("summer-diet")).willReturn(resp);
 
+        String expectedArticleId = hashids.encode(7L);
+        String expectedRecipe0   = hashids.encode(11L);
+        String expectedRecipe1   = hashids.encode(12L);
+
         mockMvc.perform(get("/api/curation-articles/{slug}", "summer-diet"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(7))
+                // id는 HashID 문자열
+                .andExpect(jsonPath("$.id").value(expectedArticleId))
+                .andExpect(jsonPath("$.id").isString())
                 .andExpect(jsonPath("$.slug").value("summer-diet"))
                 .andExpect(jsonPath("$.contentMdx").value("# body"))
-                .andExpect(jsonPath("$.recipeIds[0]").value(11))
-                .andExpect(jsonPath("$.recipeIds[1]").value(12))
+                // recipeIds 각 element도 HashID 문자열
+                .andExpect(jsonPath("$.recipeIds[0]").value(expectedRecipe0))
+                .andExpect(jsonPath("$.recipeIds[1]").value(expectedRecipe1))
+                .andExpect(jsonPath("$.recipeIds[0]").isString())
                 .andExpect(jsonPath("$.status").doesNotExist())
                 .andExpect(jsonPath("$.generatedBy").doesNotExist())
                 .andExpect(jsonPath("$.humanReviewed").doesNotExist());


### PR DESCRIPTION
 ## 해결하려는 문제가 무엇인가요?

  public 큐레이션 아티클 응답(`GET /api/curation-articles`, `GET /api/curation-articles/{slug}`)에서 raw Long ID가
  그대로 내려가고 있었다. 이 프로젝트의 다른 도메인(레시피/유저/레시피북 등)은 모두 HashID 문자열로 외부에 노출하는
  표준이 잡혀 있어 큐레이션 아티클만 일관성이 깨진 상태였다.

  raw 순차 ID 노출의 부수 위험:
  - enumeration으로 글 갯수/생성 빈도 추정 가능
  - 미발행/archived 글 ID로 admin path 추측 시도 가능
  - 미래의 ID 정책 변경에 프론트가 굳어지는 의존을 만든다

  ## 어떻게 해결했나요?

  - **AS-IS:** `{ "id": 7, "recipeIds": [101, 102] }`
  - **TO-BE:** `{ "id": "xJvY7aBp", "recipeIds": ["vK9mP2Qa", "wL0nQ3Rb"] }`

  리뷰어가 먼저 봐야 할 포인트:

  1. `PublicCurationArticleSummaryResponse.id`, `PublicCurationArticleResponse.id` — `@JsonSerialize(using =
  HashIdConfig.HashIdSerializer.class)`
  2. `PublicCurationArticleResponse.recipeIds` — `@JsonSerialize(contentUsing = ...)` 로 list element 단위 직렬화
  3. `recipeIds` OpenAPI 스키마는 `@ArraySchema(schema = @Schema(type = "string"))` 로 명시 — 정적 타입이
  `List<Long>`이라 단순 `@Schema(type = "array")` 로는 item type이 `number`로 잡혀 프론트 자동생성 클라이언트와 어긋남.
  javadoc에 이유 박아둠
  4. **admin DTO(`CurationArticleResponse`, `CurationArticleSummaryResponse`)는 raw Long 그대로 유지** — 의도된 비대칭.
  운영자 신뢰 + 디버깅 편의
  5. DB / entity / repository / service 내부 타입 / S3 imageKey 패턴 모두 변경 없음

  ## Test plan

  - [x] `./gradlew compileJava compileTestJava` 통과
  - [x] `./gradlew test --tests "*CurationArticleControllerWebMvcTest*" --rerun-tasks` 4/4 PASS
  - [x] `./gradlew test --tests "*CurationArticle*" --rerun-tasks` 42/42 PASS (회귀 0)
  - [x] WebMvcTest에 `HashIdConfig.class` import + `Hashids` 빈 주입 → `expected = hashids.encode(7L)` 동적 생성
  (salt/minLength 변경에도 회귀 안 깨짐)
  - [x] `jsonPath("$.id").isString()` 추가로 wire shape이 string임을 잠금 (Long이면 isString() 실패)

  ## Rollout / DB / API impact

  **DB**: 변경 없음

  **API**:
  - public 응답 `id`, `recipeIds[]` 타입 `number → string`
  - 미배포 신규 API라 운영 프론트 영향 0
  - admin API 응답은 변경 없음 (admin은 raw Long 그대로 사용)
  - OpenAPI/Swagger의 `recipeIds` items 타입이 `integer → string`으로 정확히 표시됨 (이전엔
  `@Schema(type="array")`만으로 item type이 잘못 잡혔던 것 정정)

  **인프라**: 변경 없음 (S3/Lambda/CDN 무관)

  **feature flag**: 없음. wire shape 변경이 즉시 반영됨

  ## Risks and rollback

  | 위험 | 영향 | 대응 |
  |---|---|---|
  | 프론트가 이미 number로 가정해 클라이언트 코드 작성 | 운영 미배포 신규 API라 실 영향 0 | 핸드오프 문서로 처음부터 string 명시 |
  | HashID 인코딩 자체 실패 | 직렬화 시 `null` (HashIdSerializer가 null 반환) | `HashIdConfig` 정적 인스턴스 재사용. 다른 도메인이 이미 동일 인스턴스로 정상 동작 중이라 회귀 가능성 낮음 |

  **롤백**: 단일 커밋 revert로 즉시 원복. wire shape 외 변경 없으므로 롤백 영향 좁음.

  ## Related

  - 선행 PR: `feat(curation-articles): MDX 매거진 아티클 도메인 + admin/public API + 이미지 업로드 finalize` (커밋
  `e99d2c5`)
  - 관련 skill: `api-contract-docs`
  - 핸드오프 문서: `docs/handoff/frontend-api-changes-2026-05-04.md/html` (gitignored — Slack/직접 공유)