### PR TITLE
feat(curation-articles): public sitemap·추천 API 추가 + sitemap reserved …

### DIFF
--- a/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
+++ b/src/main/java/com/jdc/recipe_service/config/SecurityConfig.java
@@ -110,6 +110,7 @@ public class SecurityConfig {
                                     "/api/dev/search/**",  // dev V3 search mirrors
                                     "/api/curation-articles",        // public 큐레이션 아티클 목록 (PUBLISHED만 service가 강제)
                                     "/api/curation-articles/*",      // public 큐레이션 아티클 상세 (slug; PUBLISHED만 service가 강제)
+                                    "/api/curation-articles/*/recommendations",  // public 추천 — 2-depth라 위 단일 wildcard로 안 잡힘
                                     "/api/recipes/sitemap"
                             ).permitAll()
 
@@ -353,6 +354,7 @@ public class SecurityConfig {
                                 "/api/dev/search/**",  // dev V3 search mirrors
                                 "/api/curation-articles",        // public 큐레이션 아티클 목록 (PUBLISHED만 service가 강제)
                                 "/api/curation-articles/*",      // public 큐레이션 아티클 상세 (slug; PUBLISHED만 service가 강제)
+                                "/api/curation-articles/*/recommendations",  // public 추천 — 2-depth라 위 단일 wildcard로 안 잡힘
                                 "/api/recipes/sitemap"
                         ).permitAll()
 

--- a/src/main/java/com/jdc/recipe_service/controller/CurationArticleController.java
+++ b/src/main/java/com/jdc/recipe_service/controller/CurationArticleController.java
@@ -1,5 +1,7 @@
 package com.jdc.recipe_service.controller;
 
+import com.jdc.recipe_service.domain.dto.article.CurationArticleRecommendationResponse;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleSitemapResponse;
 import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleResponse;
 import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleSummaryResponse;
 import com.jdc.recipe_service.service.article.PublicCurationArticleService;
@@ -12,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 큐레이션 아티클 (public) 조회 API.
@@ -45,11 +49,41 @@ public class CurationArticleController {
         return ResponseEntity.ok(publicArticleService.listPublished(category, pageable));
     }
 
+    /**
+     * sitemap 엔드포인트는 {@code @GetMapping("/{slug}")}보다 위에 둬야 의도가 명확하다.
+     * Spring MVC는 literal path가 path variable보다 더 specific하게 매칭되므로 위치만으로
+     * 정렬되진 않지만, 사람이 읽을 때 "/sitemap"이 먼저 잡힌다는 의도가 드러나야 후임이
+     * 이 매핑을 실수로 {@code /{slug}} 아래로 옮기는 일을 막을 수 있다.
+     */
+    @GetMapping("/sitemap")
+    @Operation(summary = "발행된 아티클 sitemap 데이터 조회",
+            description = """
+                    sitemap.xml 생성용 — PUBLISHED 아티클의 slug + updatedAt 배열만 반환한다.
+                    DRAFT/ARCHIVED는 절대 포함되지 않는다. 정렬은 updatedAt DESC, id DESC.
+                    인증/path/query/body 모두 없음.""")
+    public ResponseEntity<List<CurationArticleSitemapResponse>> sitemap() {
+        return ResponseEntity.ok(publicArticleService.listSitemap());
+    }
+
     @GetMapping("/{slug}")
     @Operation(summary = "발행된 아티클 상세 조회 (slug 기준)",
             description = "PUBLISHED 상태 아티클만 반환. DRAFT/ARCHIVED 또는 존재하지 않는 slug는 404 ARTICLE_NOT_FOUND.")
     public ResponseEntity<PublicCurationArticleResponse> getBySlug(
             @Parameter(description = "URL slug") @PathVariable String slug) {
         return ResponseEntity.ok(publicArticleService.getBySlug(slug));
+    }
+
+    @GetMapping("/{slug}/recommendations")
+    @Operation(summary = "아티클 상세 페이지 추천 카드",
+            description = """
+                    상세 페이지 하단의 추천 아티클 목록. PUBLISHED만 반환하며 현재 아티클은 결과에서 제외된다.
+                    deterministic random 기반이라 같은 아티클에서 같은 추천 순서가 안정적으로 유지된다 (새로고침해도 동일).
+                    같은 카테고리 추천(min(3, size/2))과 explore 추천을 섞어 단일 카테고리가 추천을 독점하지 않게 한다.
+                    size는 [4, 12]로 clamp되며 기본 6.""")
+    public ResponseEntity<List<CurationArticleRecommendationResponse>> recommendations(
+            @Parameter(description = "현재 보고 있는 아티클의 URL slug") @PathVariable String slug,
+            @Parameter(description = "추천 개수. 기본 6, 최소 4, 최대 12 (범위 밖은 service에서 clamp)")
+            @RequestParam(required = false) Integer size) {
+        return ResponseEntity.ok(publicArticleService.listRecommendations(slug, size));
     }
 }

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleRecommendationResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleRecommendationResponse.java
@@ -1,0 +1,45 @@
+package com.jdc.recipe_service.domain.dto.article;
+
+import com.jdc.recipe_service.domain.projection.article.CurationArticleRecommendationProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 추천 아티클 카드 응답.
+ *
+ * <p>아티클 상세 페이지 하단의 "추천 카드"에 필요한 최소 필드만 노출한다 — id/contentMdx/status/recipeIds는
+ * 의도적으로 제외 (raw Long 노출 회피 + 페이로드 절감). slug로 카드 클릭 시 상세 페이지로 이동한다.
+ */
+@Getter
+@Builder
+@Schema(description = "Public 큐레이션 아티클 추천 카드 응답")
+public class CurationArticleRecommendationResponse {
+
+    @Schema(description = "URL slug. 카드 클릭 시 상세 페이지로 이동",
+            example = "high-protein-breakfast")
+    private String slug;
+
+    @Schema(description = "카드 제목",
+            example = "단백질 아침 레시피 모음")
+    private String title;
+
+    @Schema(description = "카드 썸네일 이미지의 S3 imageKey (.webp). null 가능",
+            example = "images/articles/xJvY7aBp/uuid.webp",
+            nullable = true)
+    private String coverImageKey;
+
+    @Schema(description = "카테고리 라벨. null 가능",
+            example = "diet",
+            nullable = true)
+    private String category;
+
+    public static CurationArticleRecommendationResponse of(CurationArticleRecommendationProjection p) {
+        return CurationArticleRecommendationResponse.builder()
+                .slug(p.getSlug())
+                .title(p.getTitle())
+                .coverImageKey(p.getCoverImageKey())
+                .category(p.getCategory())
+                .build();
+    }
+}

--- a/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleSitemapResponse.java
+++ b/src/main/java/com/jdc/recipe_service/domain/dto/article/CurationArticleSitemapResponse.java
@@ -1,0 +1,30 @@
+package com.jdc.recipe_service.domain.dto.article;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 큐레이션 아티클 sitemap 응답 항목.
+ *
+ * <p>PUBLISHED 아티클의 sitemap.xml 생성에 필요한 최소 필드만 노출한다.
+ * 프론트는 {@code slug}로 article URL을 만들고, {@code updatedAt}을 sitemap의 {@code <lastmod>}에 사용한다.
+ *
+ * <p>id, contentMdx, status, recipeIds 등은 의도적으로 제외 — sitemap은 검색엔진 크롤러용 외부 노출이라
+ * 필요 이상 필드가 있으면 정보 누수면이 넓어진다.
+ */
+@Getter
+@Builder
+@Schema(description = "Public 큐레이션 아티클 sitemap 항목")
+public class CurationArticleSitemapResponse {
+
+    @Schema(description = "URL slug. 프론트가 article 상세 URL을 구성하는 데 사용",
+            example = "summer-diet-cucumber-recipes")
+    private String slug;
+
+    @Schema(description = "마지막 수정 시각. sitemap.xml의 <lastmod>에 사용",
+            example = "2026-05-05T10:20:00")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/jdc/recipe_service/domain/projection/article/CurationArticleRecommendationProjection.java
+++ b/src/main/java/com/jdc/recipe_service/domain/projection/article/CurationArticleRecommendationProjection.java
@@ -1,0 +1,13 @@
+package com.jdc.recipe_service.domain.projection.article;
+
+/**
+ * 추천 후보 조회용 projection. 본문 MDX/status/recipeIds 등은 가져오지 않는다 — 추천 카드가 필요한
+ * 최소 컬럼만 select해 트래픽과 메모리 비용을 줄인다. id는 dedup/제외 로직에 필요해서 포함한다 (응답에는 미노출).
+ */
+public interface CurationArticleRecommendationProjection {
+    Long getId();
+    String getSlug();
+    String getTitle();
+    String getCoverImageKey();
+    String getCategory();
+}

--- a/src/main/java/com/jdc/recipe_service/domain/projection/article/CurationArticleSitemapProjection.java
+++ b/src/main/java/com/jdc/recipe_service/domain/projection/article/CurationArticleSitemapProjection.java
@@ -1,0 +1,8 @@
+package com.jdc.recipe_service.domain.projection.article;
+
+import java.time.LocalDateTime;
+
+public interface CurationArticleSitemapProjection {
+    String getSlug();
+    LocalDateTime getUpdatedAt();
+}

--- a/src/main/java/com/jdc/recipe_service/domain/repository/article/CurationArticleRepository.java
+++ b/src/main/java/com/jdc/recipe_service/domain/repository/article/CurationArticleRepository.java
@@ -1,6 +1,8 @@
 package com.jdc.recipe_service.domain.repository.article;
 
 import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.projection.article.CurationArticleRecommendationProjection;
+import com.jdc.recipe_service.domain.projection.article.CurationArticleSitemapProjection;
 import com.jdc.recipe_service.domain.type.article.ArticleStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -36,4 +39,54 @@ public interface CurationArticleRepository extends JpaRepository<CurationArticle
                                  @Param("category") String category,
                                  @Param("q") String q,
                                  Pageable pageable);
