### PR TITLE
refactor(curation-articles): admin path/response/request + S3 imageKey 모두 HashID로 통일 + strict 강제

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/HashIdConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/HashIdConfig.java
@@ -112,4 +112,30 @@ public class HashIdConfig implements WebMvcConfigurer {
             return decoded[0];
         }
     }
+
+    /**
+     * 엄격(strict) HashID 디코더. 숫자 문자열 fallback을 허용하지 않는다.
+     *
+     * <p>{@link HashIdDeserializer}는 마이그레이션 호환을 위해 raw 숫자 문자열도 받아주지만, 이건
+     * 신규 API에서 의도치 않은 raw Long 입력을 통과시켜 정책을 우회하게 만든다.
+     *
+     * <p>큐레이션 아티클처럼 "처음부터 HashID만 받겠다"고 정한 신규 도메인의 request DTO에 사용한다.
+     * 기존 도메인(레시피, 유저 등)은 lenient {@link HashIdDeserializer}를 그대로 쓴다.
+     */
+    public static class StrictHashIdDeserializer extends JsonDeserializer<Long> {
+        @Override
+        public Long deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            String value = p.getText();
+            if (value == null || value.isBlank()) return null;
+            // 숫자만으로 된 입력은 거부 — raw Long을 그대로 박는 호출을 차단한다.
+            if (value.matches("^[0-9]+$")) {
+                throw new IllegalArgumentException("HashID는 문자열로만 입력해야 합니다 (숫자 입력 거부): " + value);
+            }
+            long[] decoded = staticHashids.decode(value);
+            if (decoded.length == 0) {
+                throw new IllegalArgumentException("Invalid Hash ID: " + value);
+            }
+            return decoded[0];
+        }
+    }
 }

--- a/src/main/java/com/jdc/recipe_service/controller/admin/AdminCurationArticleController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/admin/AdminCurationArticleController.java
@@ -9,6 +9,8 @@ import com.jdc.recipe_service.domain.dto.article.CurationArticleResponse;
 import com.jdc.recipe_service.domain.dto.article.CurationArticleSummaryResponse;
 import com.jdc.recipe_service.domain.dto.article.CurationArticleUpdateRequest;
 import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import com.jdc.recipe_service.exception.CustomException;
+import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.service.article.CurationArticleImageUploadService;
 import com.jdc.recipe_service.service.article.CurationArticleService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +18,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.hashids.Hashids;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -33,6 +36,10 @@ import java.util.Map;
  * <p>SecurityConfig의 `/api/admin/**` ROLE_ADMIN 매처에 추가로 클래스 레벨 @PreAuthorize로 이중 방어한다.
  * 일반 유저용 public API는 별도의 {@link com.jdc.recipe_service.controller.CurationArticleController}에서
  * PUBLISHED 상태 아티클만 노출하도록 제공한다.