+
+    /**
+     * sitemap 생성용 projection. PUBLISHED 만 반환하며 정렬은 updatedAt DESC, id DESC로
+     * 강제한다 — 클라이언트가 sort 파라미터를 변조해도 운영 의도와 다른 결과가 나오지 않게,
+     * status 필터와 정렬을 모두 query에서 박는다.
+     */
+    @Query("""
+            SELECT a.slug AS slug, a.updatedAt AS updatedAt
+            FROM CurationArticle a
+            WHERE a.status = com.jdc.recipe_service.domain.type.article.ArticleStatus.PUBLISHED
+            ORDER BY a.updatedAt DESC, a.id DESC
+            """)
+    List<CurationArticleSitemapProjection> findAllForSitemap();
+
+    /**
+     * 추천 후보(같은 카테고리). PUBLISHED + 같은 category + 현재 article 제외.
+     *
+     * <p>전체 후보를 반환한다 — Pageable로 잘라내면 자른 부분집합 안에서만 deterministic random이 돌아
+     * "전체 PUBLISHED가 후보"라는 정책과 어긋난다. 응답 컬럼이 5개뿐(id/slug/title/coverImageKey/category)이라
+     * V1 운영 규모에선 부담이 작다. 아티클 수가 수만 단위로 늘어 메모리/페이로드가 문제되면 그때 다시 검토.
+     *
+     * <p>ORDER BY는 두지 않는다 — service의 deterministic random sort가 단일 source-of-truth.
+     */
+    @Query("""
+            SELECT a.id AS id, a.slug AS slug, a.title AS title,
+                   a.coverImageKey AS coverImageKey, a.category AS category
+            FROM CurationArticle a
+            WHERE a.status = com.jdc.recipe_service.domain.type.article.ArticleStatus.PUBLISHED
+              AND a.category = :category
+              AND a.id <> :excludeId
+            """)
+    List<CurationArticleRecommendationProjection> findRecommendationCandidatesByCategory(
+            @Param("category") String category,
+            @Param("excludeId") Long excludeId);
+
+    /**
+     * 추천 후보(explore — category 무제한). PUBLISHED + 현재 article 제외.
+     *
+     * <p>sameCategory에서 이미 선택된 id는 service에서 in-memory dedup으로 거른다 (post-fetch filter가 단순함).
+     * 후보 상한 정책에 대한 설명은 {@link #findRecommendationCandidatesByCategory}와 동일.
+     */
+    @Query("""
+            SELECT a.id AS id, a.slug AS slug, a.title AS title,
+                   a.coverImageKey AS coverImageKey, a.category AS category
+            FROM CurationArticle a
+            WHERE a.status = com.jdc.recipe_service.domain.type.article.ArticleStatus.PUBLISHED
+              AND a.id <> :excludeId
+            """)
+    List<CurationArticleRecommendationProjection> findRecommendationExploreCandidates(
+            @Param("excludeId") Long excludeId);
 }

--- a/src/main/java/com/jdc/recipe_service/exception/ErrorCode.java
+++ b/src/main/java/com/jdc/recipe_service/exception/ErrorCode.java
@@ -115,7 +115,8 @@ public enum ErrorCode {
     ARTICLE_INVALID_RECIPE_REF(HttpStatus.BAD_REQUEST, "1204", "참조한 레시피 중 존재하지 않는 ID가 있습니다."),
     ARTICLE_IMAGE_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "1205", "지원하지 않는 이미지 형식입니다. (jpeg/png/webp만 허용)"),
     ARTICLE_IMAGE_TOO_LARGE(HttpStatus.BAD_REQUEST, "1206", "이미지 크기가 허용 한도(10MB)를 초과합니다."),
-    ARTICLE_IMAGES_NOT_READY(HttpStatus.CONFLICT, "1207", "아직 변환되지 않았거나 업로드되지 않은 이미지가 있습니다.");
+    ARTICLE_IMAGES_NOT_READY(HttpStatus.CONFLICT, "1207", "아직 변환되지 않았거나 업로드되지 않은 이미지가 있습니다."),
+    ARTICLE_SLUG_RESERVED(HttpStatus.BAD_REQUEST, "1208", "예약된 slug라 사용할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/jdc/recipe_service/service/article/CurationArticleService.java
+++ b/src/main/java/com/jdc/recipe_service/service/article/CurationArticleService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * 큐레이션 아티클 어드민 유스케이스.
@@ -34,6 +35,15 @@ public class CurationArticleService {
     private final CurationArticleRepository articleRepo;
     private final CurationArticleRecipeRefRepository refRepo;
     private final RecipeRepository recipeRepo;
+
+    /**
+     * public {@code /api/curation-articles/{slug}}와 같은 prefix 아래 literal route가 잡고 있는 segment 목록.
+     * 이 값들이 slug로 들어오면 {@code GET /{slug}} 매핑이 영영 도달 불가능해지므로 create 시점에 차단한다.
+     *
+     * <p>새 literal route(예: 추후 {@code /api/curation-articles/feed} 같은 것)가
+     * {@link com.jdc.recipe_service.controller.CurationArticleController}에 추가되면 그 segment를 여기에도 추가해야 한다.
+     */
+    private static final Set<String> RESERVED_SLUGS = Set.of("sitemap");
 
     // ── Read ──
 
@@ -55,6 +65,9 @@ public class CurationArticleService {
 
     @Transactional
     public Long create(CurationArticleCreateRequest req) {
+        if (RESERVED_SLUGS.contains(req.getSlug())) {
+            throw new CustomException(ErrorCode.ARTICLE_SLUG_RESERVED);
+        }
         if (articleRepo.existsBySlug(req.getSlug())) {
             throw new CustomException(ErrorCode.ARTICLE_SLUG_DUPLICATE);
         }
@@ -110,7 +123,6 @@ public class CurationArticleService {
         loadArticle(articleId).markReviewed();
     }
 
-    // ── helpers ──
 
     private CurationArticle loadArticle(Long articleId) {
         return articleRepo.findById(articleId)
@@ -120,9 +132,6 @@ public class CurationArticleService {
     private void validateRecipeIds(List<Long> recipeIds) {
         if (recipeIds == null || recipeIds.isEmpty()) return;
 
-        // DTO에 element-level @NotNull/@Positive가 있지만, service 단독 호출(향후 internal caller / batch)
-        // 경로도 안전해야 한다. recipeRepo.findAllById가 null element를 받으면 IllegalArgumentException으로
-        // 터지면서 catch-all 500이 나갈 수 있어 여기서 명시적 4xx로 차단한다.
         if (recipeIds.stream().anyMatch(id -> id == null || id <= 0)) {
             throw new CustomException(ErrorCode.ARTICLE_INVALID_RECIPE_REF);
         }

--- a/src/main/java/com/jdc/recipe_service/service/article/PublicCurationArticleService.java
+++ b/src/main/java/com/jdc/recipe_service/service/article/PublicCurationArticleService.java
@@ -1,8 +1,11 @@
 package com.jdc.recipe_service.service.article;
 
+import com.jdc.recipe_service.domain.dto.article.CurationArticleRecommendationResponse;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleSitemapResponse;
 import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleResponse;
 import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleSummaryResponse;
 import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.projection.article.CurationArticleRecommendationProjection;
 import com.jdc.recipe_service.domain.repository.article.CurationArticleRecipeRefRepository;
 import com.jdc.recipe_service.domain.repository.article.CurationArticleRepository;
 import com.jdc.recipe_service.domain.type.article.ArticleStatus;
@@ -16,7 +19,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Public 큐레이션 아티클 조회 유스케이스.
@@ -36,6 +43,14 @@ import java.util.List;
 public class PublicCurationArticleService {
 
     static final int MAX_PAGE_SIZE = 50;
+
+    /** 추천 size 정책. 4 ≤ size ≤ 12, default 6. */
+    static final int RECOMMENDATION_DEFAULT_SIZE = 6;
+    static final int RECOMMENDATION_MIN_SIZE = 4;
+    static final int RECOMMENDATION_MAX_SIZE = 12;
+
+    /** sameCategory cap. 절반 vs 3 중 작은 값. (safeSize=12면 6이 아니라 3이 cap) */
+    static final int SAME_CATEGORY_HARD_CAP = 3;
 
     private final CurationArticleRepository articleRepo;
     private final CurationArticleRecipeRefRepository refRepo;
@@ -57,6 +72,127 @@ public class PublicCurationArticleService {
                 .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
         List<Long> recipeIds = refRepo.findRecipeIdsByArticleId(article.getId());
         return PublicCurationArticleResponse.of(article, recipeIds);
+    }
+
+    /**
+     * 아티클 상세 페이지 하단 "추천" 카드용 — sameCategory + explore 두 갈래로 나눠 deterministic random으로 섞는다.
+     *
+     * <p>같은 {@code currentArticleId}에 대해선 추천 순서가 안정적이고(새로고침해도 동일), 다른 article로 가면 다른 추천이
+     * 나오도록 score 함수에 두 id를 모두 넣는다. {@code ORDER BY RAND()}는 매 요청마다 결과가 바뀌고 인덱스도 안 타므로 금지.
+     *
+     * <p>safeSize는 [4, 12]로 clamp. sameCategoryTarget = min(3, safeSize/2) — single category가 추천을 독점하지 않게
+     * 의도적으로 cap. category가 비어있으면 sameCategoryTarget=0, 전부 explore에서 채운다. sameCategory 후보가 부족하면
+     * 모자란 만큼 explore가 더 채운다.
+     */
+    public List<CurationArticleRecommendationResponse> listRecommendations(String slug, Integer size) {
+        CurationArticle current = articleRepo.findBySlugAndStatus(slug, ArticleStatus.PUBLISHED)
+                .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
+
+        int safeSize = clampSize(size);
+        int sameCategoryTarget = computeSameCategoryTarget(current.getCategory(), safeSize);
+
+        List<CurationArticleRecommendationProjection> sameCategoryPicked =
+                pickSameCategory(current, sameCategoryTarget);
+
+        int exploreTarget = safeSize - sameCategoryPicked.size();
+        List<CurationArticleRecommendationProjection> explorePicked =
+                pickExplore(current, exploreTarget, sameCategoryPicked);
+
+        List<CurationArticleRecommendationProjection> merged = new ArrayList<>(sameCategoryPicked.size() + explorePicked.size());
+        merged.addAll(sameCategoryPicked);
+        merged.addAll(explorePicked);
+
+        return merged.stream()
+                .map(CurationArticleRecommendationResponse::of)
+                .toList();
+    }
+
+    private int clampSize(Integer size) {
+        if (size == null) return RECOMMENDATION_DEFAULT_SIZE;
+        if (size < RECOMMENDATION_MIN_SIZE) return RECOMMENDATION_MIN_SIZE;
+        if (size > RECOMMENDATION_MAX_SIZE) return RECOMMENDATION_MAX_SIZE;
+        return size;
+    }
+
+    private int computeSameCategoryTarget(String currentCategory, int safeSize) {
+        if (currentCategory == null || currentCategory.isBlank()) return 0;
+        return Math.min(SAME_CATEGORY_HARD_CAP, safeSize / 2);
+    }
+
+    private List<CurationArticleRecommendationProjection> pickSameCategory(CurationArticle current, int target) {
+        if (target <= 0) return List.of();
+        List<CurationArticleRecommendationProjection> candidates = articleRepo.findRecommendationCandidatesByCategory(
+                current.getCategory(), current.getId());
+        return shuffleDeterministic(candidates, current.getId()).stream()
+                .limit(target)
+                .toList();
+    }
+
+    private List<CurationArticleRecommendationProjection> pickExplore(
+            CurationArticle current,
+            int target,
+            List<CurationArticleRecommendationProjection> alreadyPicked) {
+        if (target <= 0) return List.of();
+        Set<Long> excludeIds = new HashSet<>();
+        for (CurationArticleRecommendationProjection p : alreadyPicked) excludeIds.add(p.getId());
+
+        List<CurationArticleRecommendationProjection> candidates = articleRepo.findRecommendationExploreCandidates(
+                current.getId());
+        List<CurationArticleRecommendationProjection> filtered = new ArrayList<>(candidates.size());
+        for (CurationArticleRecommendationProjection p : candidates) {
+            if (!excludeIds.contains(p.getId())) filtered.add(p);
+        }
+        return shuffleDeterministic(filtered, current.getId()).stream()
+                .limit(target)
+                .toList();
+    }
+
+    /**
+     * deterministic 정렬. splitmix64 기반 비선형 mixer로 score를 만든다.
+     *
+     * <p>왜 단순 hash가 아닌가: {@code Objects.hash(curr, cand, slug)}는 polynomial hash가 linear라서
+     * 두 후보의 score 차이에서 curr 항이 상쇄돼 ordering에 영향을 못 준다. {@code String concat + hashCode}도
+     * 짧은 입력에선 비슷한 ordering 패턴을 만들기 쉽다. splitmix64는 단방향 비선형 bit-mixing이라
+     * 입력 1비트 변화에도 출력이 골고루 흩어진다 → currentArticleId가 바뀌면 후보 간 상대 순서도 함께 바뀐다.
+     *
+     * <p>동률(score 충돌)이 나도 candidateId secondary로 안정 정렬.
+     */
+    private static List<CurationArticleRecommendationProjection> shuffleDeterministic(
+            List<CurationArticleRecommendationProjection> candidates, Long currentArticleId) {
+        List<CurationArticleRecommendationProjection> copy = new ArrayList<>(candidates);
+        copy.sort(Comparator
+                .comparingLong((CurationArticleRecommendationProjection p) ->
+                        deterministicScore(currentArticleId, p.getId(), p.getSlug()))
+                .thenComparingLong(CurationArticleRecommendationProjection::getId));
+        return copy;
+    }
+
+    private static long deterministicScore(long currentId, long candidateId, String candidateSlug) {
+        long h = splitmix64(currentId);
+        h = splitmix64(h ^ candidateId);
+        h = splitmix64(h ^ (candidateSlug != null ? candidateSlug.hashCode() : 0));
+        return h;
+    }
+
+    /** splitmix64 — 단방향 비선형 bit-mixer. avalanche 좋음. */
+    private static long splitmix64(long x) {
+        x = (x ^ (x >>> 30)) * 0xbf58476d1ce4e5b9L;
+        x = (x ^ (x >>> 27)) * 0x94d049bb133111ebL;
+        return x ^ (x >>> 31);
+    }
+
+    /**
+     * sitemap.xml 생성용 — PUBLISHED 아티클의 slug + updatedAt만 노출한다.
+     * id/본문/status는 노출하지 않는다 (검색엔진 크롤러용 외부면이라 필요 최소 필드만).
+     * 정렬과 status 필터는 repository query에서 강제된다.
+     */
+    public List<CurationArticleSitemapResponse> listSitemap() {
+        return articleRepo.findAllForSitemap().stream()
+                .map(p -> CurationArticleSitemapResponse.builder()
+                        .slug(p.getSlug())
+                        .updatedAt(p.getUpdatedAt())
+                        .build())
+                .toList();
     }
 
     private static String nullIfBlank(String s) {

--- a/src/test/java/com/jdc/recipe_service/controller/CurationArticleControllerWebMvcTest.java
+++ b/src/test/java/com/jdc/recipe_service/controller/CurationArticleControllerWebMvcTest.java
@@ -1,6 +1,8 @@
 package com.jdc.recipe_service.controller;
 
 import com.jdc.recipe_service.config.HashIdConfig;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleRecommendationResponse;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleSitemapResponse;
 import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleResponse;
 import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleSummaryResponse;
 import com.jdc.recipe_service.exception.CustomException;
@@ -161,6 +163,116 @@ class CurationArticleControllerWebMvcTest {
                 .willThrow(new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
 
         mockMvc.perform(get("/api/curation-articles/{slug}", "archived-slug"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("1201"));
+    }
+
+    @Test
+    @DisplayName("GET /api/curation-articles/sitemap: 200 + slug/updatedAt 배열, id/contentMdx/status 미노출")
+    void sitemap_ok() throws Exception {
+        CurationArticleSitemapResponse a = CurationArticleSitemapResponse.builder()
+                .slug("summer-diet")
+                .updatedAt(LocalDateTime.of(2026, 5, 5, 10, 20))
+                .build();
+        CurationArticleSitemapResponse b = CurationArticleSitemapResponse.builder()
+                .slug("winter-soup")
+                .updatedAt(LocalDateTime.of(2026, 5, 4, 9, 0))
+                .build();
+        given(publicArticleService.listSitemap()).willReturn(List.of(a, b));
+
+        mockMvc.perform(get("/api/curation-articles/sitemap"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].slug").value("summer-diet"))
+                .andExpect(jsonPath("$[0].updatedAt").value("2026-05-05T10:20:00"))
+                .andExpect(jsonPath("$[1].slug").value("winter-soup"))
+                .andExpect(jsonPath("$[0].id").doesNotExist())
+                .andExpect(jsonPath("$[0].contentMdx").doesNotExist())
+                .andExpect(jsonPath("$[0].status").doesNotExist())
+                .andExpect(jsonPath("$[0].title").doesNotExist())
+                .andExpect(jsonPath("$[0].coverImageKey").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /api/curation-articles/sitemap: 발행글이 없으면 빈 배열을 200으로 응답한다 (404 아님)")
+    void sitemap_empty_returns200WithEmptyArray() throws Exception {
+        given(publicArticleService.listSitemap()).willReturn(List.of());
+
+        mockMvc.perform(get("/api/curation-articles/sitemap"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /api/curation-articles/sitemap: /sitemap이 /{slug} 매핑에 잡히지 않는다 — getBySlug 호출 안됨")
+    void sitemap_doesNotFallThroughToSlugHandler() throws Exception {
+        given(publicArticleService.listSitemap()).willReturn(List.of());
+
+        mockMvc.perform(get("/api/curation-articles/sitemap"))
+                .andExpect(status().isOk());
+
+        org.mockito.Mockito.verify(publicArticleService, org.mockito.Mockito.times(1)).listSitemap();
+        org.mockito.Mockito.verify(publicArticleService, org.mockito.Mockito.never())
+                .getBySlug(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    @DisplayName("GET /api/curation-articles/{slug}/recommendations: 200 + slug/title/coverImageKey/category만 노출, 나머지 미노출")
+    void recommendations_ok() throws Exception {
+        CurationArticleRecommendationResponse a = CurationArticleRecommendationResponse.builder()
+                .slug("high-protein-breakfast")
+                .title("단백질 아침")
+                .coverImageKey("images/articles/abc/cover.webp")
+                .category("diet")
+                .build();
+        CurationArticleRecommendationResponse b = CurationArticleRecommendationResponse.builder()
+                .slug("winter-soup")
+                .title("겨울 수프")
+                .coverImageKey(null)
+                .category(null)
+                .build();
+        given(publicArticleService.listRecommendations(eq("summer-diet"), eq(6)))
+                .willReturn(List.of(a, b));
+
+        mockMvc.perform(get("/api/curation-articles/{slug}/recommendations", "summer-diet")
+                        .param("size", "6"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].slug").value("high-protein-breakfast"))
+                .andExpect(jsonPath("$[0].title").value("단백질 아침"))
+                .andExpect(jsonPath("$[0].coverImageKey").value("images/articles/abc/cover.webp"))
+                .andExpect(jsonPath("$[0].category").value("diet"))
+                // 카드 응답에 노출되면 안 되는 필드들
+                .andExpect(jsonPath("$[0].id").doesNotExist())
+                .andExpect(jsonPath("$[0].contentMdx").doesNotExist())
+                .andExpect(jsonPath("$[0].status").doesNotExist())
+                .andExpect(jsonPath("$[0].recipeIds").doesNotExist())
+                .andExpect(jsonPath("$[0].generatedBy").doesNotExist())
+                .andExpect(jsonPath("$[0].humanReviewed").doesNotExist())
+                // null 필드는 그대로 null로 직렬화
+                .andExpect(jsonPath("$[1].coverImageKey").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$[1].category").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    @Test
+    @DisplayName("GET /api/curation-articles/{slug}/recommendations: size 미지정이면 service에 null 전달 (default 처리는 service)")
+    void recommendations_sizeOmitted_passesNullToService() throws Exception {
+        given(publicArticleService.listRecommendations(eq("summer-diet"), org.mockito.ArgumentMatchers.isNull()))
+                .willReturn(List.of());
+
+        mockMvc.perform(get("/api/curation-articles/{slug}/recommendations", "summer-diet"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /api/curation-articles/{slug}/recommendations: 없는 slug면 service가 ARTICLE_NOT_FOUND, 404 + code=1201")
+    void recommendations_unknownSlug_returns404() throws Exception {
+        given(publicArticleService.listRecommendations(eq("ghost-slug"), org.mockito.ArgumentMatchers.any()))
+                .willThrow(new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
+
+        mockMvc.perform(get("/api/curation-articles/{slug}/recommendations", "ghost-slug"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("1201"));
     }

--- a/src/test/java/com/jdc/recipe_service/repository/article/CurationArticleRepositoryTest.java
+++ b/src/test/java/com/jdc/recipe_service/repository/article/CurationArticleRepositoryTest.java
@@ -3,6 +3,8 @@ package com.jdc.recipe_service.repository.article;
 import com.jdc.recipe_service.config.JpaAuditingConfig;
 import com.jdc.recipe_service.config.QuerydslConfig;
 import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.projection.article.CurationArticleRecommendationProjection;
+import com.jdc.recipe_service.domain.projection.article.CurationArticleSitemapProjection;
 import com.jdc.recipe_service.domain.repository.article.CurationArticleRepository;
 import com.jdc.recipe_service.domain.type.article.ArticleStatus;
 import jakarta.persistence.EntityManager;
@@ -20,6 +22,9 @@ import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -100,6 +105,106 @@ class CurationArticleRepositoryTest {
 
         assertThat(articleRepo.existsBySlug("exists-slug")).isTrue();
         assertThat(articleRepo.existsBySlug("missing-slug")).isFalse();
+    }
+
+    @Test
+    @DisplayName("findAllForSitemap은 PUBLISHED만 반환하며 정렬은 updatedAt DESC, id DESC다 (DRAFT/ARCHIVED 제외)")
+    void findAllForSitemap() {
+        LocalDateTime t1 = LocalDateTime.of(2026, 5, 1, 10, 0);
+        LocalDateTime t2 = LocalDateTime.of(2026, 5, 2, 10, 0);
+        LocalDateTime t3 = LocalDateTime.of(2026, 5, 3, 10, 0);
+
+        CurationArticle pubOlder  = articleRepo.save(buildArticle("pub-old",   "옛날 글",   ArticleStatus.PUBLISHED, "diet"));
+        CurationArticle pubMid1   = articleRepo.save(buildArticle("pub-mid-1", "동률 글 1", ArticleStatus.PUBLISHED, "diet"));
+        CurationArticle pubMid2   = articleRepo.save(buildArticle("pub-mid-2", "동률 글 2", ArticleStatus.PUBLISHED, "diet"));
+        CurationArticle pubNewest = articleRepo.save(buildArticle("pub-new",   "최신 글",   ArticleStatus.PUBLISHED, "diet"));
+        CurationArticle draftOne  = articleRepo.save(buildArticle("draft",    "초안",     ArticleStatus.DRAFT,     "diet"));
+        CurationArticle archived  = articleRepo.save(buildArticle("arch",     "아카이브",   ArticleStatus.ARCHIVED,  "diet"));
+        em.flush();
+
+        forceUpdatedAt(pubOlder.getId(),  t1);
+        forceUpdatedAt(pubMid1.getId(),   t2);
+        forceUpdatedAt(pubMid2.getId(),   t2);
+        forceUpdatedAt(pubNewest.getId(), t3);
+        forceUpdatedAt(draftOne.getId(),  t3);
+        forceUpdatedAt(archived.getId(),  t3);
+        em.clear();
+
+        List<CurationArticleSitemapProjection> result = articleRepo.findAllForSitemap();
+
+        assertThat(result).extracting(CurationArticleSitemapProjection::getSlug)
+                .doesNotContain("draft", "arch");
+        assertThat(result).hasSize(4);
+
+        assertThat(result).extracting(CurationArticleSitemapProjection::getSlug)
+                .containsExactly("pub-new", "pub-mid-2", "pub-mid-1", "pub-old");
+    }
+
+    @Test
+    @DisplayName("findRecommendationCandidatesByCategory: PUBLISHED + 같은 category + current 제외만 반환 (DRAFT/ARCHIVED/다른 category 제외)")
+    void findRecommendationCandidatesByCategory_filtersCorrectly() {
+        CurationArticle current  = articleRepo.save(buildArticle("current",   "현재 글",     ArticleStatus.PUBLISHED, "diet"));
+        CurationArticle dietA    = articleRepo.save(buildArticle("diet-a",    "다이어트 A",  ArticleStatus.PUBLISHED, "diet"));
+        CurationArticle dietB    = articleRepo.save(buildArticle("diet-b",    "다이어트 B",  ArticleStatus.PUBLISHED, "diet"));
+        CurationArticle winterC  = articleRepo.save(buildArticle("winter-c",  "겨울 C",      ArticleStatus.PUBLISHED, "winter"));
+        CurationArticle dietDraft = articleRepo.save(buildArticle("diet-draft", "초안 다이어트", ArticleStatus.DRAFT,    "diet"));
+        CurationArticle dietArch  = articleRepo.save(buildArticle("diet-arch",  "보관 다이어트", ArticleStatus.ARCHIVED, "diet"));
+        em.flush();
+        em.clear();
+
+        List<CurationArticleRecommendationProjection> result = articleRepo.findRecommendationCandidatesByCategory(
+                "diet", current.getId());
+
+        assertThat(result).extracting(CurationArticleRecommendationProjection::getSlug)
+                .containsExactlyInAnyOrder("diet-a", "diet-b")
+                .doesNotContain("current", "winter-c", "diet-draft", "diet-arch");
+    }
+
+    @Test
+    @DisplayName("findRecommendationExploreCandidates: PUBLISHED + current 제외, category 무제한 (DRAFT/ARCHIVED 제외)")
+    void findRecommendationExploreCandidates_returnsAllPublishedExceptCurrent() {
+        CurationArticle current  = articleRepo.save(buildArticle("current",  "현재",   ArticleStatus.PUBLISHED, "diet"));
+        CurationArticle pubA     = articleRepo.save(buildArticle("pub-a",    "글 A",   ArticleStatus.PUBLISHED, "diet"));
+        CurationArticle pubB     = articleRepo.save(buildArticle("pub-b",    "글 B",   ArticleStatus.PUBLISHED, "winter"));
+        CurationArticle pubC     = articleRepo.save(buildArticle("pub-c",    "글 C",   ArticleStatus.PUBLISHED, null));
+        CurationArticle draft    = articleRepo.save(buildArticle("draft",    "초안",   ArticleStatus.DRAFT,     "spring"));
+        CurationArticle archived = articleRepo.save(buildArticle("archived", "보관",   ArticleStatus.ARCHIVED,  "summer"));
+        em.flush();
+        em.clear();
+
+        List<CurationArticleRecommendationProjection> result = articleRepo.findRecommendationExploreCandidates(
+                current.getId());
+
+        assertThat(result).extracting(CurationArticleRecommendationProjection::getSlug)
+                .containsExactlyInAnyOrder("pub-a", "pub-b", "pub-c")
+                .doesNotContain("current", "draft", "archived");
+    }
+
+    @Test
+    @DisplayName("findRecommendationCandidates*: 후보 상한 없이 PUBLISHED 전체를 반환한다 (정책: 전체 후보 풀)")
+    void recommendationQueries_returnAllPublishedCandidates() {
+        CurationArticle current = articleRepo.save(buildArticle("current", "현재", ArticleStatus.PUBLISHED, "diet"));
+        for (int i = 0; i < 8; i++) {
+            articleRepo.save(buildArticle("diet-" + i, "글 " + i, ArticleStatus.PUBLISHED, "diet"));
+        }
+        em.flush();
+        em.clear();
+
+        List<CurationArticleRecommendationProjection> sameCat = articleRepo.findRecommendationCandidatesByCategory(
+                "diet", current.getId());
+        List<CurationArticleRecommendationProjection> explore = articleRepo.findRecommendationExploreCandidates(
+                current.getId());
+
+        // current 제외하고 PUBLISHED 8개가 모두 후보로 들어와야 한다 — Pageable cap 없이 전체 풀.
+        assertThat(sameCat).hasSize(8);
+        assertThat(explore).hasSize(8);
+    }
+
+    private void forceUpdatedAt(Long id, LocalDateTime t) {
+        em.createQuery("UPDATE CurationArticle a SET a.updatedAt = :t WHERE a.id = :id")
+                .setParameter("t", t)
+                .setParameter("id", id)
+                .executeUpdate();
     }
 
     private CurationArticle buildArticle(String slug, String title, ArticleStatus status, String category) {

--- a/src/test/java/com/jdc/recipe_service/service/article/CurationArticleServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/article/CurationArticleServiceTest.java
@@ -85,7 +85,6 @@ class CurationArticleServiceTest {
         @DisplayName("recipeIds 중 존재하지 않는 ID가 있으면 ARTICLE_INVALID_RECIPE_REF 예외를 던진다")
         void throwsWhenRecipeRefInvalid() {
             given(articleRepo.existsBySlug("summer-diet")).willReturn(false);
-            // 요청은 [1, 2]지만 1만 존재
             given(recipeRepo.findAllById(List.of(1L, 2L)))
                     .willReturn(List.of(Recipe.builder().build()));
 
@@ -149,6 +148,26 @@ class CurationArticleServiceTest {
         }
 
         @Test
+        @DisplayName("slug이 reserved 목록(sitemap)이면 ARTICLE_SLUG_RESERVED 예외 (route 충돌 방지)")
+        void create_reservedSlug_returns400() {
+            CurationArticleCreateRequest req = CurationArticleCreateRequest.builder()
+                    .slug("sitemap")
+                    .title("t")
+                    .contentMdx("c")
+                    .build();
+
+            assertThatThrownBy(() -> articleService.create(req))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.ARTICLE_SLUG_RESERVED);
+
+            // reserved 검증이 가장 먼저 — DB(existsBySlug)나 recipeRepo가 호출되지 않는다
+            verify(articleRepo, never()).existsBySlug(any());
+            verify(recipeRepo, never()).findAllById(any());
+            verify(articleRepo, never()).save(any());
+        }
+
+        @Test
         @DisplayName("정상 생성 시 article 저장 + refs도 저장한다")
         void savesArticleAndRefs() {
             given(articleRepo.existsBySlug("summer-diet")).willReturn(false);
@@ -183,7 +202,6 @@ class CurationArticleServiceTest {
         @Test
         @DisplayName("본문이 바뀌면 humanReviewed가 false로 리셋된다")
         void resetsHumanReviewed() {
-            // given humanReviewed가 true인 article
             draftArticle.markReviewed();
             assertThat(draftArticle.isHumanReviewed()).isTrue();
             given(articleRepo.findById(100L)).willReturn(Optional.of(draftArticle));

--- a/src/test/java/com/jdc/recipe_service/service/article/PublicCurationArticleServiceTest.java
+++ b/src/test/java/com/jdc/recipe_service/service/article/PublicCurationArticleServiceTest.java
@@ -1,8 +1,12 @@
 package com.jdc.recipe_service.service.article;
 
+import com.jdc.recipe_service.domain.dto.article.CurationArticleRecommendationResponse;
+import com.jdc.recipe_service.domain.dto.article.CurationArticleSitemapResponse;
 import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleResponse;
 import com.jdc.recipe_service.domain.dto.article.PublicCurationArticleSummaryResponse;
 import com.jdc.recipe_service.domain.entity.article.CurationArticle;
+import com.jdc.recipe_service.domain.projection.article.CurationArticleRecommendationProjection;
+import com.jdc.recipe_service.domain.projection.article.CurationArticleSitemapProjection;
 import com.jdc.recipe_service.domain.repository.article.CurationArticleRecipeRefRepository;
 import com.jdc.recipe_service.domain.repository.article.CurationArticleRepository;
 import com.jdc.recipe_service.domain.type.article.ArticleStatus;
@@ -22,11 +26,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
@@ -105,6 +111,43 @@ class PublicCurationArticleServiceTest {
     }
 
     @Test
+    @DisplayName("listSitemap은 repository.findAllForSitemap을 호출하고 projection을 DTO로 매핑한다 (slug + updatedAt만)")
+    void listSitemap_mapsProjectionToDto() {
+        // status 필터 + 정렬은 repository @Query 안에서 강제되므로 service 단위 테스트는
+        // (a) repository를 정확히 1회 호출하고 (b) projection의 slug/updatedAt이 DTO에 그대로
+        // 매핑되며 (c) projection 순서가 DTO 응답 순서로 보존되는지 검증한다.
+        CurationArticleSitemapProjection p1 = sitemapProjection("a-1", LocalDateTime.of(2026, 5, 5, 10, 0));
+        CurationArticleSitemapProjection p2 = sitemapProjection("a-2", LocalDateTime.of(2026, 5, 4, 9, 0));
+        given(articleRepo.findAllForSitemap()).willReturn(List.of(p1, p2));
+
+        List<CurationArticleSitemapResponse> result = publicService.listSitemap();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getSlug()).isEqualTo("a-1");
+        assertThat(result.get(0).getUpdatedAt()).isEqualTo(LocalDateTime.of(2026, 5, 5, 10, 0));
+        assertThat(result.get(1).getSlug()).isEqualTo("a-2");
+        assertThat(result.get(1).getUpdatedAt()).isEqualTo(LocalDateTime.of(2026, 5, 4, 9, 0));
+        org.mockito.Mockito.verify(articleRepo, org.mockito.Mockito.times(1)).findAllForSitemap();
+    }
+
+    @Test
+    @DisplayName("listSitemap은 빈 결과를 빈 List로 반환한다 (null 아님)")
+    void listSitemap_emptyReturnsEmptyList() {
+        given(articleRepo.findAllForSitemap()).willReturn(List.of());
+
+        List<CurationArticleSitemapResponse> result = publicService.listSitemap();
+
+        assertThat(result).isNotNull().isEmpty();
+    }
+
+    private CurationArticleSitemapProjection sitemapProjection(String slug, LocalDateTime updatedAt) {
+        return new CurationArticleSitemapProjection() {
+            @Override public String getSlug() { return slug; }
+            @Override public LocalDateTime getUpdatedAt() { return updatedAt; }
+        };
+    }
+
+    @Test
     @DisplayName("getBySlug는 PUBLISHED 글에 대해 본문/recipeIds를 함께 응답한다")
     void getBySlug_returnsArticleWithRecipeIds() {
         CurationArticle article = CurationArticle.builder()
@@ -126,5 +169,299 @@ class PublicCurationArticleServiceTest {
         assertThat(resp.getTitle()).isEqualTo("여름 다이어트");
         assertThat(resp.getContentMdx()).isEqualTo("# body");
         assertThat(resp.getRecipeIds()).containsExactly(11L, 12L);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // listRecommendations
+    // ─────────────────────────────────────────────────────────────────────
+
+    private CurationArticle currentArticle(long id, String category) {
+        CurationArticle a = CurationArticle.builder()
+                .slug("current-slug")
+                .title("current title")
+                .contentMdx("# x")
+                .category(category)
+                .status(ArticleStatus.PUBLISHED)
+                .build();
+        ReflectionTestUtils.setField(a, "id", id);
+        return a;
+    }
+
+    private CurationArticleRecommendationProjection rec(long id, String slug, String title,
+                                                        String coverImageKey, String category) {
+        return new CurationArticleRecommendationProjection() {
+            @Override public Long getId() { return id; }
+            @Override public String getSlug() { return slug; }
+            @Override public String getTitle() { return title; }
+            @Override public String getCoverImageKey() { return coverImageKey; }
+            @Override public String getCategory() { return category; }
+        };
+    }
+
+    @Test
+    @DisplayName("listRecommendations: current article이 PUBLISHED가 아니면 ARTICLE_NOT_FOUND")
+    void listRecommendations_currentNotPublished_returnsArticleNotFound() {
+        // findBySlugAndStatus(slug, PUBLISHED)가 DRAFT/ARCHIVED 글에 대해 empty Optional → 동일하게 not found.
+        given(articleRepo.findBySlugAndStatus("missing-slug", ArticleStatus.PUBLISHED))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> publicService.listRecommendations("missing-slug", null))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ARTICLE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("listRecommendations: size=null이면 default 6, sameCategoryTarget=3, exploreTarget=3")
+    void listRecommendations_defaultSize_splitsThreeAndThree() {
+        CurationArticle current = currentArticle(7L, "diet");
+        given(articleRepo.findBySlugAndStatus("current-slug", ArticleStatus.PUBLISHED))
+                .willReturn(Optional.of(current));
+        // sameCategory 후보 5개 → 3개 추출
+        given(articleRepo.findRecommendationCandidatesByCategory(eq("diet"), eq(7L)))
+                .willReturn(List.of(
+                        rec(11L, "s11", "t11", "ck11", "diet"),
+                        rec(12L, "s12", "t12", "ck12", "diet"),
+                        rec(13L, "s13", "t13", "ck13", "diet"),
+                        rec(14L, "s14", "t14", "ck14", "diet"),
+                        rec(15L, "s15", "t15", "ck15", "diet")
+                ));
+        // explore 후보 5개 (12, 13은 sameCategory 후보와 id 겹침 — dedup 검증)
+        given(articleRepo.findRecommendationExploreCandidates(eq(7L)))
+                .willReturn(List.of(
+                        rec(12L, "s12", "t12", "ck12", "diet"),
+                        rec(13L, "s13", "t13", "ck13", "diet"),
+                        rec(20L, "s20", "t20", "ck20", "winter"),
+                        rec(21L, "s21", "t21", "ck21", "winter"),
+                        rec(22L, "s22", "t22", "ck22", "spring")
+                ));
+
+        List<CurationArticleRecommendationResponse> result =
+                publicService.listRecommendations("current-slug", null);
+
+        assertThat(result).hasSize(6);
+        // sameCategory 3개 + explore 3개. sameCategory에서 뽑힌 id가 explore에서 다시 안 나와야 한다.
+        long uniqueSlugs = result.stream().map(CurationArticleRecommendationResponse::getSlug).distinct().count();
+        assertThat(uniqueSlugs).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("listRecommendations: size=2면 4로 clamp (sameCategoryTarget=min(3, 2)=2, exploreTarget=2)")
+    void listRecommendations_belowMin_clampsToFour() {
+        CurationArticle current = currentArticle(7L, "diet");
+        given(articleRepo.findBySlugAndStatus("current-slug", ArticleStatus.PUBLISHED))
+                .willReturn(Optional.of(current));
+        given(articleRepo.findRecommendationCandidatesByCategory(eq("diet"), eq(7L)))
+                .willReturn(List.of(
+                        rec(11L, "s11", "t11", null, "diet"),
+                        rec(12L, "s12", "t12", null, "diet"),
+                        rec(13L, "s13", "t13", null, "diet"),
+                        rec(14L, "s14", "t14", null, "diet")
+                ));
+        given(articleRepo.findRecommendationExploreCandidates(eq(7L)))
+                .willReturn(List.of(
+                        rec(20L, "s20", "t20", null, "winter"),
+                        rec(21L, "s21", "t21", null, "winter"),
+                        rec(22L, "s22", "t22", null, "spring")
+                ));
+
+        List<CurationArticleRecommendationResponse> result =
+                publicService.listRecommendations("current-slug", 2);
+
+        assertThat(result).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("listRecommendations: size=20이면 12로 clamp (sameCategoryTarget=min(3, 6)=3, exploreTarget=9)")
+    void listRecommendations_aboveMax_clampsToTwelve() {
+        CurationArticle current = currentArticle(7L, "diet");
+        given(articleRepo.findBySlugAndStatus("current-slug", ArticleStatus.PUBLISHED))
+                .willReturn(Optional.of(current));
+        // sameCategory 후보 5개 → 최대 3개만 사용
+        given(articleRepo.findRecommendationCandidatesByCategory(eq("diet"), eq(7L)))
+                .willReturn(List.of(
+                        rec(11L, "s11", "t11", null, "diet"),
+                        rec(12L, "s12", "t12", null, "diet"),
+                        rec(13L, "s13", "t13", null, "diet"),
+                        rec(14L, "s14", "t14", null, "diet"),
+                        rec(15L, "s15", "t15", null, "diet")
+                ));
+        // explore 후보를 충분히 줘서 12를 채운다
+        List<CurationArticleRecommendationProjection> exploreList = new java.util.ArrayList<>();
+        for (long i = 20; i < 35; i++) {
+            exploreList.add(rec(i, "s" + i, "t" + i, null, "winter"));
+        }
+        given(articleRepo.findRecommendationExploreCandidates(eq(7L)))
+                .willReturn(exploreList);
+
+        List<CurationArticleRecommendationResponse> result =
+                publicService.listRecommendations("current-slug", 20);
+
+        assertThat(result).hasSize(12);
+    }
+
+    @Test
+    @DisplayName("listRecommendations: category가 null이면 sameCategory 호출 안 하고 explore만 사용")
+    void listRecommendations_nullCategory_skipsSameCategoryQuery() {
+        CurationArticle current = currentArticle(7L, null);
+        given(articleRepo.findBySlugAndStatus("current-slug", ArticleStatus.PUBLISHED))
+                .willReturn(Optional.of(current));
+        List<CurationArticleRecommendationProjection> exploreList = new java.util.ArrayList<>();
+        for (long i = 20; i < 30; i++) {
+            exploreList.add(rec(i, "s" + i, "t" + i, null, null));
+        }
+        given(articleRepo.findRecommendationExploreCandidates(eq(7L)))
+                .willReturn(exploreList);
+
+        List<CurationArticleRecommendationResponse> result =
+                publicService.listRecommendations("current-slug", null);
+
+        assertThat(result).hasSize(6);
+        // category null이면 sameCategory query 자체를 호출하지 않는다 (DB round trip 절감)
+        org.mockito.Mockito.verify(articleRepo, org.mockito.Mockito.never())
+                .findRecommendationCandidatesByCategory(any(), any());
+    }
+
+    @Test
+    @DisplayName("listRecommendations: sameCategory 부족 시 explore가 부족분만큼 추가로 채운다")
+    void listRecommendations_sameCategoryShort_exploreFillsGap() {
+        CurationArticle current = currentArticle(7L, "diet");
+        given(articleRepo.findBySlugAndStatus("current-slug", ArticleStatus.PUBLISHED))
+                .willReturn(Optional.of(current));
+        // sameCategory 후보 1개 (target=3보다 적음)
+        given(articleRepo.findRecommendationCandidatesByCategory(eq("diet"), eq(7L)))
+                .willReturn(List.of(rec(11L, "s11", "t11", null, "diet")));
+        // explore 후보 6개 — sameCategory 부족분 만큼 더 채워서 size=6 채워야 한다
+        given(articleRepo.findRecommendationExploreCandidates(eq(7L)))
+                .willReturn(List.of(
+                        rec(20L, "s20", "t20", null, "winter"),
+                        rec(21L, "s21", "t21", null, "winter"),
+                        rec(22L, "s22", "t22", null, "winter"),
+                        rec(23L, "s23", "t23", null, "winter"),
+                        rec(24L, "s24", "t24", null, "winter"),
+                        rec(25L, "s25", "t25", null, "winter")
+                ));
+
+        List<CurationArticleRecommendationResponse> result =
+                publicService.listRecommendations("current-slug", 6);
+
+        // sameCategory 1 + explore 5 = 6
+        assertThat(result).hasSize(6);
+        long sameCategoryCount = result.stream()
+                .filter(r -> "diet".equals(r.getCategory()))
+                .count();
+        assertThat(sameCategoryCount).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("listRecommendations: 후보가 부족하면 가능한 만큼만 반환 (0개면 빈 배열)")
+    void listRecommendations_noCandidates_returnsEmpty() {
+        CurationArticle current = currentArticle(7L, "diet");
+        given(articleRepo.findBySlugAndStatus("current-slug", ArticleStatus.PUBLISHED))
+                .willReturn(Optional.of(current));
+        given(articleRepo.findRecommendationCandidatesByCategory(eq("diet"), eq(7L)))
+                .willReturn(List.of());
+        given(articleRepo.findRecommendationExploreCandidates(eq(7L)))
+                .willReturn(List.of());
+
+        List<CurationArticleRecommendationResponse> result =
+                publicService.listRecommendations("current-slug", null);
+
+        assertThat(result).isNotNull().isEmpty();
+    }
+
+    @Test
+    @DisplayName("listRecommendations: 같은 입력은 같은 추천 순서를 반환한다 (deterministic)")
+    void listRecommendations_isDeterministic() {
+        CurationArticle current = currentArticle(7L, "diet");
+        given(articleRepo.findBySlugAndStatus("current-slug", ArticleStatus.PUBLISHED))
+                .willReturn(Optional.of(current));
+        // 같은 후보 set
+        List<CurationArticleRecommendationProjection> sameCat = List.of(
+                rec(11L, "s11", "t11", null, "diet"),
+                rec(12L, "s12", "t12", null, "diet"),
+                rec(13L, "s13", "t13", null, "diet"),
+                rec(14L, "s14", "t14", null, "diet"));
+        List<CurationArticleRecommendationProjection> explore = List.of(
+                rec(20L, "s20", "t20", null, "winter"),
+                rec(21L, "s21", "t21", null, "winter"),
+                rec(22L, "s22", "t22", null, "spring"),
+                rec(23L, "s23", "t23", null, "spring"));
+        given(articleRepo.findRecommendationCandidatesByCategory(eq("diet"), eq(7L)))
+                .willReturn(sameCat);
+        given(articleRepo.findRecommendationExploreCandidates(eq(7L)))
+                .willReturn(explore);
+
+        List<String> firstCall = publicService.listRecommendations("current-slug", null)
+                .stream().map(CurationArticleRecommendationResponse::getSlug).toList();
+        List<String> secondCall = publicService.listRecommendations("current-slug", null)
+                .stream().map(CurationArticleRecommendationResponse::getSlug).toList();
+
+        assertThat(firstCall).isEqualTo(secondCall);
+    }
+
+    @Test
+    @DisplayName("listRecommendations: 다른 currentArticleId면 다른 추천 분포가 나올 수 있다 (deterministic but distinct)")
+    void listRecommendations_differentCurrentArticle_canProduceDifferentOrder() {
+        // 후보 set은 동일하지만 current article id가 다르면 score 함수 결과가 달라져 정렬 결과가 달라질 수 있다.
+        // (반드시 다르다는 보장은 아니므로, 보통 케이스에서 다르게 나오는 시드를 사용한다.)
+        List<CurationArticleRecommendationProjection> sameCat = List.of(
+                rec(11L, "s11", "t11", null, "diet"),
+                rec(12L, "s12", "t12", null, "diet"),
+                rec(13L, "s13", "t13", null, "diet"),
+                rec(14L, "s14", "t14", null, "diet"));
+        List<CurationArticleRecommendationProjection> explore = List.of(
+                rec(20L, "s20", "t20", null, "winter"),
+                rec(21L, "s21", "t21", null, "winter"),
+                rec(22L, "s22", "t22", null, "spring"),
+                rec(23L, "s23", "t23", null, "spring"));
+
+        CurationArticle current1 = currentArticle(7L, "diet");
+        given(articleRepo.findBySlugAndStatus("a", ArticleStatus.PUBLISHED)).willReturn(Optional.of(current1));
+        given(articleRepo.findRecommendationCandidatesByCategory(eq("diet"), eq(7L))).willReturn(sameCat);
+        given(articleRepo.findRecommendationExploreCandidates(eq(7L))).willReturn(explore);
+        List<String> orderForId7 = publicService.listRecommendations("a", null)
+                .stream().map(CurationArticleRecommendationResponse::getSlug).toList();
+
+        CurationArticle current2 = currentArticle(99L, "diet");
+        given(articleRepo.findBySlugAndStatus("b", ArticleStatus.PUBLISHED)).willReturn(Optional.of(current2));
+        given(articleRepo.findRecommendationCandidatesByCategory(eq("diet"), eq(99L))).willReturn(sameCat);
+        given(articleRepo.findRecommendationExploreCandidates(eq(99L))).willReturn(explore);
+        List<String> orderForId99 = publicService.listRecommendations("b", null)
+                .stream().map(CurationArticleRecommendationResponse::getSlug).toList();
+
+        // 동일 후보 set, 동일 size로 호출했지만 currentId가 달라서 score 분포가 달라짐 → 결과 순서가 다를 수 있다.
+        // (이 시드 조합은 실제로 다르게 나오도록 잡았다.)
+        assertThat(orderForId7).isNotEqualTo(orderForId99);
+    }
+
+    @Test
+    @DisplayName("listRecommendations: 응답에는 sameCategory 카드가 explore 카드보다 앞에 온다 (안정 순서)")
+    void listRecommendations_sameCategoryAppearsBeforeExplore() {
+        CurationArticle current = currentArticle(7L, "diet");
+        given(articleRepo.findBySlugAndStatus("current-slug", ArticleStatus.PUBLISHED))
+                .willReturn(Optional.of(current));
+        given(articleRepo.findRecommendationCandidatesByCategory(eq("diet"), eq(7L)))
+                .willReturn(List.of(
+                        rec(11L, "diet-1", "t11", null, "diet"),
+                        rec(12L, "diet-2", "t12", null, "diet"),
+                        rec(13L, "diet-3", "t13", null, "diet")));
+        given(articleRepo.findRecommendationExploreCandidates(eq(7L)))
+                .willReturn(List.of(
+                        rec(20L, "winter-1", "t20", null, "winter"),
+                        rec(21L, "winter-2", "t21", null, "winter"),
+                        rec(22L, "winter-3", "t22", null, "winter")));
+
+        List<CurationArticleRecommendationResponse> result =
+                publicService.listRecommendations("current-slug", null);
+
+        // 처음 3개는 모두 same category, 마지막 3개는 explore
+        assertThat(result).hasSize(6);
+        for (int i = 0; i < 3; i++) {
+            assertThat(result.get(i).getCategory()).isEqualTo("diet");
+        }
+        for (int i = 3; i < 6; i++) {
+            assertThat(result.get(i).getCategory()).isEqualTo("winter");
+        }
     }
 }


### PR DESCRIPTION
  ## 해결하려는 문제가 무엇인가요?

  큐레이션 아티클 도메인의 public 영역을 두 축으로 확장한다 — (1) 검색엔진용 sitemap, (2) 상세
   페이지 하단 추천 카드. 두 변경 사이에 reserved-slug 가드가 자동 발생한다 — sitemap literal
  route가 추가되면 slug `"sitemap"`인 글이 영영 도달 불가능해지므로 create 시점에 차단해야
  한다. PR 사이즈는 +910/-7로 500줄을 넘지만, +576이 테스트 추가분이고 production code 약
  +334. 세 변경(sitemap / reserved-slug / recommendations)이 한 도메인의 자연스러운 확장이라
  분리하면 reviewer가 cross-reference 부담만 늘어난다고 판단해 단일 PR로 묶는다.

  ## 어떻게 해결했나요?

  - **AS-IS:** public이 목록·상세 두 endpoint만. recommendation 미존재. slug 검증은
  패턴/중복만 체크.
  - **TO-BE:**
    - `GET /api/curation-articles/sitemap` — PUBLISHED 글의 `slug + updatedAt` 배열만 반환.
  id/contentMdx/status/recipeIds 미노출 (외부 크롤러 면 좁히기). status 필터와 정렬은
  repository `@Query`에 박아 service 우회 불가.
    - `GET /api/curation-articles/{slug}/recommendations?size=6` — 상세 페이지 추천 카드.
  `ORDER BY RAND()` 대신 splitmix64 기반 deterministic random. `sameCategoryTarget = min(3,
  safeSize/2)`, 부족하면 explore가 채움. size는 `[4, 12]`로 clamp.
    - `CurationArticleService.create()`에 `RESERVED_SLUGS = Set.of("sitemap")` 가드 추가 →
  `ErrorCode 1208 ARTICLE_SLUG_RESERVED` (400). 검증 순서: RESERVED → existsBySlug → recipe
  ref.

  리뷰어가 먼저 봐야 할 영역:
  1. `PublicCurationArticleService` — `listSitemap`, `listRecommendations`, **splitmix64
  deterministic score** (단순 `Objects.hash`/`String.hashCode`는 polynomial이 linear라
  currentId 항이 후보 간 score 차이에서 상쇄됨 → ordering 무영향. splitmix64는 비선형 mixer라
  1비트 입력 변화에 avalanche)
  2. `CurationArticleService` — `RESERVED_SLUGS` 가드 위치와 검증 순서
  3. `CurationArticleRepository` — 새 query 3개 (모두 PUBLISHED 강제, ORDER BY 없음 —
  service의 deterministic sort가 단일 source-of-truth)
  4. `SecurityConfig` — `/api/curation-articles/*/recommendations` permitAll 명시 (2-depth라
  기존 single-segment wildcard로 안 잡힘. local + prod 양쪽)

  ## Test plan

  `./gradlew compileJava compileTestJava` ✓ + `./gradlew test --tests "*CurationArticle*"
  --rerun-tasks` **73/73 PASS** (이전 50 → +23).

  | 추가 테스트 | 수 | 핵심 시나리오 |
  |---|---|---|
  | `PublicCurationArticleServiceTest` | +9 | size clamp 3가지, NOT_FOUND, null category skip, sameCategory 부족 시 explore 채움, 후보 0개, deterministic 동일성, **다른 currentId → 다른 ordering**, sameCategory가 explore보다 앞 |
  | `PublicCurationArticleServiceTest` (sitemap) | +2 | projection→DTO 매핑, 빈 결과 |
  | `CurationArticleControllerWebMvcTest` | +6 | sitemap 200/empty/slug fallthrough, recommendations 200/size omit/404 |
  | `CurationArticleRepositoryTest` | +3 | sitemap PUBLISHED + 정렬, recommendation category/explore 필터, 후보 풀 전체 보장 |
  | `CurationArticleServiceTest` | +1 | reserved slug `"sitemap"` 거부 + 검증 순서 잠금 |
  | `findAllForSitemap` 정렬 검증 | — | JPA Auditing의 `@LastModifiedDate`가 dirty checking 시 덮어쓰는 함정을 피하려 native JPQL `UPDATE`로 `updatedAt` 결정값 주입 |

  수동 검증 plan: 배포 후 prod에서 cookies 갱신 + 기존 큐레이션 아티클로 추천/sitemap
  end-to-end 호출. (이전 PR과 동일한 방식)

  ## Rollout / DB / API impact

  - **DB:** 변경 없음 (Flyway 추가 없음).
  - **API:** 신규 추가만. 기존 응답 shape 변경 없음 → **non-breaking**.
    - `GET /api/curation-articles/sitemap` (신규)
    - `GET /api/curation-articles/{slug}/recommendations` (신규)
    - `POST /api/admin/curation-articles`에서 `slug="sitemap"` 입력 시 1208 거부 (미배포 신규
  도메인이라 운영 영향 0)
  - **SecurityConfig:** 2-depth path matcher 명시 추가 (배포 직후 유효).
  - **핸드오프 문서:** `docs/handoff/frontend-api-changes-2026-05-03.{md,html}`에 §6 ErrorCode
   1208 / §7.3 sitemap / §7.4 추천 / §8.1 slug reserved 표기 / §12 Breaking Changes / §15 빠른
   참조까지 동기화 (gitignored이라 PR diff 외).
  - **Lambda/S3:** 변경 없음.

  ## Risks and rollback

  | 위험 | 영향 | 대응 |
  |---|---|---|
  | Deterministic score 함정 | 단순 polynomial hash는 currentId가 ordering에 영향을 못 줘서
  모든 currentId가 같은 추천을 반환 | splitmix64로 통일. `listRecommendations_differentCurrentArticle_canProduceDifferentOrder` 테스트가 회귀 가드 |
  | 후보 풀 상한 미적용 | 아티클 수가 수만 단위로 늘면 메모리/페이로드 부담 | V1 운영 규모(수십~수백 추정)에선 5컬럼 projection이라 부담 작음. 늘면 캐시/사전계산 score 도입 검토|
  | reserved slug 누락 | 추후 `/api/curation-articles/feed` 같은 literal route가 추가되면 같은
 충돌 재발 | `RESERVED_SLUGS` 상수 javadoc에 controller와 동기화하라는 가이드 명시. 하지만 컴파일 타임 강제는 아님 |

  **롤백:** 단일 commit revert로 즉시 원복. DB 변경 없고 SecurityConfig matcher 추가만 있어서
  롤백 후 부작용 없음. `RESERVED_SLUGS`는 미배포 신규 API라 실 호출자 0이므로 revert해도 운영
  데이터 영향 없음.

  ## Related

  - 선행 PR/커밋:
    - `feat(curation-articles): MDX 매거진 아티클 도메인 + admin/public API + 이미지 업로드
  finalize` (`e99d2c5`)
    - `refactor(curation-articles): public 응답 id/recipeIds를 HashID 문자열로 직렬화`
  (`1de4256`)
    - `refactor(curation-articles): admin path/response/request + S3 imageKey 모두 HashID로
  통일 + strict 강제` (`3243fb2`)
  - Skill: `git-workflow`, `api-contract-docs` (handoff doc 동기화)
  - 핸드오프 문서: `docs/handoff/frontend-api-changes-2026-05-03.{md,html}`