+ *
+ * <p><b>articleId path 정책</b>: 모든 path variable은 HashID 문자열로만 받는다. 전역 {@code @DecodeId}는
+ * 마이그레이션 호환을 위해 raw 숫자도 받아주지만, 큐레이션 아티클은 신규 도메인이라 처음부터 strict하게
+ * HashID만 허용한다. 숫자 path(예: {@code /42/publish})는 {@link #decodeArticleId} 에서 400으로 거부.
  */
 @RestController
 @RequestMapping("/api/admin/curation-articles")
@@ -44,18 +51,19 @@ public class AdminCurationArticleController {
 
     private final CurationArticleService articleService;
     private final CurationArticleImageUploadService imageUploadService;
+    private final Hashids hashids;
 
     @PostMapping
-    @Operation(summary = "아티클 생성", description = "DRAFT 상태로 새 아티클을 생성한다. recipeIds는 audit/soft link로 저장된다.")
-    public ResponseEntity<Map<String, Long>> create(
+    @Operation(summary = "아티클 생성", description = "DRAFT 상태로 새 아티클을 생성한다. recipeIds는 audit/soft link로 저장되며 요청은 HashID 문자열 배열로 받는다. 응답의 articleId도 HashID 문자열.")
+    public ResponseEntity<Map<String, String>> create(
             @RequestBody @Valid CurationArticleCreateRequest request) {
         Long articleId = articleService.create(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("articleId", articleId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("articleId", hashids.encode(articleId)));
     }
 
     @GetMapping
     @Operation(summary = "아티클 목록 조회",
-            description = "status/category/q(title LIKE) 모두 optional. Page 기반으로 총 개수가 응답에 포함된다.")
+            description = "status/category/q(title LIKE) 모두 optional. Page 기반으로 총 개수가 응답에 포함된다. 응답의 id는 모두 HashID 문자열.")
     public ResponseEntity<Page<CurationArticleSummaryResponse>> list(
             @Parameter(description = "발행 상태") @RequestParam(required = false) ArticleStatus status,
             @Parameter(description = "카테고리") @RequestParam(required = false) String category,
@@ -65,51 +73,51 @@ public class AdminCurationArticleController {
     }
 
     @GetMapping("/{articleId}")
-    @Operation(summary = "아티클 상세 조회")
+    @Operation(summary = "아티클 상세 조회", description = "articleId는 HashID 문자열로 받는다. 숫자 입력은 400 거부. 응답의 id, recipeIds 모두 HashID 문자열.")
     public ResponseEntity<CurationArticleResponse> get(
-            @Parameter(description = "아티클 ID") @PathVariable Long articleId) {
-        return ResponseEntity.ok(articleService.get(articleId));
+            @Parameter(description = "아티클 ID (HashID)") @PathVariable String articleId) {
+        return ResponseEntity.ok(articleService.get(decodeArticleId(articleId)));
     }
 
     @PutMapping("/{articleId}")
     @Operation(summary = "아티클 수정",
-            description = "본문/메타데이터 + recipeIds 전체 교체. slug는 변경 불가. 본문이 바뀌면 humanReviewed가 false로 초기화된다.")
-    public ResponseEntity<Map<String, Long>> update(
-            @Parameter(description = "아티클 ID") @PathVariable Long articleId,
+            description = "본문/메타데이터 + recipeIds 전체 교체. slug는 변경 불가. 본문이 바뀌면 humanReviewed가 false로 초기화된다. articleId path와 body recipeIds 모두 HashID 문자열.")
+    public ResponseEntity<Map<String, String>> update(
+            @Parameter(description = "아티클 ID (HashID)") @PathVariable String articleId,
             @RequestBody @Valid CurationArticleUpdateRequest request) {
-        Long updatedId = articleService.update(articleId, request);
-        return ResponseEntity.ok(Map.of("articleId", updatedId));
+        Long updatedId = articleService.update(decodeArticleId(articleId), request);
+        return ResponseEntity.ok(Map.of("articleId", hashids.encode(updatedId)));
     }
 
     @PostMapping("/{articleId}/publish")
     @Operation(summary = "아티클 발행",
             description = "status=PUBLISHED. publishedAt이 null이면 현재 시각으로 채우고 이후 호출에서는 보존된다 (idempotent).")
     public ResponseEntity<Void> publish(
-            @Parameter(description = "아티클 ID") @PathVariable Long articleId) {
-        articleService.publish(articleId);
+            @Parameter(description = "아티클 ID (HashID)") @PathVariable String articleId) {
+        articleService.publish(decodeArticleId(articleId));
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/{articleId}/archive")
     @Operation(summary = "아티클 아카이브", description = "status=ARCHIVED (idempotent).")
     public ResponseEntity<Void> archive(
-            @Parameter(description = "아티클 ID") @PathVariable Long articleId) {
-        articleService.archive(articleId);
+            @Parameter(description = "아티클 ID (HashID)") @PathVariable String articleId) {
+        articleService.archive(decodeArticleId(articleId));
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/{articleId}/review")
     @Operation(summary = "사람 검수 완료 표시", description = "humanReviewed=true (idempotent).")
     public ResponseEntity<Void> review(
-            @Parameter(description = "아티클 ID") @PathVariable Long articleId) {
-        articleService.markReviewed(articleId);
+            @Parameter(description = "아티클 ID (HashID)") @PathVariable String articleId) {
+        articleService.markReviewed(decodeArticleId(articleId));
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/{articleId}/images/presigned-urls")
-    @Operation(summary = "아티클 이미지 presigned PUT URL 발급 (articleId 기반)",
+    @Operation(summary = "아티클 이미지 presigned PUT URL 발급 (articleHashId 기반)",
             description = """
-                    articleId path variable이 가리키는 아티클 소속 이미지 업로드 URL을 발급한다.
+                    articleId path(HashID)가 가리키는 아티클 소속 이미지 업로드 URL을 발급한다.
                     아티클이 없으면 ARTICLE_NOT_FOUND. DRAFT/PUBLISHED/ARCHIVED 어떤 상태에서도 어드민은 발급 가능하다.
 
                     image/jpeg, image/png, image/webp만 허용. fileSize 10MB 이하.
@@ -123,13 +131,13 @@ public class AdminCurationArticleController {
                     강제하지 않는다. 어드민 전용이라 V1에서 허용하며, 강제가 필요해지면 presigned POST + content-length-range
                     또는 업로드 후 HEAD/finalize 검증을 별도로 도입한다.
 
-                    Key 패턴:
-                      uploadKey = original/images/articles/{articleId}/{uuid}.{ext}
-                      imageKey  = images/articles/{articleId}/{uuid}.webp""")
+                    Key 패턴 (articleHashId segment 기반):
+                      uploadKey = original/images/articles/{articleHashId}/{uuid}.{ext}
+                      imageKey  = images/articles/{articleHashId}/{uuid}.webp""")
     public ResponseEntity<ArticleImagePresignedUrlResponse> issueImagePresignedUrl(
-            @Parameter(description = "아티클 ID") @PathVariable Long articleId,
+            @Parameter(description = "아티클 ID (HashID)") @PathVariable String articleId,
             @RequestBody @Valid ArticleImagePresignedUrlRequest request) {
-        return ResponseEntity.ok(imageUploadService.issuePresignedUrl(articleId, request));
+        return ResponseEntity.ok(imageUploadService.issuePresignedUrl(decodeArticleId(articleId), request));
     }
 
     @PostMapping("/{articleId}/images/finalize")
@@ -138,12 +146,42 @@ public class AdminCurationArticleController {
                     프론트가 S3 PUT을 끝낸 후, 변환된 .webp가 S3에 실제로 존재하는지 확인한다 (Lambda 변환 완료 검증).
                     DB 상태는 변경하지 않고 단순히 존재 여부만 본다.
 
-                    검증 순서: ① articleId 존재 ② 각 imageKey가 images/articles/{articleId}/ 로 시작 + .webp 종료 ③ S3 HEAD.
+                    검증 순서: ① articleId 존재 ② 각 imageKey가 images/articles/{articleHashId}/ 로 시작 + .webp 종료 ③ S3 HEAD.
                     모두 존재하면 200 + ready=true.
                     하나라도 없으면 409 + ARTICLE_IMAGES_NOT_READY (응답에 missingKeys 포함) — 프론트는 짧게 폴링하거나 사용자에게 다시 시도 안내.""")
     public ResponseEntity<ArticleImageFinalizeResponse> finalizeImages(
-            @Parameter(description = "아티클 ID") @PathVariable Long articleId,
+            @Parameter(description = "아티클 ID (HashID)") @PathVariable String articleId,
             @RequestBody @Valid ArticleImageFinalizeRequest request) {
-        return ResponseEntity.ok(imageUploadService.finalizeImages(articleId, request.getImageKeys()));
+        return ResponseEntity.ok(imageUploadService.finalizeImages(decodeArticleId(articleId), request.getImageKeys()));
+    }
+
+    /**
+     * 큐레이션 아티클 전용 strict HashID 디코더.
+     *
+     * <p>전역 {@code @DecodeId} resolver는 마이그레이션 호환을 위해 숫자 문자열도 그대로 Long으로 받아주지만,
+     * 큐레이션 아티클은 신규 도메인이라 처음부터 HashID만 받는다는 정책이 명확하다. 여기서는:
+     * <ul>
+     *   <li>입력이 순수 숫자({@code "42"})면 INVALID_INPUT_VALUE로 400 거부</li>
+     *   <li>HashID 디코드 실패면 마찬가지로 400 거부</li>
+     *   <li>유효한 HashID만 raw Long으로 반환</li>
+     * </ul>
+     *
+     * <p>전역 resolver를 바꾸지 않는 이유: 다른 도메인(레시피/유저 등)은 lenient 동작에 의존할 수 있다.
+     */
+    private Long decodeArticleId(String hashId) {
+        if (hashId == null || hashId.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "articleId가 비어 있습니다.");
+        }
+        if (hashId.matches("^[0-9]+$")) {
+            // 숫자만 박은 path는 raw Long을 그대로 보내려는 시도 — 정책상 거부.
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE,
+                    "articleId는 HashID 문자열로 입력해야 합니다 (숫자 입력 거부): " + hashId);
+        }
+        long[] decoded = hashids.decode(hashId);
+        if (decoded.length == 0) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE,
+                    "유효하지 않은 articleId(HashID): " + hashId);
+        }
+        return decoded[0];
     }
 }

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImageFinalizeRequest.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImageFinalizeRequest.java
@@ -20,7 +20,7 @@ public class ArticleImageFinalizeRequest {
 
     @NotEmpty(message = "imageKeys는 비어 있을 수 없습니다.")
     @Size(max = 50, message = "한 번에 finalize 가능한 imageKey 개수는 최대 50개입니다.")
-    @Schema(description = "확인할 imageKey 목록 (.webp). 모두 images/articles/{articleId}/ 형식이어야 한다. 한 번에 최대 50개.",
-            example = "[\"images/articles/42/abc-uuid.webp\", \"images/articles/42/def-uuid.webp\"]")
+    @Schema(description = "확인할 imageKey 목록 (.webp). 모두 images/articles/{articleHashId}/ 형식이어야 한다. 한 번에 최대 50개.",
+            example = "[\"images/articles/xJvY7aBp/abc-uuid.webp\", \"images/articles/xJvY7aBp/def-uuid.webp\"]")
     private List<@NotBlank @Size(max = 500) String> imageKeys;
 }

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImageFinalizeResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImageFinalizeResponse.java
@@ -22,6 +22,6 @@ public class ArticleImageFinalizeResponse {
     private boolean ready;
 
     @Schema(description = "확인 완료된 imageKey 목록 (요청과 동일).",
-            example = "[\"images/articles/42/abc-uuid.webp\"]")
+            example = "[\"images/articles/xJvY7aBp/abc-uuid.webp\"]")
     private List<String> imageKeys;
 }

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImagePresignedUrlResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/ArticleImagePresignedUrlResponse.java
@@ -5,12 +5,12 @@ import lombok.Builder;
 import lombok.Getter;
 
 /**
- * 아티클 이미지 presigned URL 응답 (articleId 기반).
+ * 아티클 이미지 presigned URL 응답 (articleHashId 기반).
  *
- * <p>레시피 이미지와 동일하게 원본 → webp 변환 파이프라인을 사용하며 key는 articleId path를 포함한다.
+ * <p>레시피 이미지와 동일하게 원본 → webp 변환 파이프라인을 사용하며 key는 articleHashId path segment를 포함한다.
  * <ul>
- *   <li>{@code uploadKey} ({@code original/images/articles/{articleId}/{uuid}.{ext}}): 프론트가 PUT 업로드할 위치(원본).</li>
- *   <li>{@code imageKey} ({@code images/articles/{articleId}/{uuid}.webp}): Lambda 변환 후의 최종 위치. DB(coverImageKey),
+ *   <li>{@code uploadKey} ({@code original/images/articles/{articleHashId}/{uuid}.{ext}}): 프론트가 PUT 업로드할 위치(원본).</li>
+ *   <li>{@code imageKey} ({@code images/articles/{articleHashId}/{uuid}.webp}): Lambda 변환 후의 최종 위치. DB(coverImageKey),
  *       MDX의 {@code <ArticleImage imageKey="..." />}에는 항상 이 키만 저장한다.</li>
  *   <li>{@code presignedUrl}: {@code uploadKey}에 대한 S3 PUT URL. 발급 후 10분간 유효.</li>
  * </ul>
@@ -19,15 +19,15 @@ import lombok.Getter;
  */
 @Getter
 @Builder
-@Schema(description = "아티클 이미지 presigned URL 발급 응답 (articleId 기반)")
+@Schema(description = "아티클 이미지 presigned URL 발급 응답 (articleHashId 기반)")
 public class ArticleImagePresignedUrlResponse {
 
-    @Schema(description = "S3 PUT 업로드 대상 키 (원본 위치, ext는 contentType에 따라 jpg/png/webp). articleId path 포함.",
-            example = "original/images/articles/123/4f5b3a3a-1a2b-4c5d-9e6f-1234567890ab.jpg")
+    @Schema(description = "S3 PUT 업로드 대상 키 (원본 위치, ext는 contentType에 따라 jpg/png/webp). articleHashId segment 포함.",
+            example = "original/images/articles/xJvY7aBp/4f5b3a3a-1a2b-4c5d-9e6f-1234567890ab.jpg")
     private String uploadKey;
 
     @Schema(description = "변환 후 최종 이미지 키 (.webp 고정). coverImageKey 또는 MDX에 저장한다.",
-            example = "images/articles/123/4f5b3a3a-1a2b-4c5d-9e6f-1234567890ab.webp")
+            example = "images/articles/xJvY7aBp/4f5b3a3a-1a2b-4c5d-9e6f-1234567890ab.webp")
     private String imageKey;
 
     @Schema(description = "uploadKey에 대한 presigned PUT URL. 10분간 유효.")

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleCreateRequest.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleCreateRequest.java
@@ -1,5 +1,8 @@
 package com.jdc.recipe_service.domain.dto.article;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.jdc.recipe_service.config.HashIdConfig;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -38,7 +41,7 @@ public class CurationArticleCreateRequest {
 
     @Size(max = 500)
     @Schema(description = "커버 이미지 S3 key. presigned URL 응답의 imageKey(.webp)를 저장한다 — uploadKey가 아니다.",
-            example = "images/articles/123/uuid.webp")
+            example = "images/articles/xJvY7aBp/uuid.webp")
     private String coverImageKey;
 
     @NotBlank
@@ -53,7 +56,20 @@ public class CurationArticleCreateRequest {
     @Schema(description = "생성에 사용된 AI 모델 식별자", example = "claude-opus-4.7")
     private String generatedBy;
 
-    @Schema(description = "참조한 레시피 ID 목록 (audit/soft link). 각 ID는 양의 정수여야 한다.")
+    /**
+     * 프론트가 보내는 wire 형식은 HashID 문자열 배열이지만, 내부 필드는 Long으로 유지해
+     * service/repository 레이어가 raw Long으로 처리하게 한다.
+     *
+     * <p>{@code @JsonDeserialize(contentUsing = StrictHashIdDeserializer)}가 element 단위로 String → Long 변환.
+     * Strict 버전이라 raw 숫자 입력(예: {@code [101, 102]})은 거부되고 HashID 문자열만 허용된다.
+     * Bean Validation의 {@code @NotNull} / {@code @Positive}는 디코드 후 element 값에 적용된다.
+     * OpenAPI는 wire 형식(string[])을 정확히 표현하기 위해 {@code @ArraySchema(schema=@Schema(type="string"))}.
+     */
+    @JsonDeserialize(contentUsing = HashIdConfig.StrictHashIdDeserializer.class)
+    @ArraySchema(
+            schema = @Schema(type = "string", example = "vK9mP2Qa", description = "레시피 ID (HashID 문자열)"),
+            arraySchema = @Schema(description = "참조한 레시피 ID 목록 (HashID 문자열 배열, audit/soft link)")
+    )
     private List<@NotNull(message = "recipeIds 항목에 null이 포함될 수 없습니다.")
                  @Positive(message = "recipeIds 항목은 양의 정수여야 합니다.") Long> recipeIds;
 }

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleResponse.java
@@ -1,7 +1,10 @@
 package com.jdc.recipe_service.domain.dto.article;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.jdc.recipe_service.config.HashIdConfig;
 import com.jdc.recipe_service.domain.entity.article.CurationArticle;
 import com.jdc.recipe_service.domain.type.article.ArticleStatus;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,12 +12,19 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * 어드민 큐레이션 아티클 상세 응답.
+ *
+ * <p>외부에 노출되는 모든 ID 필드는 HashID 문자열로 직렬화한다 — admin이라도 raw Long을 wire에 노출하지 않는다.
+ * 내부 필드 타입은 그대로 Long 유지 (DB/service/repository와 정합).
+ */
 @Getter
 @Builder
 @Schema(description = "큐레이션 아티클 상세 응답")
 public class CurationArticleResponse {
 
-    @Schema(description = "아티클 ID")
+    @JsonSerialize(using = HashIdConfig.HashIdSerializer.class)
+    @Schema(description = "아티클 ID (HashID 문자열)", example = "xJvY7aBp", type = "string")
     private Long id;
 
     @Schema(description = "URL slug")
@@ -26,7 +36,8 @@ public class CurationArticleResponse {
     @Schema(description = "메타 설명")
     private String description;
 
-    @Schema(description = "커버 이미지 S3 key")
+    @Schema(description = "커버 이미지 S3 imageKey (.webp). path segment는 articleHashId 기반.",
+            example = "images/articles/xJvY7aBp/uuid.webp")
     private String coverImageKey;
 
     @Schema(description = "본문 MDX 원본")
@@ -53,7 +64,11 @@ public class CurationArticleResponse {
     @Schema(description = "수정 시각")
     private LocalDateTime updatedAt;
 
-    @Schema(description = "참조한 레시피 ID 목록 (audit)")
+    @JsonSerialize(contentUsing = HashIdConfig.HashIdSerializer.class)
+    @ArraySchema(
+            schema = @Schema(type = "string", example = "vK9mP2Qa", description = "레시피 ID (HashID 문자열)"),
+            arraySchema = @Schema(description = "참조한 레시피 ID 목록 (HashID 문자열 배열, audit/soft link)")
+    )
     private List<Long> recipeIds;
 
     public static CurationArticleResponse of(CurationArticle a, List<Long> recipeIds) {

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleSummaryResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleSummaryResponse.java
@@ -1,5 +1,7 @@
 package com.jdc.recipe_service.domain.dto.article;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.jdc.recipe_service.config.HashIdConfig;
 import com.jdc.recipe_service.domain.entity.article.CurationArticle;
 import com.jdc.recipe_service.domain.type.article.ArticleStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,16 +12,22 @@ import java.time.LocalDateTime;
 
 /**
  * 어드민 목록 응답. 본문 MDX는 포함하지 않는다 (목록 트래픽 절감).
+ *
+ * <p>id는 HashID 문자열로 직렬화된다 — wire에 raw Long 노출 금지 정책.
  */
 @Getter
 @Builder
 @Schema(description = "큐레이션 아티클 목록용 요약 응답")
 public class CurationArticleSummaryResponse {
 
+    @JsonSerialize(using = HashIdConfig.HashIdSerializer.class)
+    @Schema(description = "아티클 ID (HashID 문자열)", example = "xJvY7aBp", type = "string")
     private Long id;
+
     private String slug;
     private String title;
     private String description;
+    @Schema(description = "커버 이미지 S3 imageKey (.webp)", example = "images/articles/xJvY7aBp/uuid.webp")
     private String coverImageKey;
     private String category;
     private ArticleStatus status;

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleUpdateRequest.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleUpdateRequest.java
@@ -1,6 +1,8 @@
-
 package com.jdc.recipe_service.domain.dto.article;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.jdc.recipe_service.config.HashIdConfig;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -36,7 +38,7 @@ public class CurationArticleUpdateRequest {
 
     @Size(max = 500)
     @Schema(description = "커버 이미지 S3 key. presigned URL 응답의 imageKey(.webp)를 저장한다 — uploadKey가 아니다.",
-            example = "images/articles/123/uuid.webp")
+            example = "images/articles/xJvY7aBp/uuid.webp")
     private String coverImageKey;
 
     @NotBlank
@@ -51,7 +53,14 @@ public class CurationArticleUpdateRequest {
     @Schema(description = "생성에 사용된 AI 모델 식별자 (재생성 시 갱신)")
     private String generatedBy;
 
-    @Schema(description = "참조한 레시피 ID 목록 — 요청 값으로 전체 교체된다. 각 ID는 양의 정수여야 한다.")
+    /**
+     * 프론트는 HashID 문자열 배열로 보내고, 내부 필드는 Long으로 유지된다 (CreateRequest와 동일 정책).
+     */
+    @JsonDeserialize(contentUsing = HashIdConfig.StrictHashIdDeserializer.class)
+    @ArraySchema(
+            schema = @Schema(type = "string", example = "vK9mP2Qa", description = "레시피 ID (HashID 문자열)"),
+            arraySchema = @Schema(description = "참조한 레시피 ID 목록 (HashID 문자열 배열) — 요청 값으로 전체 교체된다.")
+    )
     private List<@NotNull(message = "recipeIds 항목에 null이 포함될 수 없습니다.")
                  @Positive(message = "recipeIds 항목은 양의 정수여야 합니다.") Long> recipeIds;
 }

--- a/src/main/java/com/jdc/recipe_service/service/article/CurationArticleImageUploadService.java
+++ b/src/main/java/com/jdc/recipe_service/service/article/CurationArticleImageUploadService.java
@@ -9,6 +9,7 @@ import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.util.S3Util;
 import lombok.RequiredArgsConstructor;
+import org.hashids.Hashids;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -20,14 +21,18 @@ import java.util.UUID;
 /**
  * 어드민 큐레이션 아티클 이미지 업로드.
  *
- * <p>레시피 이미지와 동일한 원본→webp 변환 구조 + articleId 기반 key 정책:
+ * <p>레시피 이미지와 동일한 원본→webp 변환 구조 + <strong>articleHashId 기반 key 정책</strong>:
  * <pre>
- *   uploadKey  : original/images/articles/{articleId}/{uuid}.{ext}   (프론트 PUT 업로드 대상)
- *   imageKey   : images/articles/{articleId}/{uuid}.webp             (변환 후 최종, DB/MDX에 저장)
+ *   uploadKey  : original/images/articles/{articleHashId}/{uuid}.{ext}   (프론트 PUT 업로드 대상)
+ *   imageKey   : images/articles/{articleHashId}/{uuid}.webp             (변환 후 최종, DB/MDX에 저장)
  * </pre>
  *
- * <p>articleId를 path에 박아두는 이유는 운영 추적성 — S3 key만 봐도 어느 글에 속한 이미지인지 알 수 있고,
- * 글 삭제 시 prefix 단위 정리(`original/images/articles/{id}/`, `images/articles/{id}/`)가 가능해진다.
+ * <p>article segment를 raw Long이 아니라 HashID로 두는 이유: wire에 노출되는 모든 식별자(API path, response,
+ * S3 key)에서 raw Long을 새지 않게 한다. 운영 추적성은 그대로 — S3 key의 articleHashId를 디코드하면 article ID
+ * 식별 가능하고, 글 삭제 시 prefix 단위 정리(`original/images/articles/{hashId}/`, `images/articles/{hashId}/`)도 가능.
+ *
+ * <p>Lambda recipe-image-resizer는 srcKey의 {@code original/} prefix를 떼고 확장자만 {@code .webp}로 바꾸는 구조라
+ * 폴더 segment 형식이 raw Long이든 HashID든 상관없이 그대로 동작한다 — Lambda 코드 변경 불필요.
  *
  * <p>fileKey는 서버에서만 생성해 프론트가 S3 path를 결정하지 못하게 한다. DRAFT/PUBLISHED/ARCHIVED 어떤 상태에서도
  * 어드민은 이미지 업로드 URL을 받을 수 있다 — 발행 후 본문 수정 중 이미지 추가 시나리오를 막지 않기 위함.
@@ -44,14 +49,12 @@ import java.util.UUID;
  *   <li>finalize에서 HeadObjectResponse.contentLength()까지 검사하도록 확장 (단, 변환 후 webp의 크기는 원본과 다름)</li>
  * </ul>
  *
- * <p>TODO(image-pipeline): Lambda recipe-image-resizer가 articles 분기에서 다음 입출력을 처리해야 한다.
+ * <p>참고: Lambda recipe-image-resizer는 다음 입출력으로 동작한다 (이미 운영 배포됨, 추가 작업 불필요).
  * <pre>
- *   입력: original/images/articles/{articleId}/{uuid}.{ext}
- *   출력: images/articles/{articleId}/{uuid}.webp
+ *   입력: original/images/articles/{articleHashId}/{uuid}.{ext}
+ *   출력: images/articles/{articleHashId}/{uuid}.webp
  *   변환: width 1024, withoutEnlargement true, webp quality 85
  * </pre>
- * recipes 라우팅({@code original/images/recipes/} → {@code images/recipes/})은 이미 잡혀 있고, 여기에
- * articles 분기가 추가되어야 한다. 인프라/Lambda 갱신은 별도 배포 항목.
  */
 @Service
 @RequiredArgsConstructor
@@ -74,6 +77,7 @@ public class CurationArticleImageUploadService {
 
     private final S3Util s3Util;
     private final CurationArticleRepository articleRepo;
+    private final Hashids hashids;
 
     public ArticleImagePresignedUrlResponse issuePresignedUrl(Long articleId,
                                                               ArticleImagePresignedUrlRequest req) {
@@ -88,12 +92,12 @@ public class CurationArticleImageUploadService {
         if (req.getFileSize() > MAX_FILE_SIZE_BYTES) {
             throw new CustomException(ErrorCode.ARTICLE_IMAGE_TOO_LARGE);
         }
-
+        String articleHashId = hashids.encode(articleId);
         String uuid = UUID.randomUUID().toString();
-        String uploadKey = String.format("%s/%d/%s.%s",
-                UPLOAD_KEY_PREFIX, articleId, uuid, EXTENSION_BY_CONTENT_TYPE.get(contentType));
-        String imageKey = String.format("%s/%d/%s.%s",
-                IMAGE_KEY_PREFIX, articleId, uuid, CONVERTED_EXTENSION);
+        String uploadKey = String.format("%s/%s/%s.%s",
+                UPLOAD_KEY_PREFIX, articleHashId, uuid, EXTENSION_BY_CONTENT_TYPE.get(contentType));
+        String imageKey = String.format("%s/%s/%s.%s",
+                IMAGE_KEY_PREFIX, articleHashId, uuid, CONVERTED_EXTENSION);
 
         String presignedUrl = s3Util.createPresignedUrl(uploadKey, contentType);
 
@@ -110,7 +114,7 @@ public class CurationArticleImageUploadService {
      * <p>검증 순서:
      * <ol>
      *   <li>articleId 존재</li>
-     *   <li>각 key가 {@code images/articles/{articleId}/}로 시작하고 {@code .webp}로 끝나는지 (다른 글의 키 사칭 방지)</li>
+     *   <li>각 key가 {@code images/articles/{articleHashId}/}로 시작하고 {@code .webp}로 끝나는지 (다른 글의 키 사칭 방지)</li>
      *   <li>S3 HEAD로 객체 존재 여부 확인</li>
      * </ol>
      *
@@ -122,12 +126,11 @@ public class CurationArticleImageUploadService {
             throw new CustomException(ErrorCode.ARTICLE_NOT_FOUND);
         }
 
-        String requiredPrefix = String.format("%s/%d/", IMAGE_KEY_PREFIX, articleId);
+        String requiredPrefix = String.format("%s/%s/", IMAGE_KEY_PREFIX, hashids.encode(articleId));
         List<String> distinct = imageKeys.stream().distinct().toList();
 
         for (String key : distinct) {
             if (key == null || !key.startsWith(requiredPrefix) || !key.endsWith("." + CONVERTED_EXTENSION)) {
-                // 다른 article의 키 사칭 방지 + 변환 결과(.webp)만 허용
                 throw new CustomException(ErrorCode.INVALID_INPUT_VALUE,
                         "imageKey 형식이 잘못되었습니다: " + key);
             }
@@ -136,8 +139,6 @@ public class CurationArticleImageUploadService {
         List<String> missing = new ArrayList<>();
         List<String> present = new ArrayList<>();
         for (String key : distinct) {
-            // isObjectPresent는 404만 false. 권한/네트워크 문제는 예외로 propagate되어 catch-all 500이 되며,
-            // 프론트가 "아직 변환 안 됨"으로 오해하고 무한 폴링하는 것을 막는다.
             if (s3Util.isObjectPresent(key)) {
                 present.add(key);
             } else {

--- a/src/test/java/com/jdc/recipe_service/controller/admin/AdminCurationArticleControllerWebMvcTest.java
+++ b/src/test/java/com/jdc/recipe_service/controller/admin/AdminCurationArticleControllerWebMvcTest.java
@@ -1,6 +1,7 @@
 package com.jdc.recipe_service.controller.admin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jdc.recipe_service.config.HashIdConfig;
 import com.jdc.recipe_service.domain.dto.article.ArticleImageFinalizeRequest;
 import com.jdc.recipe_service.domain.dto.article.ArticleImageFinalizeResponse;
 import com.jdc.recipe_service.domain.dto.article.ArticleImagePresignedUrlRequest;
@@ -17,6 +18,7 @@ import com.jdc.recipe_service.service.article.CurationArticleImageUploadService;
 import com.jdc.recipe_service.service.article.CurationArticleService;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.hashids.Hashids;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +35,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -41,7 +44,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -54,7 +59,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @WebMvcTest(controllers = AdminCurationArticleController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@Import({GlobalExceptionHandler.class, AdminCurationArticleControllerWebMvcTest.MethodSecurityTestConfig.class})
+@Import({GlobalExceptionHandler.class, HashIdConfig.class,
+        AdminCurationArticleControllerWebMvcTest.MethodSecurityTestConfig.class})
+@TestPropertySource(properties = {
+        "app.hashids.salt=TEST_SALT_FOR_ADMIN_CURATION_ARTICLE_CONTROLLER",
+        "app.hashids.min-length=8"
+})
 class AdminCurationArticleControllerWebMvcTest {
 
     @TestConfiguration
@@ -68,6 +78,7 @@ class AdminCurationArticleControllerWebMvcTest {
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
+    @Autowired Hashids hashids;
 
     @MockBean CurationArticleService articleService;
     @MockBean CurationArticleImageUploadService imageUploadService;
@@ -96,7 +107,7 @@ class AdminCurationArticleControllerWebMvcTest {
     }
 
     @Test
-    @DisplayName("POST /api/admin/curation-articles: 정상 요청 → 201 + articleId 응답")
+    @DisplayName("POST /api/admin/curation-articles: 정상 요청 → 201 + articleId가 HashID 문자열")
     void create_ok() throws Exception {
         CurationArticleCreateRequest req = CurationArticleCreateRequest.builder()
                 .slug("summer-diet")
@@ -105,13 +116,49 @@ class AdminCurationArticleControllerWebMvcTest {
                 .build();
         given(articleService.create(any(CurationArticleCreateRequest.class))).willReturn(42L);
 
+        String expectedHashId = hashids.encode(42L);
+
         mockMvc.perform(post("/api/admin/curation-articles")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.articleId").value(42));
+                .andExpect(jsonPath("$.articleId").value(expectedHashId))
+                .andExpect(jsonPath("$.articleId").isString());
 
         verify(articleService).create(any(CurationArticleCreateRequest.class));
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/curation-articles: 요청 본문의 recipeIds(string HashID 배열)가 service에 raw Long으로 디코드되어 전달")
+    void create_recipeIdsAreDecodedFromHashId() throws Exception {
+        long rawRecipeId1 = 101L;
+        long rawRecipeId2 = 102L;
+        String hashedRecipe1 = hashids.encode(rawRecipeId1);
+        String hashedRecipe2 = hashids.encode(rawRecipeId2);
+
+        // body는 HashID 문자열 배열
+        String body = String.format("""
+                {
+                  "slug": "summer-diet",
+                  "title": "test",
+                  "contentMdx": "# body",
+                  "recipeIds": ["%s", "%s"]
+                }
+                """, hashedRecipe1, hashedRecipe2);
+
+        given(articleService.create(any(CurationArticleCreateRequest.class))).willReturn(42L);
+
+        mockMvc.perform(post("/api/admin/curation-articles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated());
+
+        // service에 전달된 request는 raw Long 디코드된 상태여야 한다
+        org.mockito.ArgumentCaptor<CurationArticleCreateRequest> cap =
+                org.mockito.ArgumentCaptor.forClass(CurationArticleCreateRequest.class);
+        verify(articleService).create(cap.capture());
+        org.assertj.core.api.Assertions.assertThat(cap.getValue().getRecipeIds())
+                .containsExactly(rawRecipeId1, rawRecipeId2);
     }
 
     @Test
@@ -150,38 +197,43 @@ class AdminCurationArticleControllerWebMvcTest {
     }
 
     @Test
-    @DisplayName("POST /{articleId}/images/presigned-urls: articleId path가 service로 전달되고 응답 3-필드가 그대로 내려간다")
+    @DisplayName("POST /{articleId}/images/presigned-urls: articleId path는 HashID로 받고 service엔 raw Long 전달")
     void issuePresignedUrl_ok() throws Exception {
-        long articleId = 123L;
+        long rawArticleId = 123L;
+        String hashedArticleId = hashids.encode(rawArticleId);
         ArticleImagePresignedUrlRequest req = ArticleImagePresignedUrlRequest.builder()
                 .contentType("image/jpeg")
                 .fileSize(123_456L)
                 .build();
-        given(imageUploadService.issuePresignedUrl(eq(articleId), any(ArticleImagePresignedUrlRequest.class)))
+        // 응답의 imageKey segment도 HashID 기반
+        String mockUploadKey = "original/images/articles/" + hashedArticleId + "/uuid.jpg";
+        String mockImageKey = "images/articles/" + hashedArticleId + "/uuid.webp";
+        given(imageUploadService.issuePresignedUrl(eq(rawArticleId), any(ArticleImagePresignedUrlRequest.class)))
                 .willReturn(ArticleImagePresignedUrlResponse.builder()
-                        .uploadKey("original/images/articles/123/uuid.jpg")
-                        .imageKey("images/articles/123/uuid.webp")
+                        .uploadKey(mockUploadKey)
+                        .imageKey(mockImageKey)
                         .presignedUrl("https://s3.test/uuid")
                         .build());
 
-        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/presigned-urls", articleId)
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/presigned-urls", hashedArticleId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.uploadKey").value("original/images/articles/123/uuid.jpg"))
-                .andExpect(jsonPath("$.imageKey").value("images/articles/123/uuid.webp"))
+                .andExpect(jsonPath("$.uploadKey").value(mockUploadKey))
+                .andExpect(jsonPath("$.imageKey").value(mockImageKey))
                 .andExpect(jsonPath("$.presignedUrl").value("https://s3.test/uuid"));
 
-        verify(imageUploadService).issuePresignedUrl(eq(articleId), any(ArticleImagePresignedUrlRequest.class));
+        // path의 HashID가 디코드되어 service에는 raw Long(123)으로 전달됐는지 검증
+        verify(imageUploadService).issuePresignedUrl(eq(rawArticleId), any(ArticleImagePresignedUrlRequest.class));
     }
 
     @Test
     @DisplayName("POST /{articleId}/images/presigned-urls: fileSize 누락 → 400 (service 미호출)")
     void issuePresignedUrl_missingFileSize_returns400() throws Exception {
-        // fileSize 없이 contentType만
+        String hashedArticleId = hashids.encode(1L);
         String body = "{\"contentType\":\"image/webp\"}";
 
-        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/presigned-urls", 1L)
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/presigned-urls", hashedArticleId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isBadRequest());
@@ -190,70 +242,189 @@ class AdminCurationArticleControllerWebMvcTest {
     }
 
     @Test
-    @DisplayName("POST /{articleId}/publish: path variable로 service에 raw Long 전달")
+    @DisplayName("POST /{articleId}/publish: HashID path가 service에 raw Long으로 디코드되어 전달")
     void publish_callsService() throws Exception {
-        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/publish", 42L))
+        long rawArticleId = 42L;
+        String hashedArticleId = hashids.encode(rawArticleId);
+
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/publish", hashedArticleId))
                 .andExpect(status().isOk());
 
-        verify(articleService).publish(eq(42L));
+        verify(articleService).publish(eq(rawArticleId));
     }
 
     @Test
-    @DisplayName("POST /{articleId}/images/finalize: 모든 imageKey가 ready면 200 + ready=true 응답 + service 호출 인자 검증")
+    @DisplayName("POST /{articleId}/images/finalize: 모든 imageKey ready면 200 + service에 raw Long 전달 (HashID 디코드)")
     void finalize_ok() throws Exception {
-        long articleId = 42L;
+        long rawArticleId = 42L;
+        String hashedArticleId = hashids.encode(rawArticleId);
+        String key = "images/articles/" + hashedArticleId + "/abc.webp";
+
         ArticleImageFinalizeRequest req = ArticleImageFinalizeRequest.builder()
-                .imageKeys(java.util.List.of("images/articles/42/abc.webp"))
+                .imageKeys(java.util.List.of(key))
                 .build();
-        given(imageUploadService.finalizeImages(eq(articleId), any()))
+        given(imageUploadService.finalizeImages(eq(rawArticleId), any()))
                 .willReturn(ArticleImageFinalizeResponse.builder()
                         .ready(true)
-                        .imageKeys(java.util.List.of("images/articles/42/abc.webp"))
+                        .imageKeys(java.util.List.of(key))
                         .build());
 
-        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/finalize", articleId)
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/finalize", hashedArticleId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.ready").value(true))
-                .andExpect(jsonPath("$.imageKeys[0]").value("images/articles/42/abc.webp"));
+                .andExpect(jsonPath("$.imageKeys[0]").value(key));
 
-        verify(imageUploadService).finalizeImages(eq(articleId), any());
+        verify(imageUploadService).finalizeImages(eq(rawArticleId), any());
     }
 
     @Test
     @DisplayName("POST /{articleId}/images/finalize: 일부 imageKey가 누락되면 409 + code=1207 + missingKeys/presentKeys 포함")
     void finalize_notReady_returns409WithMissingKeys() throws Exception {
-        long articleId = 42L;
-        ArticleImageFinalizeRequest req = ArticleImageFinalizeRequest.builder()
-                .imageKeys(java.util.List.of("images/articles/42/abc.webp", "images/articles/42/def.webp"))
-                .build();
-        given(imageUploadService.finalizeImages(eq(articleId), any()))
-                .willThrow(new ArticleImagesNotReadyException(
-                        java.util.List.of("images/articles/42/def.webp"),
-                        java.util.List.of("images/articles/42/abc.webp")));
+        long rawArticleId = 42L;
+        String hashedArticleId = hashids.encode(rawArticleId);
+        String present = "images/articles/" + hashedArticleId + "/abc.webp";
+        String missing = "images/articles/" + hashedArticleId + "/def.webp";
 
-        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/finalize", articleId)
+        ArticleImageFinalizeRequest req = ArticleImageFinalizeRequest.builder()
+                .imageKeys(java.util.List.of(present, missing))
+                .build();
+        given(imageUploadService.finalizeImages(eq(rawArticleId), any()))
+                .willThrow(new ArticleImagesNotReadyException(
+                        java.util.List.of(missing),
+                        java.util.List.of(present)));
+
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/finalize", hashedArticleId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value("1207"))
-                .andExpect(jsonPath("$.missingKeys[0]").value("images/articles/42/def.webp"))
-                .andExpect(jsonPath("$.presentKeys[0]").value("images/articles/42/abc.webp"));
+                .andExpect(jsonPath("$.missingKeys[0]").value(missing))
+                .andExpect(jsonPath("$.presentKeys[0]").value(present));
     }
 
     @Test
     @DisplayName("POST /{articleId}/images/finalize: imageKeys 누락 → 400 (service 미호출)")
     void finalize_emptyImageKeys_returns400() throws Exception {
-        // imageKeys 배열 자체가 비어 있음
+        String hashedArticleId = hashids.encode(1L);
         String body = "{\"imageKeys\":[]}";
 
-        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/finalize", 1L)
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/images/finalize", hashedArticleId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isBadRequest());
 
         verify(imageUploadService, never()).finalizeImages(any(), any());
+    }
+
+    @Test
+    @DisplayName("GET /{articleId}: 응답 DTO의 id는 HashID 문자열, recipeIds도 string[]로 직렬화된다")
+    void getDetail_serializesIdsAsHashIdStrings() throws Exception {
+        long rawArticleId = 7L;
+        String hashedArticleId = hashids.encode(rawArticleId);
+        String hashedRecipe1 = hashids.encode(101L);
+        String hashedRecipe2 = hashids.encode(102L);
+
+        com.jdc.recipe_service.domain.dto.article.CurationArticleResponse resp =
+                com.jdc.recipe_service.domain.dto.article.CurationArticleResponse.builder()
+                        .id(rawArticleId)
+                        .slug("summer-diet")
+                        .title("title")
+                        .contentMdx("c")
+                        .status(com.jdc.recipe_service.domain.type.article.ArticleStatus.PUBLISHED)
+                        .humanReviewed(true)
+                        .recipeIds(java.util.List.of(101L, 102L))
+                        .build();
+        given(articleService.get(eq(rawArticleId))).willReturn(resp);
+
+        mockMvc.perform(get("/api/admin/curation-articles/{articleId}", hashedArticleId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(hashedArticleId))
+                .andExpect(jsonPath("$.id").isString())
+                .andExpect(jsonPath("$.recipeIds[0]").value(hashedRecipe1))
+                .andExpect(jsonPath("$.recipeIds[1]").value(hashedRecipe2))
+                .andExpect(jsonPath("$.recipeIds[0]").isString());
+    }
+
+    @Test
+    @DisplayName("GET /: 목록 응답 content[].id가 HashID 문자열로 직렬화된다")
+    void list_serializesIdsAsHashIdStrings() throws Exception {
+        long rawArticleId = 42L;
+        String hashedArticleId = hashids.encode(rawArticleId);
+        com.jdc.recipe_service.domain.dto.article.CurationArticleSummaryResponse item =
+                com.jdc.recipe_service.domain.dto.article.CurationArticleSummaryResponse.builder()
+                        .id(rawArticleId)
+                        .slug("summer-diet")
+                        .title("title")
+                        .status(com.jdc.recipe_service.domain.type.article.ArticleStatus.DRAFT)
+                        .humanReviewed(false)
+                        .build();
+        given(articleService.search(any(), any(), any(), any()))
+                .willReturn(new org.springframework.data.domain.PageImpl<>(java.util.List.of(item)));
+
+        mockMvc.perform(get("/api/admin/curation-articles"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(hashedArticleId))
+                .andExpect(jsonPath("$.content[0].id").isString());
+    }
+
+    @Test
+    @DisplayName("PUT /{articleId}: 응답 articleId가 HashID 문자열")
+    void update_returnsHashIdArticleId() throws Exception {
+        long rawArticleId = 42L;
+        String hashedArticleId = hashids.encode(rawArticleId);
+        given(articleService.update(eq(rawArticleId), any())).willReturn(rawArticleId);
+
+        // body는 최소 필수만 — recipeIds는 비워도 됨 (validation 통과)
+        String body = """
+                { "title": "수정", "contentMdx": "c" }
+                """;
+        mockMvc.perform(put("/api/admin/curation-articles/{articleId}", hashedArticleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.articleId").value(hashedArticleId))
+                .andExpect(jsonPath("$.articleId").isString());
+    }
+
+    @Test
+    @DisplayName("strict decoder: raw 숫자 path(`/42/publish`)는 400 거부 (service 미호출)")
+    void publish_rejectsRawNumericPath() throws Exception {
+        // 숫자만 박은 path는 정책상 거부 — strict decoder가 INVALID_INPUT_VALUE
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/publish", "42"))
+                .andExpect(status().isBadRequest());
+
+        verify(articleService, never()).publish(any());
+    }
+
+    @Test
+    @DisplayName("strict decoder: 잘못된 HashID path도 400 거부 (decode 실패)")
+    void publish_rejectsInvalidHashIdPath() throws Exception {
+        mockMvc.perform(post("/api/admin/curation-articles/{articleId}/publish", "definitelyNotAHashId123!@#"))
+                .andExpect(status().isBadRequest());
+
+        verify(articleService, never()).publish(any());
+    }
+
+    @Test
+    @DisplayName("strict deserializer: body recipeIds에 raw 숫자 배열이 오면 400 거부")
+    void create_rejectsRawNumericRecipeIds() throws Exception {
+        // 숫자 그대로 박은 recipeIds — strict deserializer가 거부
+        String body = """
+                {
+                  "slug": "ok-slug",
+                  "title": "t",
+                  "contentMdx": "c",
+                  "recipeIds": [101, 102]
+                }
+                """;
+        mockMvc.perform(post("/api/admin/curation-articles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+
+        verify(articleService, never()).create(any());
     }
 
     @Test

--- a/src/test/java/com/jdc/recipe_service/service/article/CurationArticleImageUploadServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/article/CurationArticleImageUploadServiceTest.java
@@ -8,11 +8,12 @@ import com.jdc.recipe_service.exception.ArticleImagesNotReadyException;
 import com.jdc.recipe_service.exception.CustomException;
 import com.jdc.recipe_service.exception.ErrorCode;
 import com.jdc.recipe_service.util.S3Util;
+import org.hashids.Hashids;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -31,12 +32,22 @@ class CurationArticleImageUploadServiceTest {
     @Mock private S3Util s3Util;
     @Mock private CurationArticleRepository articleRepo;
 
-    @InjectMocks private CurationArticleImageUploadService imageUploadService;
+    // 실 Hashids 인스턴스 사용 — 같은 인스턴스로 expected value 동적 생성해 salt 변경에도 회귀 안 깨짐.
+    // HashIdConfig가 사용하는 정적 인스턴스도 함께 초기화해 service 내부의 hashids.encode가 동일 결과를 내게 한다.
+    private final Hashids hashids = new Hashids("TEST_SALT_FOR_IMAGE_UPLOAD_SERVICE", 8);
+
+    private CurationArticleImageUploadService imageUploadService;
+
+    @BeforeEach
+    void setUp() {
+        imageUploadService = new CurationArticleImageUploadService(s3Util, articleRepo, hashids);
+    }
 
     @Test
-    @DisplayName("article이 존재하면 articleId path를 포함한 uploadKey/imageKey가 생성되고 S3 presigned URL이 uploadKey에 발급된다")
-    void issuesPresignedUrlWithArticleIdPath() {
+    @DisplayName("article이 존재하면 articleHashId path를 포함한 uploadKey/imageKey가 생성되고 S3 presigned URL이 uploadKey에 발급된다")
+    void issuesPresignedUrlWithArticleHashIdPath() {
         long articleId = 42L;
+        String articleHashId = hashids.encode(articleId);
         given(articleRepo.existsById(articleId)).willReturn(true);
         given(s3Util.createPresignedUrl(anyString(), anyString())).willReturn("https://s3.test/upload");
 
@@ -47,19 +58,21 @@ class CurationArticleImageUploadServiceTest {
 
         ArticleImagePresignedUrlResponse resp = imageUploadService.issuePresignedUrl(articleId, req);
 
-        // path에 articleId가 박힘 + ext가 contentType 매핑(jpeg→jpg) + 변환 결과는 webp 고정
-        assertThat(resp.getUploadKey())
-                .startsWith("original/images/articles/42/")
-                .endsWith(".jpg");
-        assertThat(resp.getImageKey())
-                .startsWith("images/articles/42/")
-                .endsWith(".webp");
+        // path segment에 raw Long(42)이 아니라 HashID 문자열이 박혀야 한다 — wire에 raw Long 노출 금지 정책
+        String expectedUploadPrefix = "original/images/articles/" + articleHashId + "/";
+        String expectedImagePrefix = "images/articles/" + articleHashId + "/";
+        assertThat(resp.getUploadKey()).startsWith(expectedUploadPrefix).endsWith(".jpg");
+        assertThat(resp.getImageKey()).startsWith(expectedImagePrefix).endsWith(".webp");
+        // raw Long segment("/42/")가 절대 들어가서는 안 된다
+        assertThat(resp.getUploadKey()).doesNotContain("/42/");
+        assertThat(resp.getImageKey()).doesNotContain("/42/");
+
         // upload/image key UUID 동일성 — 서로 prefix만 다른 같은 자원이어야 한다
         String uploadUuid = resp.getUploadKey().substring(
-                "original/images/articles/42/".length(),
+                expectedUploadPrefix.length(),
                 resp.getUploadKey().length() - ".jpg".length());
         String imageUuid = resp.getImageKey().substring(
-                "images/articles/42/".length(),
+                expectedImagePrefix.length(),
                 resp.getImageKey().length() - ".webp".length());
         assertThat(uploadUuid).isEqualTo(imageUuid);
 
@@ -109,48 +122,69 @@ class CurationArticleImageUploadServiceTest {
     // ── finalizeImages ──
 
     @Test
-    @DisplayName("finalize: 모든 imageKey가 S3에 존재하면 ready=true 응답")
+    @DisplayName("finalize: 모든 imageKey가 S3에 존재하면 ready=true 응답 (HashID prefix 검증)")
     void finalize_allReady() {
         long articleId = 42L;
+        String articleHashId = hashids.encode(articleId);
+        String key1 = "images/articles/" + articleHashId + "/abc.webp";
+        String key2 = "images/articles/" + articleHashId + "/def.webp";
         given(articleRepo.existsById(articleId)).willReturn(true);
-        given(s3Util.isObjectPresent("images/articles/42/abc.webp")).willReturn(true);
-        given(s3Util.isObjectPresent("images/articles/42/def.webp")).willReturn(true);
+        given(s3Util.isObjectPresent(key1)).willReturn(true);
+        given(s3Util.isObjectPresent(key2)).willReturn(true);
 
         ArticleImageFinalizeResponse resp = imageUploadService.finalizeImages(
-                articleId, List.of("images/articles/42/abc.webp", "images/articles/42/def.webp"));
+                articleId, List.of(key1, key2));
 
         assertThat(resp.isReady()).isTrue();
-        assertThat(resp.getImageKeys())
-                .containsExactlyInAnyOrder("images/articles/42/abc.webp", "images/articles/42/def.webp");
+        assertThat(resp.getImageKeys()).containsExactlyInAnyOrder(key1, key2);
     }
 
     @Test
     @DisplayName("finalize: 일부 imageKey가 S3에 없으면 ArticleImagesNotReadyException(missing/present 분리)")
     void finalize_partialMissingThrows() {
         long articleId = 42L;
+        String articleHashId = hashids.encode(articleId);
+        String present = "images/articles/" + articleHashId + "/abc.webp";
+        String missing = "images/articles/" + articleHashId + "/def.webp";
         given(articleRepo.existsById(articleId)).willReturn(true);
-        given(s3Util.isObjectPresent("images/articles/42/abc.webp")).willReturn(true);
-        given(s3Util.isObjectPresent("images/articles/42/def.webp")).willReturn(false);
+        given(s3Util.isObjectPresent(present)).willReturn(true);
+        given(s3Util.isObjectPresent(missing)).willReturn(false);
 
         assertThatThrownBy(() -> imageUploadService.finalizeImages(
-                articleId, List.of("images/articles/42/abc.webp", "images/articles/42/def.webp")))
+                articleId, List.of(present, missing)))
                 .isInstanceOf(ArticleImagesNotReadyException.class)
                 .satisfies(ex -> {
                     ArticleImagesNotReadyException notReady = (ArticleImagesNotReadyException) ex;
-                    assertThat(notReady.getMissingKeys()).containsExactly("images/articles/42/def.webp");
-                    assertThat(notReady.getPresentKeys()).containsExactly("images/articles/42/abc.webp");
+                    assertThat(notReady.getMissingKeys()).containsExactly(missing);
+                    assertThat(notReady.getPresentKeys()).containsExactly(present);
                 });
     }
 
     @Test
-    @DisplayName("finalize: imageKey가 다른 article prefix를 갖고 있으면 INVALID_INPUT_VALUE — S3 HEAD 호출되지 않음")
+    @DisplayName("finalize: imageKey가 다른 article의 HashID prefix를 갖고 있으면 INVALID_INPUT_VALUE — S3 HEAD 호출 0")
     void finalize_wrongPrefixThrows() {
+        long articleId = 42L;
+        String otherHashId = hashids.encode(99L);  // 다른 article의 HashID 사칭 시도
+        given(articleRepo.existsById(articleId)).willReturn(true);
+
+        assertThatThrownBy(() -> imageUploadService.finalizeImages(
+                articleId, List.of("images/articles/" + otherHashId + "/abc.webp")))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+
+        verify(s3Util, never()).isObjectPresent(anyString());
+    }
+
+    @Test
+    @DisplayName("finalize: 키에 raw Long segment(`/42/`)가 들어 있으면 거부 — HashID prefix와 다르므로 INVALID_INPUT_VALUE")
+    void finalize_rawLongSegmentRejected() {
         long articleId = 42L;
         given(articleRepo.existsById(articleId)).willReturn(true);
 
-        // articleId=42인데 키는 articleId=99의 것
+        // raw Long을 segment로 박은 키는 더 이상 허용되지 않는다 (HashID 정책 전환)
         assertThatThrownBy(() -> imageUploadService.finalizeImages(
-                articleId, List.of("images/articles/99/abc.webp")))
+                articleId, List.of("images/articles/42/abc.webp")))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
@@ -162,10 +196,11 @@ class CurationArticleImageUploadServiceTest {
     @DisplayName("finalize: imageKey가 .webp가 아니면 INVALID_INPUT_VALUE")
     void finalize_nonWebpExtensionThrows() {
         long articleId = 42L;
+        String articleHashId = hashids.encode(articleId);
         given(articleRepo.existsById(articleId)).willReturn(true);
 
         assertThatThrownBy(() -> imageUploadService.finalizeImages(
-                articleId, List.of("images/articles/42/abc.jpg")))
+                articleId, List.of("images/articles/" + articleHashId + "/abc.jpg")))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
@@ -176,10 +211,12 @@ class CurationArticleImageUploadServiceTest {
     @Test
     @DisplayName("finalize: article이 없으면 ARTICLE_NOT_FOUND. 형식 검증/S3 호출은 일어나지 않는다")
     void finalize_articleMissingThrows() {
-        given(articleRepo.existsById(999L)).willReturn(false);
+        long missingArticleId = 999L;
+        String missingHashId = hashids.encode(missingArticleId);
+        given(articleRepo.existsById(missingArticleId)).willReturn(false);
 
         assertThatThrownBy(() -> imageUploadService.finalizeImages(
-                999L, List.of("images/articles/999/abc.webp")))
+                missingArticleId, List.of("images/articles/" + missingHashId + "/abc.webp")))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ARTICLE_NOT_FOUND);


### PR DESCRIPTION
  ## 해결하려는 문제가 무엇인가요?

  이전 라운드에서 public 응답의 id/recipeIds만 HashID로 전환됐고 admin 영역과 S3 imageKey segment는 raw Long이 그대로
  노출됐다. 미래에 admin 도구가 부분 노출되거나 어떤 운영 화면이 imageKey를 그대로 외부에 보일 때 raw 순차 ID
  enumeration이 다시 가능해진다. 큐레이션 아티클이 미배포 신규 도메인이라 backward compat 부담 없이 한 번에 통일하는 게
  옳음.

  ## 어떻게 해결했나요?

  - **AS-IS:** admin path `/42/publish`, response `{ "articleId": 42 }`, S3 key `images/articles/42/uuid.webp`
  - **TO-BE:** admin path `/xJvY7aBp/publish`, response `{ "articleId": "xJvY7aBp" }`, S3 key
  `images/articles/xJvY7aBp/uuid.webp`

  리뷰 포인트:
  1. **Strict 분기 격리** — 기존 전역 `@DecodeId` / `HashIdDeserializer`(lenient, 숫자 fallback)는 다른 도메인이 의존할
  수 있으니 그대로. `StrictHashIdDeserializer` 새로 만들고 큐레이션 아티클 DTO에만 적용. Controller도 `@PathVariable
  String` + `decodeArticleId()` private 헬퍼로 strict 검증 (숫자 path → 400).
  2. **DB/entity/repository/service 내부 타입 0줄 변경** — wire boundary에서만 인코딩/디코딩.
  3. **Lambda 변경 불필요** — recipe-image-resizer는 폴더 segment 형식 무관하게 동작. 직접 Lambda 소스 확인.

  ## Test plan

  - [x] `./gradlew test --tests "*CurationArticle*" --rerun-tasks` **50/50 PASS**
  - [x] `AdminCurationArticleControllerWebMvcTest`에 6개 회귀 테스트 추가 (GET 상세/목록/PUT 응답 HashID 직렬화 + raw
  숫자 path/body 거부)
  - [x] `CurationArticleImageUploadServiceTest`에 raw Long segment 거부 회귀 테스트 추가
  - [x] strict decoder가 lenient resolver와 격리됨을 잠금 — 큐레이션 아티클 path/recipeIds는 숫자 입력 시 정확히 400

  ## Rollout / DB / API impact

  - **DB**: 변경 없음
  - **API 응답**: admin DTO `id`/`recipeIds`, POST/PUT 응답 `articleId` 모두 HashID 문자열
  - **API 요청**: admin path articleId, body recipeIds 모두 HashID 문자열로만 받음 (raw 숫자 거부)
  - **S3 key**: uploadKey/imageKey의 article segment HashID
  - **Lambda**: 변경 불필요
  - **다른 도메인**: 영향 0 (전역 lenient resolver 그대로)
  - **운영 영향**: 미배포 신규 API라 실 호출자 0

  ## Risks and rollback

  | 위험 | 영향 | 대응 |
  |---|---|---|
  | 프론트가 raw 숫자로 path 호출 | strict decoder가 400 거부 | 핸드오프 문서로 처음부터 HashID 사용 명시 |
  | 기존 S3에 raw Long segment 키가 남아 있음 | 새 정책에서 finalize prefix 검증 실패 | 미배포 신규 API라 실 데이터
  없음. 테스트 시 만든 raw segment 객체는 무해 (public 노출 없음) |

  **롤백**: 단일 커밋 revert로 즉시 원복. 다른 도메인 영향 없음.

  ## Related

  - 선행: `refactor(curation-articles): public 응답 id/recipeIds를 HashID 문자열로 직렬화` (1de4256)
  - 선행: `feat(curation-articles): MDX 매거진 아티클 도메인 + admin/public API + 이미지 업로드 finalize` (e99d2c5)
  - 핸드오프 문서: `docs/handoff/frontend-api-changes-2026-05-03.md/html` (gitignored)